### PR TITLE
Fix: providers names check before creation - no duplications allowed

### DIFF
--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -22,7 +22,6 @@ import { SecretMetadata } from "@OpsiMate/shared";
 
 const serverSchema = z.object({
     name: z.string().min(1, "Server name is required"),
-    hostname: z.string().ip({message: "Invalid IP address"}),
     port: z.coerce.number().min(1).max(65535),
     username: z.string().min(1, "Username is required"),
     authType: z.enum(["password", "key"]),
@@ -507,13 +506,19 @@ export function ProviderSidebar({provider, onClose}: ProviderSidebarProps) {
                         // Redirect to My Providers page
                         navigate('/my-providers');
                     } else {
-                        throw new Error(response.error || 'Failed to create provider');
+                        // Display the actual error message from the server
+                        toast({
+                            title: "Error adding provider",
+                            description: response.error || 'Failed to create provider',
+                            variant: "destructive"
+                        });
                     }
-                } catch (error) {
-                    console.error("Error creating server provider:", error);
+                } catch (error: any) {
+                    console.error("Error creating kubernetes provider:", error);
+                    const errorMessage = error?.message || "There was a problem creating your provider";
                     toast({
                         title: "Error adding provider",
-                        description: error instanceof Error ? error.message : "There was a problem creating your provider",
+                        description: errorMessage,
                         variant: "destructive"
                     });
                 }
@@ -554,13 +559,19 @@ export function ProviderSidebar({provider, onClose}: ProviderSidebarProps) {
                         // Redirect to My Providers page
                         navigate('/my-providers');
                     } else {
-                        throw new Error(response.error || 'Failed to create provider');
+                        // Display the actual error message from the server
+                        toast({
+                            title: "Error adding provider",
+                            description: response.error || 'Failed to create provider',
+                            variant: "destructive"
+                        });
                     }
-                } catch (error) {
+                } catch (error: any) {
                     console.error("Error creating server provider:", error);
+                    const errorMessage = error?.message || "There was a problem creating your provider";
                     toast({
                         title: "Error adding provider",
-                        description: error instanceof Error ? error.message : "There was a problem creating your provider",
+                        description: errorMessage,
                         variant: "destructive"
                     });
                 }

--- a/apps/server/src/api/v1/providers/controller.ts
+++ b/apps/server/src/api/v1/providers/controller.ts
@@ -46,7 +46,8 @@ export class ProviderController {
                 res.status(400).json({success: false, error: 'Validation error', details: error.errors});
             } else {
                 logger.error('Error creating provider:', error);
-                res.status(500).json({success: false, error: 'Internal server error'});
+                const errorMessage = error instanceof Error ? error.message : 'Internal server error';
+                res.status(400).json({success: false, error: errorMessage});
             }
         }
     }

--- a/apps/server/src/bl/providers/provider.bl.ts
+++ b/apps/server/src/bl/providers/provider.bl.ts
@@ -33,6 +33,12 @@ export class ProviderBL {
         try {
             logger.info(`Starting to create provider`, { extraArgs: { ...providerToCreate } });
             
+            // Check if a provider with the same name already exists
+            const existingProvider = await this.providerRepo.getProviderByName(providerToCreate.name);
+            if (existingProvider) {
+                throw new Error(`A provider with the name '${providerToCreate.name}' already exists`);
+            }
+            
             // Resolve secretId to privateKeyFilename if provided
             const resolvedProvider = { ...providerToCreate };
             if (providerToCreate.secretId) {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -3,7 +3,6 @@ import {IntegrationType, ProviderType, ServiceType, Role, SecretType} from './ty
 
 export const CreateProviderSchema = z.object({
     name: z.string().min(1, 'Provider name is required'),
-    providerIP: z.string().ip('Invalid IP address').optional(),
     username: z.string().min(1, 'Username is required').optional(),
     secretId: z.number().optional(),
     password: z.string().min(1, 'Password is required').optional(),
@@ -39,7 +38,6 @@ export const IntegrationTagsquerySchema = z.object({
 export const AddBulkServiceSchema = z.array(
     z.object({
         name: z.string().min(1, 'Name is required'),
-        serviceIP: z.string().ip('Invalid IP address').optional(),
         serviceStatus: z.string().min(1),
         serviceType: z.nativeEnum(ServiceType),
     })


### PR DESCRIPTION
## Issue Reference
https://github.com/OpsiMate/OpsiMate/issues/251

## What Was Changed
Duplicate provider names are now prevented during creation. If a user tries to create a provider with a name that already exists for the same type, the application displays an error and does not allow the duplicate provider to be created.

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->
Allowing multiple providers of the same type with identical names caused confusion and issues when managing providers. This change ensures each provider name is unique within its type, improving usability and preventing potential misconfigurations.

## Screenshots (Optional)

<!-- If UI changes or visual diffs were made, include screenshots here -->
![Screenshot 2025-10-02 232735](https://github.com/user-attachments/assets/d9a31468-6236-49cf-b6a9-7333f1fcb8df)

## Additional Context (Optional)

None.