### PR TITLE
sanitize log arguments to avoid logging secrets

### DIFF
--- a/apps/server/src/bl/providers/provider.bl.ts
+++ b/apps/server/src/bl/providers/provider.bl.ts
@@ -29,12 +29,12 @@ export class ProviderBL {
 
     async createProvider(providerToCreate: Omit<Provider, 'id'>, user: User): Promise<Provider> {
         try {
-            logger.info(`Starting to create provider: ${JSON.stringify(providerToCreate)}`);
+            logger.info(`Starting to create provider`, { extraArgs: { ...providerToCreate } });
             const { lastID } = await this.providerRepo.createProvider(providerToCreate);
             logger.info(`Provider created with ID: ${lastID}`);
 
             const createdProvider = await this.providerRepo.getProviderById(lastID);
-            logger.info(`Fetched created provider: ${JSON.stringify(createdProvider)}`);
+            logger.info(`Fetched created provider`, { extraArgs: { ...createdProvider } });
 
             await this.auditBL.logAction({
                 actionType: AuditActionType.CREATE,
@@ -102,7 +102,7 @@ export class ProviderBL {
     async discoverServicesInProvider(providerId: number): Promise<DiscoveredService[]> {
         try {
             const provider = await this.providerRepo.getProviderById(providerId);
-            logger.info(`Fetched provider: ${JSON.stringify(provider)}`);
+            logger.info("Fetched provider", { extraArgs: { ...provider } });
 
             const providerConnector = providerConnectorFactory(provider.providerType);
             return await providerConnector.discoverServices(provider);

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -10,7 +10,6 @@ export class Logger {
 
     private readonly sensitiveKeyPattern = /(password|pass|token|secret|key)$/i;
 
-    // Recursively sanitize data
     private sanitize(data: unknown): unknown {
         if (Array.isArray(data)) {
             return data.map(item => this.sanitize(item));
@@ -23,12 +22,6 @@ export class Logger {
                     }
                     return [k, this.sanitize(v)];
                 })
-            );
-        }
-        if (typeof data === 'string') {
-            return data.replace(
-                /(password|pass|token|secret|key)\s*=\s*[^&\s]+/gi,
-                '$1=[REDACTED]'
             );
         }
         return data;

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -3,11 +3,36 @@ type LogLevel = 'info' | 'warn' | 'error' | 'debug';
 interface LogOptions {
     extraArgs?: Record<string, unknown>;
 }
-
 const getTimestamp = (): string => new Date().toISOString();
 
 export class Logger {
     constructor(private context: string) {}
+
+    private readonly sensitiveKeyPattern = /(password|pass|token|secret|key)$/i;
+
+    // Recursively sanitize data
+    private sanitize(data: unknown): unknown {
+        if (Array.isArray(data)) {
+            return data.map(item => this.sanitize(item));
+        }
+        if (data && typeof data === 'object') {
+            return Object.fromEntries(
+                Object.entries(data as Record<string, unknown>).map(([k, v]) => {
+                    if (this.sensitiveKeyPattern.test(k)) {
+                        return [k, '[REDACTED]'];
+                    }
+                    return [k, this.sanitize(v)];
+                })
+            );
+        }
+        if (typeof data === 'string') {
+            return data.replace(
+                /(password|pass|token|secret|key)\s*=\s*[^&\s]+/gi,
+                '$1=[REDACTED]'
+            );
+        }
+        return data;
+    }
 
     private formatMessage(level: LogLevel, message: string): string {
         const parts = [
@@ -42,8 +67,9 @@ export class Logger {
         }
 
         if (options?.extraArgs) {
+            const safeArgs = this.sanitize(options.extraArgs);
             // eslint-disable-next-line no-console
-            console.dir({extraArgs: options.extraArgs}, {depth: null, colors: true});
+            console.dir({ extraArgs: safeArgs }, { depth: null, colors: true });
         }
     }
 


### PR DESCRIPTION
## Issue Reference

https://github.com/OpsiMate/OpsiMate/issues/154

---

## What Was Changed

Added sanitize logic inside the logger to avoid logging sensitive data

---

## Why Was It Changed

protect customer sensitive data from being logged as plain text

---

<img width="741" height="336" alt="image" src="https://github.com/user-attachments/assets/13c99449-b85b-43a3-b4e5-84ac98188314" />

