### PR TITLE
[FEAT] Enhance SSL key management in Settings and ProviderSidebar

### DIFF
--- a/apps/client/src/components/ui/file-dropzone.tsx
+++ b/apps/client/src/components/ui/file-dropzone.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+
+type FileDropzoneProps = {
+  id: string;
+  accept?: string;
+  onFile: (file: File) => void;
+  placeholder?: string;
+  loading?: boolean;
+  className?: string;
+};
+
+export function FileDropzone({
+  id,
+  accept,
+  onFile,
+  placeholder = "Click to select a file or drag & drop here",
+  loading = false,
+  className,
+}: FileDropzoneProps) {
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file) onFile(file);
+  };
+
+  const onSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) onFile(file);
+  };
+
+  return (
+    <div
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={onDrop}
+      className={cn(
+        "relative group flex flex-col items-center justify-center border-2 border-dashed rounded-md p-6 py-12 text-center hover:bg-accent",
+        className
+      )}
+    >
+      <input id={id} type="file" accept={accept} onChange={onSelect} className="hidden" />
+      <Label
+        htmlFor={id}
+        className="absolute inset-0 flex items-center justify-center cursor-pointer transition-colors group-hover:text-white"
+      >
+        {loading ? "Uploading..." : placeholder}
+      </Label>
+    </div>
+  );
+}
+
+

--- a/apps/client/src/lib/sslKeys.ts
+++ b/apps/client/src/lib/sslKeys.ts
@@ -1,0 +1,33 @@
+export type SSLKey = {
+  id: string;
+  name: string;
+  createdAt: string;
+};
+
+const STORAGE_KEY = "OpsiMate-ssl-keys";
+
+export function getSslKeys(): SSLKey[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as SSLKey[];
+  } catch {
+    return [];
+  }
+}
+
+export function addSslKey(name: string): SSLKey {
+  const keys = getSslKeys();
+  const key: SSLKey = { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}` , name, createdAt: new Date().toISOString() };
+  const next = [key, ...keys];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  return key;
+}
+
+export function deleteSslKey(id: string): void {
+  const keys = getSslKeys();
+  const next = keys.filter(k => k.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+}
+
+


### PR DESCRIPTION
- Added SSL key upload functionality with a new dialog in the Settings page.
- Introduced a new SslKeysTable component to display and manage SSL keys.
- Updated ProviderSidebar to utilize a FileDropzone for importing JSON files.
- Improved SSH key selection with dynamic loading of available keys.

Screenshots:
**SSL keys and reorganized settings page**:

<img width="1508" height="826" alt="image" src="https://github.com/user-attachments/assets/07e14cc2-f6f6-4d8a-84eb-153b42f1f5bd" />

**Select a key from dropdown when configuring a provider**:

<img width="439" height="404" alt="image" src="https://github.com/user-attachments/assets/368a735c-770a-4c42-a45f-522b33cba19a" />

**State when there are no keys at all, redirecting in another tab to the settings - ssl sub page**:

<img width="428" height="108" alt="image" src="https://github.com/user-attachments/assets/f5b2d719-59f6-4bce-97c3-f689172bdeca" />

**Adding new key form**:

<img width="763" height="607" alt="image" src="https://github.com/user-attachments/assets/c326a098-dd6e-4e89-ab1f-205b968a24dc" />


## Issue Reference

<!-- Link to the related issue or ticket, e.g. Closes #123 -->

---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->

---

## Screenshots (Optional)

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->
