### PR TITLE
[FIX]: Update provider IP validation to accept DNS hostnames as well as IP addresses

### DIFF
--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -20,13 +20,15 @@ import { SecretMetadata } from "@OpsiMate/shared";
 
 // --- FORM SCHEMAS ---
 
+const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+const hostnameRegex = /^(?![\d.]+$)(?=.{1,253}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+const isValidHostnameOrIP = (value: string): boolean => ipRegex.test(value) || hostnameRegex.test(value);
+
 const serverSchema = z.object({
     name: z.string().min(1, "Server name is required"),
     hostname: z.string().min(1, "Hostname/IP is required").refine((value) => {
         // Allow both IP addresses and hostnames
-        const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-        const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
-        return ipRegex.test(value) || hostnameRegex.test(value);
+        return isValidHostnameOrIP(value);
     }, {
         message: "Must be a valid IP address or hostname"
     }),

--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -22,7 +22,14 @@ import { SecretMetadata } from "@OpsiMate/shared";
 
 const serverSchema = z.object({
     name: z.string().min(1, "Server name is required"),
-    hostname: z.string().ip({message: "Invalid IP address"}),
+    hostname: z.string().min(1, "Hostname/IP is required").refine((value) => {
+        // Allow both IP addresses and hostnames
+        const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+        const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
+        return ipRegex.test(value) || hostnameRegex.test(value);
+    }, {
+        message: "Must be a valid IP address or hostname"
+    }),
     port: z.coerce.number().min(1).max(65535),
     username: z.string().min(1, "Username is required"),
     authType: z.enum(["password", "key"]),

--- a/apps/client/src/components/ValidationFeedback.tsx
+++ b/apps/client/src/components/ValidationFeedback.tsx
@@ -99,11 +99,12 @@ export const validationRules = {
     },
     {
       id: 'ip-format',
-      label: 'Must be a valid IP address',
+      label: 'Must be a valid IP address or hostname',
       validator: (value: string) => {
         if (value.length === 0) return true; // Don't validate empty
         const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-        return ipRegex.test(value);
+        const hostnameRegex = /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+        return ipRegex.test(value) || hostnameRegex.test(value);
       },
     },
   ],

--- a/apps/client/src/components/ValidationFeedback.tsx
+++ b/apps/client/src/components/ValidationFeedback.tsx
@@ -103,7 +103,7 @@ export const validationRules = {
       validator: (value: string) => {
         if (value.length === 0) return true; // Don't validate empty
         const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-        const hostnameRegex = /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+        const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
         return ipRegex.test(value) || hostnameRegex.test(value);
       },
     },

--- a/apps/client/src/components/ValidationFeedback.tsx
+++ b/apps/client/src/components/ValidationFeedback.tsx
@@ -14,6 +14,10 @@ interface ValidationFeedbackProps {
   showValid?: boolean; // Whether to show green checkmarks for valid rules
 }
 
+const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+const hostnameRegex = /^(?![\d.]+$)(?=.{1,253}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+const isValidHostnameOrIP = (value: string): boolean => ipRegex.test(value) || hostnameRegex.test(value);
+
 export const ValidationFeedback: React.FC<ValidationFeedbackProps> = ({
   value,
   rules,
@@ -102,9 +106,7 @@ export const validationRules = {
       label: 'Must be a valid IP address or hostname',
       validator: (value: string) => {
         if (value.length === 0) return true; // Don't validate empty
-        const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-        const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
-        return ipRegex.test(value) || hostnameRegex.test(value);
+        return isValidHostnameOrIP(value);
       },
     },
   ],

--- a/apps/client/src/pages/MyProviders.tsx
+++ b/apps/client/src/pages/MyProviders.tsx
@@ -802,7 +802,7 @@ export function MyProviders() {
                                                                                 <p className="font-medium text-sm truncate">{service.name}</p>
                                                                                 <p className="text-xs text-muted-foreground truncate">
                                                                                     {service.type === "DOCKER"
-                                                                                        ? `Container: ${service.containerDetails?.image || service.name}`
+                                                                                        ? `${provider.providerType === "K8S" ? "Pod" : "Container"}: ${service.containerDetails?.image || service.name}`
                                                                                         : service.serviceIP
                                                                                             ? `IP: ${service.serviceIP}`
                                                                                             : "Manual service"

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,12 +1,14 @@
 import {z} from 'zod';
 import {IntegrationType, ProviderType, ServiceType, Role, SecretType} from './types';
 
+const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+const hostnameRegex = /^(?![\d.]+$)(?=.{1,253}$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+const isValidHostnameOrIP = (value: string): boolean => ipRegex.test(value) || hostnameRegex.test(value);
+
 export const CreateProviderSchema = z.object({
     name: z.string().min(1, 'Provider name is required'),
     providerIP: z.string().min(1, "Hostname/IP is required").refine((value) => {
-        const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-        const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
-        return ipRegex.test(value) || hostnameRegex.test(value);
+        return isValidHostnameOrIP(value);
     }, {
         message: "Must be a valid IP address or hostname"
     }).optional(),
@@ -46,9 +48,7 @@ export const AddBulkServiceSchema = z.array(
     z.object({
         name: z.string().min(1, 'Name is required'),
         serviceIP: z.string().min(1, "Hostname/IP is required").refine((value) => {
-            const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-            const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
-            return ipRegex.test(value) || hostnameRegex.test(value);
+            return isValidHostnameOrIP(value);
         }, {
             message: "Must be a valid IP address or hostname"
         }).optional(),

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -3,7 +3,13 @@ import {IntegrationType, ProviderType, ServiceType, Role, SecretType} from './ty
 
 export const CreateProviderSchema = z.object({
     name: z.string().min(1, 'Provider name is required'),
-    providerIP: z.string().ip('Invalid IP address').optional(),
+    providerIP: z.string().min(1, "Hostname/IP is required").refine((value) => {
+        const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+        const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
+        return ipRegex.test(value) || hostnameRegex.test(value);
+    }, {
+        message: "Must be a valid IP address or hostname"
+    }).optional(),
     username: z.string().min(1, 'Username is required').optional(),
     secretId: z.number().optional(),
     password: z.string().min(1, 'Password is required').optional(),
@@ -39,7 +45,13 @@ export const IntegrationTagsquerySchema = z.object({
 export const AddBulkServiceSchema = z.array(
     z.object({
         name: z.string().min(1, 'Name is required'),
-        serviceIP: z.string().ip('Invalid IP address').optional(),
+        serviceIP: z.string().min(1, "Hostname/IP is required").refine((value) => {
+            const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+            const hostnameRegex = /^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))*\.([a-z]{2,63})$/;
+            return ipRegex.test(value) || hostnameRegex.test(value);
+        }, {
+            message: "Must be a valid IP address or hostname"
+        }).optional(),
         serviceStatus: z.string().min(1),
         serviceType: z.nativeEnum(ServiceType),
     })


### PR DESCRIPTION
## Issue Reference

<!-- Link to the related issue or ticket, e.g. Closes #123 -->
Closes #200 

---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->
provider IP validation logic was updated to accept both IPv4 addresses and DNS hostnames
using hostname regex.

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->
so, providers can be configured using DNS hostnames

---

## Screenshots (Optional)

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)
hostname regex can we validate here : https://regex101.com/r/6Dnwyr/1

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->
