### PR TITLE
Bugfix: Refactor service tag API endpoints to use serviceId and tagId

### DIFF
--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -296,16 +296,16 @@ export const providerApi = {
 
   // Add tag to service
   addTagToService: (serviceId: number, tagId: number) => {
-    return apiRequest<{ message: string }>('/tags/service', 'POST', { serviceId, tagId });
+    return apiRequest<{ message: string }>(`/services/${serviceId}/tags`, 'POST', { tagId });
   },
 
   // Remove tag from service
   removeTagFromService: (serviceId: number, tagId: number) => {
-    return apiRequest<{ message: string }>('/tags/service', 'DELETE', { serviceId, tagId });
+    return apiRequest<{ message: string }>(`/services/${serviceId}/tags/${tagId}`, 'DELETE');
   },
 
   // Get tags for a service
   getServiceTags: (serviceId: number) => {
-    return apiRequest<Tag[]>(`/tags/service/${serviceId}`);
+    return apiRequest<Tag[]>(`/services/${serviceId}/tags`);
   },
 };

--- a/apps/server/src/api/v1/services/router.ts
+++ b/apps/server/src/api/v1/services/router.ts
@@ -30,8 +30,8 @@ export default function createServiceRouter(serviceController: ServiceController
     router.delete('/:serviceId', serviceController.deleteServiceHandler);
 
     // Service tag association routes
-    router.post('/tags', tagController.addTagToServiceHandler);
-    router.delete('/tags', tagController.removeTagFromServiceHandler);
+    router.post('/:serviceId/tags', tagController.addTagToServiceHandler);
+    router.delete('/:serviceId/tags/:tagId', tagController.removeTagFromServiceHandler);
     router.get('/:serviceId/tags', tagController.getServiceTagsHandler);
 
     return router;

--- a/apps/server/src/api/v1/tags/controller.ts
+++ b/apps/server/src/api/v1/tags/controller.ts
@@ -98,19 +98,25 @@ export class TagController {
 
     addTagToServiceHandler = async (req: Request, res: Response) => {
         try {
-            const { serviceId, tagId } = ServiceTagSchema.parse(req.body);
+            // Get serviceId from params, tagId from body
+            const { serviceId } = req.params;
+            const { tagId } = req.body;
+            const parsed = ServiceTagSchema.parse({
+                serviceId: Number(serviceId),
+                tagId: Number(tagId)
+            });
 
-            const service = await this.serviceRepo.getServiceById(serviceId);
+            const service = await this.serviceRepo.getServiceById(parsed.serviceId);
             if (!service) {
                 return res.status(404).json({ success: false, error: 'Service not found' });
             }
 
-            const tag = await this.tagRepo.getTagById(tagId);
+            const tag = await this.tagRepo.getTagById(parsed.tagId);
             if (!tag) {
                 return res.status(404).json({ success: false, error: 'Tag not found' });
             }
 
-            await this.tagRepo.addTagToService(serviceId, tagId);
+            await this.tagRepo.addTagToService(parsed.serviceId, parsed.tagId);
             res.json({ success: true, message: 'Tag added to service successfully' });
         } catch (error) {
             if (error instanceof z.ZodError) {
@@ -124,9 +130,14 @@ export class TagController {
 
     removeTagFromServiceHandler = async (req: Request, res: Response) => {
         try {
-            const { serviceId, tagId } = ServiceTagSchema.parse(req.body);
+            // Get serviceId and tagId from route params
+            const { serviceId, tagId } = req.params;
+            const parsed = ServiceTagSchema.parse({
+                serviceId: Number(serviceId),
+                tagId: Number(tagId)
+            });
 
-            await this.tagRepo.removeTagFromService(serviceId, tagId);
+            await this.tagRepo.removeTagFromService(parsed.serviceId, parsed.tagId);
             res.json({ success: true, message: 'Tag removed from service successfully' });
         } catch (error) {
             if (error instanceof z.ZodError) {


### PR DESCRIPTION
## Issue Reference
Service tag routes were not working as expected (404/500 errors, route collisions, and handler mismatches) after backend route changes.

## What Was Changed
Backend routes for service-tag operations were updated to use parameterized URLs:
POST /api/v1/services/:serviceId/tags to add a tag to a service (with tagId in the body)
DELETE /api/v1/services/:serviceId/tags/:tagId to remove a tag from a service
GET /api/v1/services/:serviceId/tags to fetch tags for a service
Backend handlers were updated to extract parameters from the correct locations (req.params and req.body) to match the new routes.
Frontend API calls were updated to use the new parameterized endpoints.
Route order and handler logic were fixed to prevent route shadowing and validation errors.

## Why Was It Changed
The previous implementation used ambiguous or conflicting routes (e.g., /tags/service), which led to 404 and 500 errors due to route collisions and incorrect parameter parsing.
The new structure is RESTful, unambiguous, and matches standard Express routing best practices, ensuring correct handler invocation and parameter validation.
## Screenshots (Optional)N/A (API/handler changes, but can provide screenshots of successful requests if needed)

## Additional Context (Optional)
The changes ensure that all tag-to-service operations are robust, RESTful, and easy to maintain.
Linting and config issues were also investigated, but the main focus was on backend/route correctness and frontend API alignment.