### PR TITLE
Fix Cancel buttons border in dark mode

### DIFF
--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -387,7 +387,7 @@ const ServerForm = ({onSubmit, onClose}: ProviderFormProps<ServerFormData>) => {
             </div>
             {/* End Test Connection */}
             <div className="flex justify-end gap-2 pt-4">
-                <Button type="button" variant="ghost" onClick={onClose} disabled={isSubmitting}>Cancel</Button>
+                <Button type="button" variant="ghost" onClick={onClose} disabled={isSubmitting} className="shadow-sm active:scale-95 dark:border dark:border-white">Cancel</Button>
                 <Button type="submit" disabled={isSubmitting}>
                     {isSubmitting ? (
                         <>
@@ -431,7 +431,7 @@ const KubernetesForm = ({onSubmit, onClose}: ProviderFormProps<KubernetesFormDat
             </FieldWrapper>
             
             <div className="flex justify-end gap-2 pt-4">
-                <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>
+                <Button type="button" variant="ghost" onClick={onClose} className="shadow-sm active:scale-95 dark:border dark:border-white">Cancel</Button>
                 <Button type="submit">Add Provider</Button>
             </div>
         </form>
@@ -483,7 +483,7 @@ const AWSForm = ({onSubmit, onClose}: ProviderFormProps<AWSFormData>) => {
             </FieldWrapper>
 
             <div className="flex justify-end gap-2 pt-4">
-                <Button type="button" variant="ghost" onClick={onClose}>Cancel</Button>
+                <Button type="button" variant="ghost" onClick={onClose} className="shadow-sm active:scale-95 dark:border dark:border-white">Cancel</Button>
                 <Button type="submit">Add Provider</Button>
             </div>
         </form>


### PR DESCRIPTION
## Issue Reference

https://github.com/OpsiMate/OpsiMate/issues/347

---

## What Was Changed

Cancel buttons in Dark mode got a clear border

---

## Why Was It Changed

The Cancel buttons were hard to see in dark mode.
---

## Screenshots

![Screenshot 2025-10-08 000253](https://github.com/user-attachments/assets/e4ca5229-d87b-4b31-ab92-9e38faaed9a9)

---

## Additional Context (Optional)

Cancel buttons are under 'Add Provider' section.