### PR TITLE
Fixes "Container Image" field displaying N/A across multiple UI components

### DIFF
--- a/apps/client/src/components/AddServiceDialog.tsx
+++ b/apps/client/src/components/AddServiceDialog.tsx
@@ -113,7 +113,7 @@ export function AddServiceDialog({ serverId, serverName, providerType, open, onC
           return {
             serviceStatus: service.serviceStatus,
             serviceIP: service.serviceIP,
-            image: 'N/A', // DiscoveredService doesn't have image info
+            image: '', // DiscoveredService doesn't have image info
             id: `container-${index}`, // Generate ID since DiscoveredService doesn't have id
             name: service.name,
             selected: false,
@@ -478,7 +478,7 @@ export function AddServiceDialog({ serverId, serverName, providerType, open, onC
                               </div>
                             )}
                           </div>
-                          <div className="text-sm text-muted-foreground">{container.image}</div>
+                          {container.image && <div className="text-sm text-muted-foreground">{container.image}</div>}
                           <div className="text-xs mt-1">
                             <span className={`inline-block px-2 py-1 rounded-full ${container.serviceStatus === 'running' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
                               {container.serviceStatus}
@@ -582,7 +582,7 @@ export function AddServiceDialog({ serverId, serverName, providerType, open, onC
                                 </div>
                               )}
                             </div>
-                            <div className="text-sm text-muted-foreground">{container.image}</div>
+                            {container.image && <div className="text-sm text-muted-foreground">{container.image}</div>}
                             <div className="text-xs mt-1">
                               <span className={`inline-block px-2 py-1 rounded-full ${container.serviceStatus === 'running' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
                                 {container.serviceStatus}

--- a/apps/client/src/components/FilterPanel.tsx
+++ b/apps/client/src/components/FilterPanel.tsx
@@ -26,7 +26,6 @@ const FACET_FIELDS = [
   'serviceType', 
   'providerType',
   'providerName',
-  'containerImage',
   'containerNamespace',
   'tags'
 ] as const;
@@ -36,7 +35,6 @@ const FIELD_LABELS: Record<string, string> = {
   serviceType: 'Service Type',
   providerType: 'Provider Type',
   providerName: 'Provider Name',
-  containerImage: 'Container Image',
   containerNamespace: 'Container Namespace',
   tags: 'Tags'
 };
@@ -73,12 +71,6 @@ export function FilterPanel({ services, filters, onFilterChange, collapsed }: Fi
       if (service.provider?.name) {
         const value = String(service.provider.name);
         newFacets.providerName[value] = (newFacets.providerName[value] || 0) + 1;
-      }
-
-      // Container image
-      if (service.containerDetails?.image) {
-        const value = String(service.containerDetails.image);
-        newFacets.containerImage[value] = (newFacets.containerImage[value] || 0) + 1;
       }
 
       // Container namespace

--- a/apps/client/src/pages/Dashboard.tsx
+++ b/apps/client/src/pages/Dashboard.tsx
@@ -183,10 +183,6 @@ const Dashboard = () => {
                             // Nested provider property
                             return filterValues.includes(String(service.provider?.name));
                         
-                        case 'containerImage':
-                            // Nested container details property
-                            return filterValues.includes(String(service.containerDetails?.image));
-                        
                         case 'containerNamespace':
                             // Nested container details property
                             return filterValues.includes(String(service.containerDetails?.namespace));


### PR DESCRIPTION
ssue Reference
Fixes "Container Image" field displaying N/A across multiple UI components

What Was Changed
Removed Container Image filter from FilterPanel and Dashboard
Fixed AddServiceDialog to conditionally show container image only when available
Removed hardcoded 'N/A' values
Why Was It Changed
The "Container Image" field was always showing "N/A" because 
DiscoveredService
 doesn't include image data. This created UI clutter and non-functional filter options without providing value to users.

Screenshots (Optional)
Additional Context (Optional)
Container Details column in ServiceTable remains functional - shows Docker images when available and "Systemd Service" labels. This is purely UI cleanup with no breaking changes.