### PR TITLE
[FIX]: Dashboard: collapse arrows overlap filter panel

### DIFF
--- a/apps/client/src/components/DashboardLayout.tsx
+++ b/apps/client/src/components/DashboardLayout.tsx
@@ -82,7 +82,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
             onClick={() => setSidebarCollapsed(!isSidebarCollapsed)}
             variant="ghost"
             size="icon"
-            className="z-10 absolute top-1/2 -left-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
+            className="z-10 absolute top-3/4 -left-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
           >
             {isSidebarCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
           </Button>

--- a/apps/client/src/components/DashboardLayout.tsx
+++ b/apps/client/src/components/DashboardLayout.tsx
@@ -82,7 +82,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
             onClick={() => setSidebarCollapsed(!isSidebarCollapsed)}
             variant="ghost"
             size="icon"
-            className="z-10 absolute top-3/4 -left-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
+            className="z-10 absolute top-1/2 -left-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
           >
             {isSidebarCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
           </Button>

--- a/apps/client/src/pages/Dashboard.tsx
+++ b/apps/client/src/pages/Dashboard.tsx
@@ -525,7 +525,7 @@ const Dashboard = () => {
                                 onClick={toggleFilterPanel}
                                 variant="ghost"
                                 size="icon"
-                                className="z-10 absolute top-1/2 -right-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
+                                className="z-10 absolute top-3/4 -right-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
                                 title={filterPanelCollapsed ? "Expand filters" : "Collapse filters"}
                             >
                                 {filterPanelCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}

--- a/apps/client/src/pages/Dashboard.tsx
+++ b/apps/client/src/pages/Dashboard.tsx
@@ -506,7 +506,7 @@ const Dashboard = () => {
                             "border-r border-border transition-all duration-300 ease-in-out flex-shrink-0 relative",
                             filterPanelCollapsed ? "w-12" : "w-48"
                         )}>
-                            <div className="h-full flex flex-col">
+                            <div className="h-full flex flex-col px-4">
                                 <div className="flex items-center justify-between p-2 border-b border-border">
                                     {!filterPanelCollapsed && (
                                         <h3 className="text-sm font-semibold text-foreground">Filters</h3>
@@ -525,7 +525,7 @@ const Dashboard = () => {
                                 onClick={toggleFilterPanel}
                                 variant="ghost"
                                 size="icon"
-                                className="z-10 absolute top-3/4 -right-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
+                                className="z-10 absolute top-1/2 -right-4 -translate-y-1/2 border bg-background hover:bg-muted rounded-full h-8 w-8"
                                 title={filterPanelCollapsed ? "Expand filters" : "Collapse filters"}
                             >
                                 {filterPanelCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}


### PR DESCRIPTION
## Issue Reference

CLoses #284

---

## What Was Changed

Change the position of the toggle sidebar buttons to be down the page

---

## Why Was It Changed

The buttons were overlapping the filter panel.

---

## Screenshots (Optional)

![Screenshot from 2025-10-03 13-57-23](https://github.com/user-attachments/assets/149a6d72-3c91-4d49-826c-27639e41eefc)

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->
