### PR TITLE
New Release note actions with drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,22 @@
+name-template: 'v$NEXT_PATCH_VERSION 🚀'
+tag-template: 'v$NEXT_PATCH_VERSION'
+template: |
+  ## What's Changed.
+  $CHANGES
+  Thanks to our contributors: $CONTRIBUTORS
+categories:
+  - title: 'New Features 🚀'
+    labels:
+      - enhancement
+      - feature
+  - title: 'Bug Fixes 🐛'
+    labels:
+      - bug
+      - fix
+  - title: 'Documentation 📚'
+    labels:
+      - documentation
+      - docs
+exclude-labels:
+  - ignore-for-release
+  - do-not-merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,9 @@ jobs:
           -t opsimate/opsimate:latest \
           --push .
 
-    - name: Create GitHub Release
-      uses: actions/create-release@v1
+    - name: Update Release Draft
+      uses: release-drafter/release-drafter@v5
+      with:
+        config-name: release-drafter.yml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.version.outputs.tag }}
-        release_name: Release v${{ steps.version.outputs.version }}
-        draft: false
-        prerelease: false


### PR DESCRIPTION
Closes  #221 

## What Was Changed

Added Drafter for making draft releases and only share releases after approval
---

## Why Was It Changed

Now no new pr merged will directly create a new release. It will first be drafted with other PRs.
---

## Additional Context (Optional)

Drafter does not have a in-built New contributor, so we have to create a new job for it later.