### PR TITLE
[FEAT]: Dockerfile for client and server instead of previously used Monolith Dockerfile

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,47 @@
+FROM node:20-alpine AS client-builder
+
+RUN npm install -g pnpm typescript && npm cache clean --force
+WORKDIR /app
+
+# Copy workspace manifests for caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/client/package.json apps/client/package.json
+COPY packages/shared/package.json packages/shared/package.json
+
+# Install deps (client + shared)
+RUN pnpm install --frozen-lockfile && \
+    if [ "$(uname -m)" = "aarch64" ]; then pnpm add @rollup/rollup-linux-arm64-musl --save-dev --filter @OpsiMate/client; fi && \
+    pnpm store prune
+
+# Copy sources
+COPY apps/client apps/client
+COPY packages/shared packages/shared
+
+# Build shared package first, then client
+RUN pnpm --filter @OpsiMate/shared build && \
+    pnpm --filter @OpsiMate/client build
+
+# Production runtime
+FROM node:20-alpine AS client-runtime
+RUN npm install -g serve && npm cache clean --force
+WORKDIR /app
+
+# Copy built client and minimal workspace files
+COPY --from=client-builder /app/apps/client/dist apps/client/dist
+COPY --from=client-builder /app/apps/client/package.json apps/client/package.json
+COPY --from=client-builder /app/package.json package.json
+COPY --from=client-builder /app/pnpm-lock.yaml pnpm-lock.yaml
+COPY --from=client-builder /app/pnpm-workspace.yaml pnpm-workspace.yaml
+COPY --from=client-builder /app/packages/shared/package.json packages/shared/package.json
+COPY --from=client-builder /app/packages/shared/dist packages/shared/dist
+
+# Install only production deps
+COPY --from=client-builder /app/node_modules ./node_modules
+
+# Ensure workspace link for shared
+RUN mkdir -p node_modules/@OpsiMate && \
+    ln -sf /app/packages/shared node_modules/@OpsiMate/shared
+
+EXPOSE 8080
+ENV NODE_ENV=production
+CMD ["serve", "-s", "/app/apps/client/dist", "-l", "8080"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,47 @@
+FROM node:20-alpine AS server-builder
+
+RUN npm install -g pnpm typescript && npm cache clean --force
+WORKDIR /app
+
+# Copy workspace manifests for caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/server/package.json apps/server/package.json
+COPY packages/shared/package.json packages/shared/package.json
+
+# Install deps (server + shared)
+RUN pnpm install --frozen-lockfile && pnpm store prune
+
+# Copy sources
+COPY apps/server apps/server
+COPY packages/shared packages/shared
+
+# Build shared package first, then server
+RUN pnpm --filter @OpsiMate/shared build && \
+    pnpm --filter @OpsiMate/server build
+
+# Production runtime
+FROM node:20-alpine AS server-runtime
+WORKDIR /app
+
+# Copy built server and minimal workspace files
+COPY --from=server-builder /app/apps/server/dist apps/server/dist
+COPY --from=server-builder /app/apps/server/package.json apps/server/package.json
+COPY --from=server-builder /app/package.json package.json
+COPY --from=server-builder /app/pnpm-lock.yaml pnpm-lock.yaml
+COPY --from=server-builder /app/pnpm-workspace.yaml pnpm-workspace.yaml
+COPY --from=server-builder /app/packages/shared/package.json packages/shared/package.json
+COPY --from=server-builder /app/packages/shared/dist packages/shared/dist
+
+# Install only production deps
+RUN npm install -g pnpm && \
+    pnpm install --prod --frozen-lockfile && \
+    pnpm store prune && \
+    rm -rf /root/.npm /root/.cache /tmp/*
+
+# Ensure workspace link for shared
+RUN mkdir -p node_modules/@OpsiMate && \
+    ln -sf /app/packages/shared node_modules/@OpsiMate/shared
+
+EXPOSE 3001
+ENV NODE_ENV=production
+CMD ["node", "apps/server/dist/src/index.js"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,50 @@
+services:
+  client:
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+      target: client-builder
+    command: sh -c "pnpm --filter @OpsiMate/client dev -- --port 8080 --host 0.0.0.0"
+    working_dir: /app
+    ports:
+      - "8080:8080"
+    environment:
+      - NODE_ENV=development
+    volumes:
+      - ./apps/client:/app/apps/client
+      - ./packages/shared:/app/packages/shared
+      - pnpm-store-client:/root/.pnpm-store
+    networks:
+      - appnet
+    depends_on:
+      - server
+
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+      target: server-builder
+    command: sh -c "pnpm --filter @OpsiMate/server dev"
+    working_dir: /app
+    ports:
+      - "3001:3001"
+    environment:
+      - NODE_ENV=development
+      - PORT=3001
+      - HOST=0.0.0.0
+    volumes:
+      - ./apps/server:/app/apps/server
+      - ./packages/shared:/app/packages/shared
+      - ./data:/app/data
+      - ./config:/app/config
+      - pnpm-store-server:/root/.pnpm-store
+    networks:
+      - appnet
+
+networks:
+  appnet:
+    driver: bridge
+
+volumes:
+  pnpm-store-client:
+  pnpm-store-server:


### PR DESCRIPTION
use command to test:
`docker compose -f docker-compose.dev.yml up --build `
to build it up

This Pr makes the  Dockerfile for client and server instead of previously used Monolith Dockerfile.