### PR TITLE
[FEAT]: Add audit logging for dashboard view creation (Closes #324)

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -132,6 +132,7 @@ export enum AuditResourceType {
     PROVIDER = 'PROVIDER',
     SERVICE = 'SERVICE',
     USER = 'USER',
+    VIEW = 'VIEW',
     // Add more as needed
 }
 


### PR DESCRIPTION
## Issue Reference

<!-- Link to the related issue or ticket, e.g. Closes #123 -->
Closes #297
---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->
- Extended audit logging to include dashboard view creation events.
- Logged the user, timestamp, and basic view details (e.g., view name, applied filters).
- Updated relevant services to maintain consistent audit trail across providers, services, integrations, and dashboard views.

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->
- Currently, dashboard view creation is not captured in audit logs, creating gaps in traceability.
This change ensures complete logging for compliance, transparency, and troubleshooting.

---

## Video

https://github.com/user-attachments/assets/5a2c49ef-14b4-4012-bd17-7ea171df11a6

