### PR TITLE
[Fix]  243 :  Label Docker services as "Pod" for Kubernetes providers …

### DIFF
--- a/apps/client/src/pages/MyProviders.tsx
+++ b/apps/client/src/pages/MyProviders.tsx
@@ -802,7 +802,7 @@ export function MyProviders() {
                                                                                 <p className="font-medium text-sm truncate">{service.name}</p>
                                                                                 <p className="text-xs text-muted-foreground truncate">
                                                                                     {service.type === "DOCKER"
-                                                                                        ? `Container: ${service.containerDetails?.image || service.name}`
+                                                                                        ? `${provider.providerType === "K8S" ? "Pod" : "Container"}: ${service.containerDetails?.image || service.name}`
                                                                                         : service.serviceIP
                                                                                             ? `IP: ${service.serviceIP}`
                                                                                             : "Manual service"


### PR DESCRIPTION
…on My Providers page

## Issue Reference

<!-- Link to the related issue or ticket, e.g. Closes #123 -->
Closes #243 

---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->
added condition to check provider
if provider type is K8S then Service is Pod else Container
provider.providerType === "K8S" ? "Pod" : "Container"

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->
After this Fix 
Service for providerType K8S, will be Pod Instead of Container

---

## Screenshots (Optional)

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->
