### PR TITLE
[FIX] Refactor remaining integration terminology to provider

### DIFF
--- a/apps/client/src/components/LeftSidebar.tsx
+++ b/apps/client/src/components/LeftSidebar.tsx
@@ -44,7 +44,7 @@ export function LeftSidebar({ collapsed }: LeftSidebarProps) {
         >
           <Link to="/providers">
             <Layers className="h-5 w-5 flex-shrink-0" />
-            <span className={cn("font-medium", collapsed && "sr-only")}>Add Integration</span>
+            <span className={cn("font-medium", collapsed && "sr-only")}>Add Provider</span>
           </Link>
         </Button>
         

--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -67,7 +67,7 @@ type AzureFormData = z.infer<typeof azureSchema>;
 
 type AnyFormData = ServerFormData | KubernetesFormData | AWSFormData | GCPFormData | AzureFormData;
 
-interface IntegrationFormProps<T extends AnyFormData> {
+interface ProviderFormProps<T extends AnyFormData> {
   onSubmit: SubmitHandler<T>;
   onClose: () => void;
 }
@@ -88,7 +88,7 @@ const FieldWrapper = ({ children, error }: { children: React.ReactNode, error?: 
 
 // --- FORM COMPONENTS ---
 
-const ServerForm = ({ onSubmit, onClose }: IntegrationFormProps<ServerFormData>) => {
+const ServerForm = ({ onSubmit, onClose }: ProviderFormProps<ServerFormData>) => {
     const { control, handleSubmit, watch, formState: { errors, isSubmitting } } = useForm<ServerFormData>({
         resolver: zodResolver(serverSchema),
         defaultValues: { port: 22, authType: "key" },
@@ -220,7 +220,7 @@ const ServerForm = ({ onSubmit, onClose }: IntegrationFormProps<ServerFormData>)
                             Adding...
                         </>
                     ) : (
-                        "Add Integration"
+                        "Add Provider"
                     )}
                 </Button>
             </div>
@@ -228,7 +228,7 @@ const ServerForm = ({ onSubmit, onClose }: IntegrationFormProps<ServerFormData>)
     );
 }
 
-const KubernetesForm = ({ onSubmit, onClose }: IntegrationFormProps<KubernetesFormData>) => {
+const KubernetesForm = ({ onSubmit, onClose }: ProviderFormProps<KubernetesFormData>) => {
     const { control, handleSubmit, formState: { errors } } = useForm<KubernetesFormData>({
         resolver: zodResolver(kubernetesSchema),
     });
@@ -249,13 +249,13 @@ const KubernetesForm = ({ onSubmit, onClose }: IntegrationFormProps<KubernetesFo
             </FieldWrapper>
             <div className="flex justify-end gap-2 pt-4">
                 <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>
-                <Button type="submit">Add Integration</Button>
+                <Button type="submit">Add Provider</Button>
             </div>
         </form>
     );
 };
 
-const AWSForm = ({ onSubmit, onClose }: IntegrationFormProps<AWSFormData>) => {
+const AWSForm = ({ onSubmit, onClose }: ProviderFormProps<AWSFormData>) => {
     const { control, handleSubmit, formState: { errors } } = useForm<AWSFormData>({
         resolver: zodResolver(awsSchema),
     });
@@ -298,7 +298,7 @@ const AWSForm = ({ onSubmit, onClose }: IntegrationFormProps<AWSFormData>) => {
 
             <div className="flex justify-end gap-2 pt-4">
                 <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>
-                <Button type="submit">Add Integration</Button>
+                <Button type="submit">Add Provider</Button>
             </div>
         </form>
     );
@@ -365,10 +365,10 @@ export function ProviderSidebar({ provider, onClose }: ProviderSidebarProps) {
     try {
       // Map form data to API request format
       const serverData = data as ServerFormData;
-      // Determine provider_type based on integration.type
+      // Determine provider_type based on provider.type
       let providerType = 'VM'; // Default to VM
 
-      // Map integration types to provider types
+      // Map provider types to provider types
       // Using type assertion to handle the comparison
       if (provider.type.includes('kubernetes')) {
         providerType = 'K8S';
@@ -419,7 +419,7 @@ export function ProviderSidebar({ provider, onClose }: ProviderSidebarProps) {
         case "aws-eks":
             return <AWSForm onSubmit={handleFormSubmit as SubmitHandler<AWSFormData>} onClose={onClose} />;
         default:
-            return <div className="py-4">This integration type is not yet supported with the new form.</div>;
+            return <div className="py-4">This provider type is not yet supported with the new form.</div>;
     }
   };
 

--- a/apps/client/src/components/ServiceDetailsSheet.tsx
+++ b/apps/client/src/components/ServiceDetailsSheet.tsx
@@ -9,7 +9,7 @@ import { ServiceConfig } from "./AddServiceDialog";
 import { ServicesList } from "./ServicesList";
 
 interface ServiceDetailsSheetProps {
-  integration: ProviderInstance | null;
+  provider: ProviderInstance | null;
   onClose: () => void;
   onDeleteService?: (serviceId: string) => void;
   onStatusChange?: (serviceId: string, newStatus: "running" | "stopped" | "error") => void;
@@ -33,45 +33,45 @@ const getServiceStatusBadgeColor = (status: ServiceConfig["status"]) => {
 };
 
 export function ServiceDetailsSheet({
-  integration,
+  provider,
   onClose,
   onDeleteService,
   onStatusChange,
 }: ServiceDetailsSheetProps) {
-  if (!integration) return null;
+  if (!provider) return null;
 
   return (
     <Sheet open={true} onOpenChange={onClose}>
       <SheetContent className="w-full sm:max-w-md">
         <SheetHeader>
           <SheetTitle className="text-xl font-bold">
-            Integration Details
+            Provider Details
           </SheetTitle>
         </SheetHeader>
         <Separator className="my-4" />
         <div className="space-y-6 py-2">
           <div>
-            <h3 className="text-lg font-semibold">{integration.name}</h3>
-            <p className="text-sm text-muted-foreground">{getProviderTypeName(integration.type)}</p>
-            <Badge className={`mt-1 capitalize ${getStatusBadgeColor(integration.status ?? 'unknown')}`}>
-              {integration.status}
+            <h3 className="text-lg font-semibold">{provider.name}</h3>
+            <p className="text-sm text-muted-foreground">{getProviderTypeName(provider.type)}</p>
+            <Badge className={`mt-1 capitalize ${getStatusBadgeColor(provider.status ?? 'unknown')}`}>
+              {provider.status}
             </Badge>
           </div>
 
           <div className="grid grid-cols-[100px_1fr] gap-x-4 gap-y-2">
-            {Object.entries(integration.details).map(([key, value]) => (
-              <DetailRow key={key} label={`${key.charAt(0).toUpperCase() + key.slice(1)}:`} value={value} />
+            {Object.entries(provider.details).map(([key, value]) => (
+              <DetailRow key={key} label={`${key.charAt(0).toUpperCase() + key.slice(1)}:`} value={String(value)} />
             ))}
           </div>
 
-          {integration.services && integration.services.length > 0 && (
+          {provider.services && provider.services.length > 0 && (
             <div>
               <h4 className="font-semibold text-lg mb-2">Services</h4>
               <ServicesList 
-                services={integration.services} 
+                services={provider.services} 
                 onServiceClick={(service) => {/* Handle service click if needed */}}
                 onStatusChange={(serviceId, newStatus) => {
-                  if (onStatusChange && integration.id) {
+                  if (onStatusChange && provider.id) {
                     onStatusChange(serviceId, newStatus);
                   }
                 }}

--- a/apps/client/src/components/ServiceDetailsSheetWithLogs.tsx
+++ b/apps/client/src/components/ServiceDetailsSheetWithLogs.tsx
@@ -12,7 +12,7 @@ import { providerApi } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 
 interface ServiceDetailsSheetProps {
-  integration: ProviderInstance | null;
+  provider: ProviderInstance | null;
   onClose: () => void;
   onDeleteService?: (serviceId: string) => void;
   onStatusChange?: (serviceId: string, newStatus: "running" | "stopped" | "error") => void;
@@ -26,7 +26,7 @@ const DetailRow = ({ label, value }: { label: string; value: string }) => (
 );
 
 export function ServiceDetailsSheetWithLogs({
-  integration,
+  provider,
   onClose,
   onDeleteService,
   onStatusChange,
@@ -72,43 +72,43 @@ export function ServiceDetailsSheetWithLogs({
     }
   }, [selectedServiceForLogs?.id]);
 
-  if (!integration) return null;
+  if (!provider) return null;
 
   return (
     <Sheet open={true} onOpenChange={onClose}>
       <SheetContent className="w-full sm:max-w-md overflow-y-auto">
         <SheetHeader>
           <SheetTitle className="text-xl font-bold">
-            Integration Details
+            Provider Details
           </SheetTitle>
         </SheetHeader>
         <Separator className="my-4" />
         <div className="space-y-6 py-2">
           <div>
-            <h3 className="text-lg font-semibold">{integration.name}</h3>
-            <p className="text-sm text-muted-foreground">{getProviderTypeName(integration.type)}</p>
-            <Badge className={`mt-1 capitalize ${getStatusBadgeColor(integration.status ?? 'unknown')}`}>
-              {integration.status}
+            <h3 className="text-lg font-semibold">{provider.name}</h3>
+            <p className="text-sm text-muted-foreground">{getProviderTypeName(provider.type)}</p>
+            <Badge className={`mt-1 capitalize ${getStatusBadgeColor(provider.status ?? 'unknown')}`}>
+              {provider.status}
             </Badge>
           </div>
 
           <div className="grid grid-cols-[100px_1fr] gap-x-4 gap-y-2">
-            {Object.entries(integration.details).map(([key, value]) => (
-              <DetailRow key={key} label={`${key.charAt(0).toUpperCase() + key.slice(1)}:`} value={value} />
+            {Object.entries(provider.details).map(([key, value]) => (
+              <DetailRow key={key} label={`${key.charAt(0).toUpperCase() + key.slice(1)}:`} value={String(value)} />
             ))}
           </div>
 
-          {integration.services && integration.services.length > 0 && (
+          {provider.services && provider.services.length > 0 && (
             <div>
               <h4 className="font-semibold text-lg mb-2">Services</h4>
               <ServicesList 
-                services={integration.services} 
+                services={provider.services} 
                 onServiceClick={(service) => {
                   // When a service is clicked, select it for logs display
                   setSelectedServiceForLogs(service);
                 }}
                 onStatusChange={(serviceId, newStatus) => {
-                  if (onStatusChange && integration.id) {
+                  if (onStatusChange && provider.id) {
                     onStatusChange(serviceId, newStatus);
                   }
                 }}

--- a/apps/client/src/pages/Providers.tsx
+++ b/apps/client/src/pages/Providers.tsx
@@ -7,7 +7,7 @@ import { ProviderSidebar } from "../components/ProviderSidebar";
 import { DashboardLayout } from "../components/DashboardLayout";
 import { useToast } from "@/hooks/use-toast";
 
-// Integration types
+// Provider types
 export type ProviderType = "server" | "kubernetes" | "aws-ec2" | "aws-eks" | "gcp-compute" | "azure-vm";
 
 interface Provider {


### PR DESCRIPTION
- Updated component and variable names from "Integration" to "Provider" for consistency.
- Modified form props and button labels to reflect the new terminology.
- Adjusted local storage handling and API calls to align with the provider concept.
- Ensured all related components and pages are updated accordingly.