### PR TITLE
feat: Integrate secrets UI to server

### DIFF
--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -7,15 +7,15 @@ import {Separator} from "@/components/ui/separator";
 import {X, Loader2} from "lucide-react";
 import {ProviderType} from "@/pages/Providers";
 import {useToast} from "@/hooks/use-toast";
-import {useForm, Controller, SubmitHandler} from "react-hook-form";
+import {useForm, Controller, SubmitHandler, Control} from "react-hook-form";
 import {zodResolver} from "@hookform/resolvers/zod";
 import {z} from "zod";
 import {providerApi} from "@/lib/api";
-import {useState} from "react";
+import {useState, useEffect} from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {useNavigate} from "react-router-dom";
 import { FileDropzone } from "@/components/ui/file-dropzone";
-import { getSslKeys } from "@/lib/sslKeys";
+import { getSecretsFromServer, SecretMetadata } from "@/lib/sslKeys";
 
 // --- FORM SCHEMAS ---
 
@@ -89,6 +89,63 @@ const FieldWrapper = ({children, error}: { children: React.ReactNode, error?: { 
 
 
 // --- FORM COMPONENTS ---
+
+const SSHKeySelector = ({ control }: { control: Control<ServerFormData> }) => {
+    const [keys, setKeys] = useState<SecretMetadata[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const loadKeys = async () => {
+            try {
+                const secrets = await getSecretsFromServer();
+                setKeys(secrets);
+                setError(null);
+            } catch (err) {
+                console.error('Error loading SSH keys:', err);
+                setError('Failed to load SSH keys');
+            } finally {
+                setLoading(false);
+            }
+        };
+        loadKeys();
+    }, []);
+
+    if (loading) {
+        return <div className="text-sm text-muted-foreground">Loading keys...</div>;
+    }
+
+    if (error) {
+        return (
+            <div className="space-y-2">
+                <div className="text-sm text-destructive">Error loading keys: {error}</div>
+            </div>
+        );
+    }
+
+    if (keys.length === 0) {
+        return (
+            <div className="space-y-2">
+                <div className="text-sm text-muted-foreground">No keys available.</div>
+            </div>
+        );
+    }
+
+    return (
+        <Controller name="sshKey" control={control}
+            render={({ field }) => (
+                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <SelectTrigger><SelectValue placeholder="Select a key" /></SelectTrigger>
+                    <SelectContent>
+                        {keys.map(key => (
+                            <SelectItem key={key.id} value={key.name}><b>{key.name}</b></SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )}
+        />
+    );
+};
 
 const ServerForm = ({onSubmit, onClose}: ProviderFormProps<ServerFormData>) => {
     const {control, handleSubmit, watch, setValue, formState: {errors, isSubmitting}} = useForm<ServerFormData>({
@@ -206,38 +263,17 @@ const ServerForm = ({onSubmit, onClose}: ProviderFormProps<ServerFormData>) => {
             {authType === 'key' && (
                 <FieldWrapper error={errors.sshKey}>
                     <Label>SSH Key</Label>
-                    {(() => {
-                        const keys = getSslKeys();
-                        if (keys.length === 0) {
-                            return (
-                                <div className="space-y-2">
-                                    <div className="text-sm text-muted-foreground">No keys available.</div>
-                                    <a
-                                        href="/settings#SSL_keys"
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        className="text-primary underline"
-                                    >
-                                        Go to Settings to add a key
-                                    </a>
-                                </div>
-                            );
-                        }
-                        return (
-                            <Controller name="sshKey" control={control}
-                                render={({ field }) => (
-                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
-                                        <SelectTrigger><SelectValue placeholder="Select a key" /></SelectTrigger>
-                                        <SelectContent>
-                                            {keys.map(k => (
-                                                <SelectItem key={k.id} value={k.name}><b>{k.name}</b></SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                )}
-                            />
-                        );
-                    })()}
+                    <SSHKeySelector control={control} />
+                    <div className="mt-2">
+                        <a
+                            href="/settings#SSL_keys"
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-sm text-primary hover:underline"
+                        >
+                            + Add new key
+                        </a>
+                    </div>
                 </FieldWrapper>
             )}
 
@@ -518,6 +554,7 @@ export function ProviderSidebar({provider, onClose}: ProviderSidebarProps) {
                     placeholder={isImporting ? 'Importing...' : 'Click to select a JSON file or drag & drop here'}
                     loading={isImporting}
                     onFile={(file) => void handleFile(file)}
+                    multiple={false}
                 />
                 <div className="text-sm text-muted-foreground space-y-2">
                     <div className="font-medium text-foreground">JSON structure</div>

--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -266,7 +266,7 @@ const ServerForm = ({onSubmit, onClose}: ProviderFormProps<ServerFormData>) => {
                     <SSHKeySelector control={control} />
                     <div className="mt-2">
                         <a
-                            href="/settings#SSL_keys"
+                            href="/settings#secrets"
                             target="_blank"
                             rel="noreferrer"
                             className="text-sm text-primary hover:underline"

--- a/apps/client/src/components/ui/file-dropzone.tsx
+++ b/apps/client/src/components/ui/file-dropzone.tsx
@@ -9,6 +9,7 @@ type FileDropzoneProps = {
   placeholder?: string;
   loading?: boolean;
   className?: string;
+  multiple?: boolean;
 };
 
 export function FileDropzone({
@@ -18,16 +19,27 @@ export function FileDropzone({
   placeholder = "Click to select a file or drag & drop here",
   loading = false,
   className,
+  multiple = false,
 }: FileDropzoneProps) {
   const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
-    const file = e.dataTransfer.files?.[0];
-    if (file) onFile(file);
+    const files = Array.from(e.dataTransfer.files);
+    if (multiple) {
+      files.forEach(file => onFile(file));
+    } else {
+      const file = files[0];
+      if (file) onFile(file);
+    }
   };
 
   const onSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) onFile(file);
+    const files = Array.from(e.target.files || []);
+    if (multiple) {
+      files.forEach(file => onFile(file));
+    } else {
+      const file = files[0];
+      if (file) onFile(file);
+    }
   };
 
   return (
@@ -39,7 +51,7 @@ export function FileDropzone({
         className
       )}
     >
-      <input id={id} type="file" accept={accept} onChange={onSelect} className="hidden" />
+      <input id={id} type="file" accept={accept} multiple={multiple} onChange={onSelect} className="hidden" />
       <Label
         htmlFor={id}
         className="absolute inset-0 flex items-center justify-center cursor-pointer transition-colors group-hover:text-white"

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -554,7 +554,6 @@ export const secretsApi = {
       }
 
       const result = await response.json();
-      console.log('API Response (POST /secrets):', result);
       return result as ApiResponse<{ id: number }>;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';

--- a/apps/client/src/lib/sslKeys.ts
+++ b/apps/client/src/lib/sslKeys.ts
@@ -1,11 +1,5 @@
 import { secretsApi } from './api';
-
-// Type definition matching the server's SecretMetadata
-export type SecretMetadata = {
-  id: number;
-  name: string;
-  path: string;
-};
+import { SecretType, SecretMetadata } from '@OpsiMate/shared';
 
 // Server-based secrets functions
 export async function getSecretsFromServer(): Promise<SecretMetadata[]> {
@@ -21,9 +15,9 @@ export async function getSecretsFromServer(): Promise<SecretMetadata[]> {
   }
 }
 
-export async function createSecretOnServer(displayName: string, file: File): Promise<{ success: boolean; id?: number; error?: string }> {
+export async function createSecretOnServer(displayName: string, file: File, secretType: SecretType = SecretType.SSH): Promise<{ success: boolean; id?: number; error?: string }> {
   try {
-    const response = await secretsApi.createSecret(displayName, file);
+    const response = await secretsApi.createSecret(displayName, file, secretType);
     if (response.success && response.data) {
       return { success: true, id: response.data.id };
     }

--- a/apps/client/src/lib/sslKeys.ts
+++ b/apps/client/src/lib/sslKeys.ts
@@ -1,33 +1,50 @@
-export type SSLKey = {
-  id: string;
+import { secretsApi } from './api';
+
+// Type definition matching the server's SecretMetadata
+export type SecretMetadata = {
+  id: number;
   name: string;
-  createdAt: string;
+  path: string;
 };
 
-const STORAGE_KEY = "OpsiMate-ssl-keys";
-
-export function getSslKeys(): SSLKey[] {
+// Server-based secrets functions
+export async function getSecretsFromServer(): Promise<SecretMetadata[]> {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    return JSON.parse(raw) as SSLKey[];
-  } catch {
+    const response = await secretsApi.getSecrets();
+    if (response.success && response.data) {
+      return response.data.secrets;
+    }
+    return [];
+  } catch (error) {
+    console.error('Error fetching secrets from server:', error);
     return [];
   }
 }
 
-export function addSslKey(name: string): SSLKey {
-  const keys = getSslKeys();
-  const key: SSLKey = { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}` , name, createdAt: new Date().toISOString() };
-  const next = [key, ...keys];
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-  return key;
+export async function createSecretOnServer(displayName: string, file: File): Promise<{ success: boolean; id?: number; error?: string }> {
+  try {
+    const response = await secretsApi.createSecret(displayName, file);
+    if (response.success && response.data) {
+      return { success: true, id: response.data.id };
+    }
+    return { success: false, error: response.error || 'Failed to create secret' };
+  } catch (error) {
+    console.error('Error creating secret on server:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error occurred' };
+  }
 }
 
-export function deleteSslKey(id: string): void {
-  const keys = getSslKeys();
-  const next = keys.filter(k => k.id !== id);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+export async function deleteSecretOnServer(secretId: number): Promise<{ success: boolean; error?: string }> {
+  try {
+    const response = await secretsApi.deleteSecret(secretId);
+    if (response.success) {
+      return { success: true };
+    }
+    return { success: false, error: response.error || 'Failed to delete secret' };
+  } catch (error) {
+    console.error('Error deleting secret on server:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error occurred' };
+  }
 }
 
 

--- a/apps/server/src/api/v1/secrets/controller.ts
+++ b/apps/server/src/api/v1/secrets/controller.ts
@@ -49,4 +49,24 @@ export class SecretsController {
         }
     };
 
+    deleteSecret = async (req: Request, res: Response) => {
+        try {
+            const secretId = parseInt(req.params.id);
+            if (isNaN(secretId)) {
+                res.status(400).json({success: false, error: 'Invalid secret ID'});
+                return;
+            }
+
+            const deleted = await this.secretsBL.deleteSecret(secretId);
+            if (deleted) {
+                res.json({success: true, message: 'Secret deleted successfully'});
+            } else {
+                res.status(404).json({success: false, error: 'Secret not found'});
+            }
+        } catch (error) {
+            logger.error('Error deleting secret:', error);
+            res.status(500).json({success: false, error: 'Internal server error'});
+        }
+    };
+
 }

--- a/apps/server/src/api/v1/secrets/controller.ts
+++ b/apps/server/src/api/v1/secrets/controller.ts
@@ -36,8 +36,8 @@ export class SecretsController {
             // Overwrite file with encrypted content
             fs.writeFileSync(filePath, encryptedContent ?? "");
 
-            const {displayName} = CreateSecretsMetadataSchema.parse(req.body);
-            const createdSecretId: number = await this.secretsBL.createSecretMetadata(displayName, req.file!.filename);
+            const {displayName, secretType} = CreateSecretsMetadataSchema.parse(req.body);
+            const createdSecretId: number = await this.secretsBL.createSecretMetadata(displayName, req.file!.filename, secretType);
             res.status(201).json({success: true, data: {id: createdSecretId}});
         } catch (error) {
             if (error instanceof z.ZodError) {

--- a/apps/server/src/api/v1/secrets/router.ts
+++ b/apps/server/src/api/v1/secrets/router.ts
@@ -29,5 +29,8 @@ export default function createSecretsRouter(secretsController: SecretsController
     // GET /api/v1/secrets
     router.get('/', secretsController.getSecrets);
 
+    // DELETE /api/v1/secrets/:id
+    router.delete('/:id', secretsController.deleteSecret);
+
     return router;
 }

--- a/apps/server/src/bl/secrets/secretsMetadata.bl.ts
+++ b/apps/server/src/bl/secrets/secretsMetadata.bl.ts
@@ -1,4 +1,4 @@
-import {Logger, SecretMetadata} from "@OpsiMate/shared";
+import {Logger, SecretMetadata, SecretType} from "@OpsiMate/shared";
 
 
 import {SecretsMetadataRepository} from "../../dal/secretsMetadataRepository";
@@ -13,11 +13,11 @@ export class SecretsMetadataBL {
     ) {
     }
 
-    async createSecretMetadata(displayName: string, newName: string): Promise<number> {
+    async createSecretMetadata(displayName: string, newName: string, secretType: SecretType = SecretType.SSH): Promise<number> {
         try {
             const fullPath = path.resolve(getSecurityConfig().private_keys_path, newName)
             logger.info(`Creating Secret named ${displayName} in ${newName}`)
-            const createdSecret = await this.secretsMetadataRepository.createSecret({name: displayName, path: fullPath})
+            const createdSecret = await this.secretsMetadataRepository.createSecret({name: displayName, path: fullPath, type: secretType})
 
             logger.info(`Successfully created secret named ${displayName} in ${newName} in ${createdSecret.lastID}`)
 

--- a/apps/server/src/bl/secrets/secretsMetadata.bl.ts
+++ b/apps/server/src/bl/secrets/secretsMetadata.bl.ts
@@ -43,4 +43,47 @@ export class SecretsMetadataBL {
             throw e
         }
     }
+
+    async deleteSecret(id: number): Promise<boolean> {
+        try {
+            logger.info(`Deleting secret with id ${id}`);
+            
+            // First get the secret to get the file path before deleting
+            const secrets = await this.secretsMetadataRepository.getSecrets();
+            const secretToDelete = secrets.find(secret => secret.id === id);
+            
+            if (!secretToDelete) {
+                logger.warn(`Secret with id ${id} not found`);
+                return false;
+            }
+
+            // Delete from database
+            const deleted = await this.secretsMetadataRepository.deleteSecret(id);
+            
+            if (!deleted) {
+                logger.warn(`Failed to delete secret with id ${id} from database`);
+                return false;
+            }
+
+            // Delete the actual file from filesystem
+            const fs = await import('fs');
+            try {
+                if (fs.existsSync(secretToDelete.path)) {
+                    fs.unlinkSync(secretToDelete.path);
+                    logger.info(`Successfully deleted secret file: ${secretToDelete.path}`);
+                } else {
+                    logger.warn(`Secret file not found on filesystem: ${secretToDelete.path}`);
+                }
+            } catch (fileError) {
+                logger.error(`Error deleting secret file: ${secretToDelete.path}`, fileError);
+                // Don't throw here - the database record is already deleted
+            }
+
+            logger.info(`Successfully deleted secret with id ${id}`);
+            return true;
+        } catch (e) {
+            logger.error(`Error occurred deleting secret with id ${id}`, e);
+            throw e;
+        }
+    }
 }

--- a/apps/server/src/dal/secretsMetadataRepository.ts
+++ b/apps/server/src/dal/secretsMetadataRepository.ts
@@ -36,6 +36,19 @@ export class SecretsMetadataRepository {
         });
     }
 
+    async deleteSecret(id: number): Promise<boolean> {
+        return await runAsync<boolean>(() => {
+            const deleteStmt = this.db.prepare('DELETE FROM secrets WHERE id = ?');
+            const result = deleteStmt.run(id);
+            
+            if (result.changes === 0) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
     async initSecretsMetadataTable(): Promise<void> {
         return runAsync(() => {
             this.db.prepare(`

--- a/apps/server/src/dal/secretsMetadataRepository.ts
+++ b/apps/server/src/dal/secretsMetadataRepository.ts
@@ -12,12 +12,13 @@ export class SecretsMetadataRepository {
     async createSecret(data: Omit<SecretMetadata, 'id'>): Promise<{ lastID: number }> {
         return await runAsync<{ lastID: number }>(() => {
             const stmt = this.db.prepare(
-                'INSERT INTO secrets (secret_name, secret_path) VALUES (?, ?)'
+                'INSERT INTO secrets (secret_name, secret_path, secret_type) VALUES (?, ?, ?)'
             );
 
             const result = stmt.run(
                 data.name,
-                data.path
+                data.path,
+                data.type
             );
 
             return {lastID: result.lastInsertRowid as number}
@@ -29,7 +30,8 @@ export class SecretsMetadataRepository {
             const stmt = this.db.prepare(`
                 SELECT id,
                        secret_name AS name,
-                       secret_path AS path
+                       secret_path AS path,
+                       secret_type AS type
                 FROM secrets
             `);
             return stmt.all() as SecretMetadata[];
@@ -55,7 +57,8 @@ export class SecretsMetadataRepository {
                 CREATE TABLE IF NOT EXISTS secrets (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     secret_name TEXT NOT NULL,
-                    secret_path TEXT NOT NULL
+                    secret_path TEXT NOT NULL,
+                    secret_type TEXT NOT NULL DEFAULT 'ssh'
                 )
             `).run();
         });

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {IntegrationType, ProviderType, ServiceType, Role} from './types';
+import {IntegrationType, ProviderType, ServiceType, Role, SecretType} from './types';
 
 export const CreateProviderSchema = z.object({
     name: z.string().min(1, 'Provider name is required'),
@@ -143,6 +143,7 @@ export const UpdateProfileSchema = z.object({
 
 export const CreateSecretsMetadataSchema = z.object({
     displayName: z.string().min(1, 'Secret name is required'),
+    secretType: z.nativeEnum(SecretType).optional().default(SecretType.SSH),
 })
 
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -21,6 +21,11 @@ export enum Role {
     Viewer = 'viewer',
 }
 
+export enum SecretType {
+    SSH = 'ssh',
+    KUBECONFIG = 'kubeconfig',
+}
+
 export interface User {
     id: number;
     email: string;
@@ -143,5 +148,6 @@ export interface AuditLog {
 export type SecretMetadata = {
     id: number;
     name: string;
-    path: string
+    path: string;
+    type: SecretType;
 }


### PR DESCRIPTION
## Issue Reference

#[ISSURE](https://github.com/OpsiMate/OpsiMate/issues/175)
---

## What Was Changed

1. Added delete secret endpoint 
2. Integrate secret upload and secret list in settings with the server real endpoints instead of relying on local storage implementation.
3. Added secret type (ssh key/kubeconfig)
4. Changed secrets page in settings from SSL_Keys => secrets


**Screenshots**:
<img width="555" height="633" alt="image" src="https://github.com/user-attachments/assets/e206fb2a-d6c4-4dee-aa20-86438d2f0963" />

<img width="1509" height="821" alt="image" src="https://github.com/user-attachments/assets/be70278f-fbac-408d-be50-16c3bdfd236c" />

<img width="438" height="275" alt="image" src="https://github.com/user-attachments/assets/239c78ae-bff1-4aef-bcbe-fddb89ce229f" />

<img width="414" height="202" alt="image" src="https://github.com/user-attachments/assets/b22dda03-e568-452e-bf72-afa507afa4aa" />

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->

---

## Screenshots (Optional)

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->
