### PR TITLE
[FIX]: the node needs 0.0.0.0 as a binding address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,8 @@ services:
       - ./config.yml:/app/config/config.yml
     environment:
       - NODE_ENV=production
+      - HOST=0.0.0.0
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001/health || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
 
   frontend:
     image: opsimate/frontend:latest
@@ -28,13 +23,5 @@ services:
     environment:
       - NODE_ENV=production
       - API_URL=http://backend:3001   
-    depends_on:
-      backend:
-        condition: service_healthy
+      - HOST=0.0.0.0
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080 || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s


### PR DESCRIPTION
### What we did
We recently migrated to a micro-service based docker image and we are forgot to change the docker-compose file in respect to that as we forgot to add 0.0.0.0 as a binding address.

environment:
      - NODE_ENV=production
      - HOST=0.0.0.0

<img width="1222" height="240" alt="Screenshot 2025-10-12 at 9 20 43 AM" src="https://github.com/user-attachments/assets/3dbfda99-2772-44d6-95d3-efed7a6f77b4" />

---

### Learning and explanation based on facts:
**Why HOST=0.0.0.0 is Required?**
Default Binding Behavior: Most modern frameworks bind to 127.0.0.1 by default for security.

Inside Docker: In Docker, binding to 127.0.0.1 exposes services only to other processes in the same container, not to the Docker host or your browser.

Binding to All Interfaces: Setting HOST=0.0.0.0 makes the service listen on all network interfaces—internal (container) and external (host), thus making the service accessible from your machine using the published port mapping.

---
### Expected behaviour

When we run this this will set up the docker containers (fetch image from dockerhub) automatically as you can see above in the posted image and will start the services for customers/people who are using opsimate.

`https://raw.githubusercontent.com/OpsiMate/OpsiMate/main/docker-compose.yml`
---

### future implementation/ not compulsion / non-blocker / just an extra utility won't cause any real time issue
Also backend health check is present but no api for frontend health check as we recently separated them so this will be done in further PRs.
Not a necessity but it's not a DevOps task, it's a task in frontend to add a api for that. ((http://localhost:8080/health))
 

