### PR TITLE
fix filter is case sensitive

### DIFF
--- a/apps/client/src/components/FilterPanel.tsx
+++ b/apps/client/src/components/FilterPanel.tsx
@@ -115,9 +115,9 @@ export function FilterPanel({ services, filters, onFilterChange, collapsed }: Fi
 
   const handleCheckboxChange = (field: string, value: string) => {
     const currentFilters = filters[field] || [];
-    const newFilters = currentFilters.includes(value)
-      ? currentFilters.filter(v => v !== value)
-      : [...currentFilters, value];
+    const newFilters = currentFilters.includes(value.toLowerCase())
+      ? currentFilters.filter(v => v.toLowerCase() !== value.toLowerCase())
+      : [...currentFilters, value.toLowerCase()];
     onFilterChange({
       ...filters,
       [field]: newFilters,

--- a/apps/client/src/pages/Dashboard.tsx
+++ b/apps/client/src/pages/Dashboard.tsx
@@ -205,19 +205,19 @@ const Dashboard = () => {
                         case 'serviceStatus':
                         case 'serviceType':
                             // Direct service properties
-                            return filterValues.includes(String(service[key]));
+                            return filterValues.includes(String(service[key].toLowerCase()));
                         
                         case 'providerType':
                             // Nested provider property
-                            return filterValues.includes(String(service.provider?.providerType));
+                            return filterValues.includes(String(service.provider?.providerType.toLowerCase()));
                         
                         case 'providerName':
                             // Nested provider property
-                            return filterValues.includes(String(service.provider?.name));
+                            return filterValues.includes(String(service.provider?.name.toLowerCase()));
                         
                         case 'containerNamespace':
                             // Nested container details property
-                            return filterValues.includes(String(service.containerDetails?.namespace));
+                            return filterValues.includes(String(service.containerDetails?.namespace.toLowerCase()));
                         
                         case 'tags':
                             // Handle tags array - service must have ALL selected tags (AND logic)
@@ -226,12 +226,12 @@ const Dashboard = () => {
                             }
                             // Check if the service has ALL the selected tags
                             return filterValues.every(selectedTag => 
-                                service.tags.some(tag => tag.name === selectedTag)
+                                service.tags.some(tag => tag.name.toLowerCase() === selectedTag.toLowerCase())
                             );
                         
                         default:
                             // Fallback for any other direct properties
-                            return filterValues.includes(String(service[key as keyof Service]));
+                            return filterValues.includes(String(service[key as keyof Service]).toLowerCase());
                     }
                 }
                 return true;


### PR DESCRIPTION
## Issue Reference  
Closes [#264](https://github.com/OpsiMate/OpsiMate/issues/264)  

---

## What Was Changed  
- Updated the filter logic to be case insensitive.  
- Ensured that filtering now matches results regardless of input casing (e.g., `Test`, `test`, `TEST` will all return the same results).  

---

## Why Was It Changed  
The filter was previously case sensitive, which led to inconsistent and unexpected search results.  
Making the filter case insensitive provides a more user-friendly and predictable experience.  

---

## Screenshots (Optional)  
N/A  

---

## Additional Context (Optional)  
- This change affects only the filter logic; no other functionality was modified.  
