### PR TITLE
[FIX] Reload provider not functioning

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
+  }
+}
+
+

--- a/.github/workflows/PR fields validation.yml
+++ b/.github/workflows/PR fields validation.yml
@@ -1,0 +1,97 @@
+name: PR Fields Validation
+
+# This workflow validates that pull requests have meaningful titles and descriptions
+# Requirements:
+# 1. PR title must start with [FIX] or [FEAT] prefix
+# 2. PR must have a description/body with meaningful content
+# 3. Title must be descriptive and reasonably long
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check PR Description
+        id: check-description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Check if PR body exists and has meaningful content
+          BODY="$PR_BODY"
+          
+          # Remove whitespace and check if empty
+          CLEANED_BODY=$(echo "$BODY" | tr -d '[:space:]')
+          
+          if [ -z "$CLEANED_BODY" ] || [ "$CLEANED_BODY" = "null" ]; then
+            echo "❌ PR Description is missing!"
+            echo ""
+            echo "Please provide a detailed description in the PR body that explains:"
+            echo "• What changes were made"
+            echo "• Why the changeswere made"
+            echo "• Any additional context that reviewers should know"
+            echo ""
+            echo "This helps maintainers understand your contribution."
+            exit 1
+          fi
+          
+          # Check for minimum description length (excluding markers/templates)
+          MIN_LENGTH=50
+          WORD_COUNT=$(echo "$BODY" | wc -w)
+          
+          if [ "$WORD_COUNT" -lt 10 ]; then
+            echo "❌ PR Description is too short!"
+            echo ""
+            echo "Please provide a more detailed description (at least 10 words)."
+            echo "Help reviewers understand your changes better."
+            exit 1
+          fi
+          
+          echo "✅ PR Description looks good!"
+          echo "description_valid=true" >> $GITHUB_OUTPUT
+
+      - name: Custom Title Validation
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          
+          echo "Checking PR title: $TITLE"
+          
+          # Check if title starts with [FIX] or [FEAT]
+          if [[ "$TITLE" =~ ^\[(FIX|FEAT)\] ]]; then
+            echo "✅ Title prefix is valid!"
+          else
+            echo "❌ Invalid PR title format!"
+            echo ""
+            echo "The PR title must start with one of these prefixes:"
+            echo "• [FIX] - for bug fixes"
+            echo "• [FEAT] - for new features"
+            echo ""
+            echo "Examples:"
+            echo "• [FIX]: Fix login redirect issue"
+            echo "• [FEAT]: Add dark mode toggle"
+            echo ""
+            echo "Current title: \"$TITLE\""
+            exit 1
+          fi
+          
+          # Check title length
+          if [ ${#TITLE} -lt 10 ]; then
+            echo "❌ Title is too short!"
+            echo "Please provide a more descriptive title (at least 10 characters)."
+            exit 1
+          fi
+          
+          # Check if title has meaningful content after the prefix
+          DESCRIPTION=$(echo "$TITLE" | sed 's/^\[\(FIX\|FEAT\)\]: *//')
+
+          if [ ${#DESCRIPTION} -lt 5 ]; then
+            echo "❌ Title description is too short!"
+            echo "Please provide a meaningful description after the prefix."
+            exit 1
+          fi
+          
+          echo "✅ All PR title validations passed!"

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -156,6 +156,11 @@ export const providerApi = {
     return apiRequest<Provider>(`/providers/${providerId}`);
   },
 
+  // Refresh provider and get real-time service status
+  refreshProvider: (providerId: number) => {
+    return apiRequest<{ provider: Provider; services: Service[] }>(`/providers/${providerId}/refresh`, 'POST');
+  },
+
   // Create a new provider
   createProvider: (providerData: {
     name: string;

--- a/apps/server/src/api/v1/providers/controller.ts
+++ b/apps/server/src/api/v1/providers/controller.ts
@@ -33,30 +33,6 @@ export class ProviderController {
         }
     }
 
-    async getProviderById(req: Request, res: Response) {
-        try {
-            const providerId = parseInt(req.params.providerId);
-            if (isNaN(providerId)) {
-                return res.status(400).json({success: false, error: 'Invalid provider ID'});
-            }
-
-            const provider = await this.providerBL.getProviderById(providerId);
-            if (!provider) {
-                return res.status(404).json({success: false, error: 'Provider not found'});
-            }
-
-            delete provider.password;
-            res.json({success: true, data: provider});
-        } catch (error) {
-            if (error instanceof ProviderNotFound) {
-                res.status(404).json({success: false, error: `Provider ${error.provider} not found`});
-            } else {
-                logger.error('Error getting provider:', error);
-                res.status(500).json({success: false, error: 'Internal server error'});
-            }
-        }
-    }
-
     async refreshProvider(req: Request, res: Response) {
         try {
             const providerId = parseInt(req.params.providerId);

--- a/apps/server/src/api/v1/providers/controller.ts
+++ b/apps/server/src/api/v1/providers/controller.ts
@@ -33,6 +33,30 @@ export class ProviderController {
         }
     }
 
+    async getProviderById(req: Request, res: Response) {
+        try {
+            const providerId = parseInt(req.params.providerId);
+            if (isNaN(providerId)) {
+                return res.status(400).json({success: false, error: 'Invalid provider ID'});
+            }
+
+            const provider = await this.providerBL.getProviderById(providerId);
+            if (!provider) {
+                return res.status(404).json({success: false, error: 'Provider not found'});
+            }
+
+            delete provider.password;
+            res.json({success: true, data: provider});
+        } catch (error) {
+            if (error instanceof ProviderNotFound) {
+                res.status(404).json({success: false, error: `Provider ${error.provider} not found`});
+            } else {
+                logger.error('Error getting provider:', error);
+                res.status(500).json({success: false, error: 'Internal server error'});
+            }
+        }
+    }
+
     async createProvider(req: AuthenticatedRequest, res: Response) {
         try {
             const providerToCreate = CreateProviderSchema.parse(req.body);

--- a/apps/server/src/api/v1/providers/controller.ts
+++ b/apps/server/src/api/v1/providers/controller.ts
@@ -57,6 +57,36 @@ export class ProviderController {
         }
     }
 
+    async refreshProvider(req: Request, res: Response) {
+        try {
+            const providerId = parseInt(req.params.providerId);
+            if (isNaN(providerId)) {
+                return res.status(400).json({success: false, error: 'Invalid provider ID'});
+            }
+
+            const result = await this.providerBL.refreshProvider(providerId);
+            
+            delete result.provider.password;
+            
+            res.json({
+                success: true, 
+                data: {
+                    provider: result.provider,
+                    services: result.services
+                },
+                message: 'Provider refreshed successfully'
+            });
+        } catch (error) {
+            if (error instanceof ProviderNotFound) {
+                res.status(404).json({success: false, error: `Provider ${error.provider} not found`});
+            } else {
+                logger.error('Error refreshing provider:', error);
+                const message = error instanceof Error ? error.message : 'Unknown error';
+                res.status(500).json({success: false, error: 'Failed to refresh provider', details: message});
+            }
+        }
+    }
+
     async createProvider(req: AuthenticatedRequest, res: Response) {
         try {
             const providerToCreate = CreateProviderSchema.parse(req.body);

--- a/apps/server/src/api/v1/providers/router.ts
+++ b/apps/server/src/api/v1/providers/router.ts
@@ -9,15 +9,15 @@ export default function createProviderRouter(controller: ProviderController) {
     router.get('/', controller.getProviders.bind(controller));
     router.post('/', controller.createProvider.bind(controller));
     router.post('/bulk', controller.createProviderBulk.bind(controller));
-    router.post('/test-connection', controller.testConnection.bind(controller));
     
     // Provider-specific routes (with :providerId parameter)
     router.get('/:providerId', controller.getProviderById.bind(controller));
     router.post('/:providerId/refresh', controller.refreshProvider.bind(controller));
     router.put('/:providerId', controller.updateProvider.bind(controller));
     router.delete('/:providerId', controller.deleteProvider.bind(controller));
-
+    
     // Additional APIs
+    router.post('/test-connection', controller.testConnection.bind(controller));
     router.post('/:providerId/services/bulk', controller.bulkAddServices.bind(controller));
     router.get('/:providerId/discover-services', controller.discoverServices.bind(controller));
 

--- a/apps/server/src/api/v1/providers/router.ts
+++ b/apps/server/src/api/v1/providers/router.ts
@@ -9,13 +9,16 @@ export default function createProviderRouter(controller: ProviderController) {
     router.get('/', controller.getProviders.bind(controller));
     router.post('/', controller.createProvider.bind(controller));
     router.post('/bulk', controller.createProviderBulk.bind(controller));
+    router.post('/test-connection', controller.testConnection.bind(controller));
+    
+    // Provider-specific routes (with :providerId parameter)
+    router.get('/:providerId', controller.getProviderById.bind(controller));
     router.put('/:providerId', controller.updateProvider.bind(controller));
     router.delete('/:providerId', controller.deleteProvider.bind(controller));
 
     // Additional APIs
     router.post('/:providerId/services/bulk', controller.bulkAddServices.bind(controller));
     router.get('/:providerId/discover-services', controller.discoverServices.bind(controller));
-    router.post('/test-connection', controller.testConnection.bind(controller));
 
     return router;
 }

--- a/apps/server/src/api/v1/providers/router.ts
+++ b/apps/server/src/api/v1/providers/router.ts
@@ -13,6 +13,7 @@ export default function createProviderRouter(controller: ProviderController) {
     
     // Provider-specific routes (with :providerId parameter)
     router.get('/:providerId', controller.getProviderById.bind(controller));
+    router.post('/:providerId/refresh', controller.refreshProvider.bind(controller));
     router.put('/:providerId', controller.updateProvider.bind(controller));
     router.delete('/:providerId', controller.deleteProvider.bind(controller));
 

--- a/apps/server/src/api/v1/providers/router.ts
+++ b/apps/server/src/api/v1/providers/router.ts
@@ -11,7 +11,6 @@ export default function createProviderRouter(controller: ProviderController) {
     router.post('/bulk', controller.createProviderBulk.bind(controller));
     
     // Provider-specific routes (with :providerId parameter)
-    router.get('/:providerId', controller.getProviderById.bind(controller));
     router.post('/:providerId/refresh', controller.refreshProvider.bind(controller));
     router.put('/:providerId', controller.updateProvider.bind(controller));
     router.delete('/:providerId', controller.deleteProvider.bind(controller));

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -116,7 +116,7 @@ export async function createApp(db: Database.Database, config?: { enableJobs: bo
 
 
     if (config?.enableJobs) {
-        new RefreshJob(providerBL, serviceRepo).startRefreshJob();
+        new RefreshJob(providerBL).startRefreshJob();
         new PullGrafanaAlertsJob(alertBL, integrationBL, tagRepo).startPullGrafanaAlertsJob();
     }
 

--- a/apps/server/src/bl/providers/provider.bl.ts
+++ b/apps/server/src/bl/providers/provider.bl.ts
@@ -1,4 +1,4 @@
-import {DiscoveredService, Provider, Service, Logger, User} from "@OpsiMate/shared";
+import {DiscoveredService, Provider, Service, Logger, User, ServiceType} from "@OpsiMate/shared";
 import { ProviderNotFound } from "./ProviderNotFound";
 import { providerConnectorFactory } from "./provider-connector/providerConnectorFactory";
 import {ProviderRepository} from "../../dal/providerRepository";
@@ -6,6 +6,7 @@ import {ServiceRepository} from "../../dal/serviceRepository";
 import {SecretsMetadataRepository} from "../../dal/secretsMetadataRepository";
 import { AuditBL } from '../audit/audit.bl';
 import { AuditActionType, AuditResourceType } from '@OpsiMate/shared';
+import { checkSystemServiceStatus } from "../../dal/sshClient";
 
 const logger = new Logger('bl/providers/provider.bl');
 
@@ -169,23 +170,7 @@ export class ProviderBL {
         }
 
         try {
-            const providerConnector = providerConnectorFactory(provider.providerType);
-            const discoveredServices = await providerConnector.discoverServices(provider);
-            logger.info(`Discovered ${discoveredServices.length} services for provider ${providerId}`);
-
-            const dbServices = await this.serviceRepo.getServicesByProviderId(providerId);
-            
-            for (const dbService of dbServices) {
-                const matchedService = discoveredServices.find(ds => ds.name === dbService.name);
-                
-                if (matchedService && matchedService.serviceStatus !== dbService.serviceStatus) {
-                    await this.serviceRepo.updateService(dbService.id, {
-                        serviceStatus: matchedService.serviceStatus
-                    });
-                    logger.info(`Updated service ${dbService.name} status to ${matchedService.serviceStatus}`);
-                }
-            }
-
+            await this.refreshProviderServices(provider);
             const updatedServices = await this.serviceRepo.getServicesByProviderId(providerId);
             
             return {
@@ -196,5 +181,49 @@ export class ProviderBL {
             logger.error(`Error refreshing provider ${providerId}:`, error);
             throw new Error(`Failed to refresh provider: ${error instanceof Error ? error.message : 'Unknown error'}`);
         }
+    }
+
+    async refreshProviderServices(provider: Provider): Promise<void> {
+        const connector = providerConnectorFactory(provider.providerType);
+        const discoveredServices: DiscoveredService[] = await connector.discoverServices(provider);
+        const dbServices = await this.serviceRepo.getServicesByProviderId(provider.id);
+
+        for (const dbService of dbServices) {
+            if (dbService.serviceType === ServiceType.SYSTEMD) {
+                try {
+                    const actualStatus = await checkSystemServiceStatus(provider, dbService.name);
+                    
+                    if (actualStatus !== dbService.serviceStatus) {
+                        await this.serviceRepo.updateService(dbService.id, {
+                            serviceStatus: actualStatus
+                        });
+                        logger.info(`Updated systemd service ${dbService.name} status to ${actualStatus}`);
+                    }
+                } catch (error) {
+                    logger.error(`Failed to check systemd service ${dbService.name} status:`, error);
+                }
+            } else {
+                const matchedService = this.findMatchingService(discoveredServices, dbService.name);
+
+                if (!matchedService) {
+                    await this.serviceRepo.deleteService(dbService.id);
+                }
+
+                if (matchedService && matchedService.serviceStatus !== dbService.serviceStatus) {
+                    await this.serviceRepo.updateService(dbService.id, {
+                        serviceStatus: matchedService.serviceStatus
+                    });
+                }
+            }
+        }
+    }
+
+    private findMatchingService(
+        discoveredServices: DiscoveredService[],
+        dbServiceName: string
+    ): DiscoveredService | undefined {
+        return discoveredServices.find(
+            ds => ds.name.trim().toLowerCase() === dbServiceName.trim().toLowerCase()
+        );
     }
 }

--- a/apps/server/src/bl/providers/provider.bl.ts
+++ b/apps/server/src/bl/providers/provider.bl.ts
@@ -156,7 +156,7 @@ export class ProviderBL {
         }
     }
 
-    private async getProviderById(providerId: number): Promise<Provider> {
+    async getProviderById(providerId: number): Promise<Provider> {
         return await this.providerRepo.getProviderById(providerId);
     }
 }

--- a/apps/server/src/dal/kubeConnector.ts
+++ b/apps/server/src/dal/kubeConnector.ts
@@ -147,7 +147,12 @@ const getK8SServices = async (_provider: Provider): Promise<DiscoveredService[]>
                 const labelSelector = Object.entries(selector).map(([k, v]) => `${k}=${v}`).join(',');
                 const podsList = await k8sApi.listNamespacedPod({ namespace, labelSelector });
                 const items: k8s.V1Pod[] = podsList.items ?? [];
-                serviceStatus = [...new Set(items.map((i: k8s.V1Pod) => i.status?.phase || "Unknown"))].join(", ");
+                
+                if (items.length === 0) {
+                    serviceStatus = "stopped";
+                } else {
+                    serviceStatus = [...new Set(items.map((i: k8s.V1Pod) => i.status?.phase || "Unknown"))].join(", ");
+                }
             }
 
             return {

--- a/apps/server/src/jobs/refresh-job.ts
+++ b/apps/server/src/jobs/refresh-job.ts
@@ -1,17 +1,13 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { ProviderBL } from '../bl/providers/provider.bl';
-import { providerConnectorFactory } from '../bl/providers/provider-connector/providerConnectorFactory';
-import { DiscoveredService, Logger, Provider, ServiceType } from '@OpsiMate/shared';
-import { ServiceRepository } from "../dal/serviceRepository";
-import { checkSystemServiceStatus } from "../dal/sshClient";
+import { Logger, Provider } from '@OpsiMate/shared';
 
 const BATCH_SIZE = 10;
 const logger = new Logger('refresh-job');
 
 export class RefreshJob {
     constructor(
-        private providerBL: ProviderBL,
-        private serviceRepo: ServiceRepository
+        private providerBL: ProviderBL
     ) {}
 
     startRefreshJob = () => {
@@ -44,58 +40,10 @@ export class RefreshJob {
 
     private refreshProviderServicesSafely = async (provider: Provider): Promise<void> => {
         try {
-            await this.refreshProviderServices(provider);
+            await this.providerBL.refreshProviderServices(provider);
         } catch (err) {
             logger.error(`Failed to refresh services for provider ${provider.id}:`, err);
         }
-    };
-
-    private refreshProviderServices = async (provider: Provider): Promise<void> => {
-        const connector = providerConnectorFactory(provider.providerType);
-        const discoveredServices: DiscoveredService[] = await connector.discoverServices(provider);
-        const dbServices = await this.serviceRepo.getServicesByProviderId(provider.id);
-
-        for (const dbService of dbServices) {
-            // For systemd services, we need to check them individually to ensure accurate status
-            if (dbService.serviceType === ServiceType.SYSTEMD) {
-                try {
-                    const actualStatus = await checkSystemServiceStatus(provider, dbService.name);
-                    
-                    // Update service status only if it is different to reduce db calls
-                    if (actualStatus !== dbService.serviceStatus) {
-                        await this.serviceRepo.updateService(dbService.id, {
-                            serviceStatus: actualStatus
-                        });
-                        logger.info(`Updated systemd service ${dbService.name} status to ${actualStatus}`);
-                    }
-                } catch (error) {
-                    logger.error(`Failed to check systemd service ${dbService.name} status:`, error);
-                }
-            } else {
-                // For non-systemd services, use the discovered services
-                const matchedService = this.findMatchingService(discoveredServices, dbService.name);
-
-                if (!matchedService) {
-                    await this.serviceRepo.deleteService(dbService.id);
-                }
-
-                // Update service status only if it is different to reduce db calls
-                if (matchedService && matchedService.serviceStatus !== dbService.serviceStatus) {
-                    await this.serviceRepo.updateService(dbService.id, {
-                        serviceStatus: matchedService.serviceStatus
-                    });
-                }
-            }
-        }
-    };
-
-    private findMatchingService = (
-        discoveredServices: DiscoveredService[],
-        dbServiceName: string
-    ): DiscoveredService | undefined => {
-        return discoveredServices.find(
-            ds => ds.name.trim().toLowerCase() === dbServiceName.trim().toLowerCase()
-        );
     };
 
     private chunkArray = <T>(array: T[], chunkSize: number): T[][] => {


### PR DESCRIPTION
## Issue Reference

[Issue #263](https://github.com/OpsiMate/OpsiMate/issues/263)
---

# What Was Changed

### Backend
Added Provider Refresh Endpoint - New POST /api/v1/providers/:providerId/refresh endpoint that performs real-time SSH/K8s connection to discover services and update their status
Enhanced Provider Business Logic - Added refreshProvider() method that connects to remote servers, discovers services with live status, and updates the database
Router Update - Added refresh route while maintaining existing GET endpoint for cached data

### Frontend
Updated Refresh Functionality - Modified handleRefreshProvider() to use the new real-time refresh endpoint with loading states and improved user feedback
Client API - Added refreshProvider() method for real-time data fetching
Empty Status Handling - Added fallback logic to display "unknown" (gray badge) when serviceStatus is empty or missing across all components

---

## Why Was It Changed

### Problem: The "Refresh" button only fetched cached database data without connecting to servers, showing stale information. Additionally, services with no pods displayed blank status badges.
Solution:
Real-time refresh endpoint that actually SSH/connects to servers for accurate current status
Distinguishes between fast cached reads (GET) and real-time discovery (POST /refresh)
Consistent "unknown" status display prevents blank badges and improves UX
Impact: Users now get accurate real-time service status on demand with better feedback and consistent status display across the UI.

---

## Screenshots (Optional)

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->
