### PR TITLE
[FEAT]: API test for get providers endpoint

### DIFF
--- a/apps/server/tests/providers.test.ts
+++ b/apps/server/tests/providers.test.ts
@@ -8,7 +8,8 @@ import {
   AuditLog,
   Provider,
   Role,
-  Service
+  Service,
+  ProviderType
 } from '@OpsiMate/shared';
 
 const logger = new Logger('test-provider-service');
@@ -97,377 +98,378 @@ beforeAll(async () => {
   jwtToken = loginRes.body.token;
 });
 
-  describe('GET /api/v1/providers', () => {
-    let adminToken: string;
-    let editorToken: string;
-    let viewerToken: string;
+describe('GET /api/v1/providers', () => {
+  let adminToken: string;
+  let editorToken: string;
+  let viewerToken: string;
 
-    beforeEach(async () => {
-      await app.post('/api/v1/users/register').send({
-        email: 'admin@example.com',
-        fullName: 'Admin User',
-        password: 'securepassword'
-      });
-      const adminLoginRes = await app.post('/api/v1/users/login').send({
-        email: 'admin@example.com',
-        password: 'securepassword'
-      });
-      adminToken = adminLoginRes.body.token;
-
-      await app.post('/api/v1/users').set('Authorization', `Bearer ${adminToken}`).send({
-        email: 'editor@example.com',
-        fullName: 'Editor User',
-        password: 'securepassword',
-        role: Role.Editor
-      });
-      const editorLoginRes = await app.post('/api/v1/users/login').send({
-        email: 'editor@example.com',
-        password: 'securepassword'
-      });
-      editorToken = editorLoginRes.body.token;
-
-      await app.post('/api/v1/users').set('Authorization', `Bearer ${adminToken}`).send({
-        email: 'viewer@example.com',
-        fullName: 'Viewer User',
-        password: 'securepassword',
-        role: Role.Viewer
-      });
-      const viewerLoginRes = await app.post('/api/v1/users/login').send({
-        email: 'viewer@example.com',
-        password: 'securepassword'
-      });
-      viewerToken = viewerLoginRes.body.token;
+  beforeEach(async () => {
+    await app.post('/api/v1/users/register').send({
+      email: 'admin@example.com',
+      fullName: 'Admin User',
+      password: 'securepassword'
     });
-
-    describe('Successfully retrieve providers', () => {
-      // Test basic provider listing functionality
-      test('should return 200 OK with provider list for valid requests', async () => {
-        await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
-          name: 'Test Provider 1',
-          providerIP: '192.168.1.100',
-          username: 'testuser1',
-          password: 'testpass1',
-          SSHPort: 22,
-          providerType: ProviderType.VM
-        });
-
-        await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
-          name: 'Test Provider 2',
-          providerIP: '192.168.1.101',
-          username: 'testuser2',
-          password: 'testpass2',
-          SSHPort: 22,
-          providerType: ProviderType.K8S
-        });
-
-        const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
-
-        expect(res.status).toBe(200);
-        expect(res.body.success).toBe(true);
-        expect(res.body.data).toHaveProperty('providers');
-        expect(Array.isArray(res.body.data.providers)).toBe(true);
-        expect(res.body.data.providers).toHaveLength(2);
-      });
+    const adminLoginRes = await app.post('/api/v1/users/login').send({
+      email: 'admin@example.com',
+      password: 'securepassword'
     });
+    adminToken = adminLoginRes.body.token;
 
-    describe('Authentication and authorization failures', () => {
-      // Test unauthenticated request rejection
-      test('should return 401 for missing authorization header', async () => {
-        const res = await app.get('/api/v1/providers');
-
-        expect(res.status).toBe(401);
-        expect(res.body.success).toBe(false);
-        expect(res.body.error).toBe('Missing or invalid Authorization header');
-      });
-
-      // Test invalid token rejection
-      test('should return 401 for invalid JWT token', async () => {
-        const res = await app.get('/api/v1/providers').set('Authorization', 'Bearer invalid.jwt.token');
-
-        expect(res.status).toBe(401);
-        expect(res.body.success).toBe(false);
-        expect(res.body.error).toBe('Invalid or expired token');
-      });
+    await app.post('/api/v1/users').set('Authorization', `Bearer ${adminToken}`).send({
+      email: 'editor@example.com',
+      fullName: 'Editor User',
+      password: 'securepassword',
+      role: Role.Editor
     });
-
-    describe('Permissions for provider access', () => {
-      // Test admin role access
-      test('should allow admin users to access providers', async () => {
-        const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
-        
-        expect(res.status).toBe(200);
-        expect(res.body.success).toBe(true);
-        expect(res.body.data).toHaveProperty('providers');
-      });
-
-      // Test editor role access
-      test('should allow editor users to access providers', async () => {
-        const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${editorToken}`);
-        
-        expect(res.status).toBe(200);
-        expect(res.body.success).toBe(true);
-        expect(res.body.data).toHaveProperty('providers');
-      });
-
-      // Test viewer role access
-      test('should allow viewer users to access providers', async () => {
-        const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${viewerToken}`);
-        
-        expect(res.status).toBe(200);
-        expect(res.body.success).toBe(true);
-        expect(res.body.data).toHaveProperty('providers');
-      });
+    const editorLoginRes = await app.post('/api/v1/users/login').send({
+      email: 'editor@example.com',
+      password: 'securepassword'
     });
+    editorToken = editorLoginRes.body.token;
 
-    describe('Response structure validation', () => {
-      // Test response format and required fields
-      test('should return consistent response structure with provider metadata', async () => {
-        await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
-          name: 'Test Provider',
-          providerIP: '192.168.1.200',
-          username: 'testuser',
-          password: 'testpassword',
-          SSHPort: 22,
-          providerType: ProviderType.VM
-        });
+    await app.post('/api/v1/users').set('Authorization', `Bearer ${adminToken}`).send({
+      email: 'viewer@example.com',
+      fullName: 'Viewer User',
+      password: 'securepassword',
+      role: Role.Viewer
+    });
+    const viewerLoginRes = await app.post('/api/v1/users/login').send({
+      email: 'viewer@example.com',
+      password: 'securepassword'
+    });
+    viewerToken = viewerLoginRes.body.token;
+  });
 
-        const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
-
-        expect(res.status).toBe(200);
-        expect(res.body).toMatchObject({
-          success: true,
-          data: {
-            providers: expect.any(Array)
-          }
-        });
-
-        if (res.body.data.providers.length > 0) {
-          const provider = res.body.data.providers[0];
-          expect(provider).toHaveProperty('id');
-          expect(provider).toHaveProperty('name');
-          expect(provider).toHaveProperty('providerIP');
-          expect(provider).toHaveProperty('providerType');
-          expect(provider).toHaveProperty('createdAt');
-        }
+  describe('Successfully retrieve providers', () => {
+    // Test basic provider listing functionality
+    test('should return 200 OK with provider list for valid requests', async () => {
+      await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
+        name: 'Test Provider 1',
+        providerIP: '192.168.1.100',
+        username: 'testuser1',
+        password: 'testpass1',
+        SSHPort: 22,
+        providerType: ProviderType.VM
       });
 
-      // Test password field exclusion from response
-      test('should filter out sensitive data from response', async () => {
-        await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
-          name: 'Secure Provider',
-          providerIP: '192.168.1.150',
-          username: 'secureuser',
-          password: 'topsecretpassword',
-          SSHPort: 22,
-          providerType: ProviderType.VM
-        });
-
-        const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
-        
-        expect(res.status).toBe(200);
-        const provider = res.body.data.providers[0];
-        
-        expect(provider).not.toHaveProperty('password');
-        expect(provider).toHaveProperty('name');
-        expect(provider).toHaveProperty('providerIP');
-        expect(provider).toHaveProperty('username');
+      await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
+        name: 'Test Provider 2',
+        providerIP: '192.168.1.101',
+        username: 'testuser2',
+        password: 'testpass2',
+        SSHPort: 22,
+        providerType: ProviderType.K8S
       });
+
+      const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('providers');
+      expect(Array.isArray(res.body.data.providers)).toBe(true);
+      expect(res.body.data.providers).toHaveLength(2);
     });
   });
 
-  describe('GET /api/v1/providers/:providerId/discover-services', () => {
-    let adminToken: string;
-    let editorToken: string;
-    let viewerToken: string;
-    let providerId: number;
-
-    beforeEach(async () => {
-      // Register admin
-      await app.post("/api/v1/users/register").send({
-        email: "admin@example.com",
-        fullName: "Admin User",
-        password: "securepassword",
-      });
-      const loginRes = await app.post("/api/v1/users/login").send({
-        email: "admin@example.com",
-        password: "securepassword",
-      });
-      adminToken = loginRes.body.token;
-
-      // Create a provider
-      const providerRes = await app.post("/api/v1/providers").set("Authorization", `Bearer ${adminToken}`).send({
-        name: "Test Provider",
-        providerIP: "192.168.1.100",
-        username: "testuser",
-        password: "testpass",
-        SSHPort: 22,
-        providerType: ProviderType.VM,
-      });
-      providerId = providerRes.body.data.id;
-    });
-
-    test("should successfully discover services from valid provider", async () => {
-      // Note: This test assumes the provider connection works or is mocked
-      // In a real scenario, this would attempt to connect to the provider
-      const res = await app.get(`/api/v1/providers/${providerId}/discover-services`).set("Authorization", `Bearer ${adminToken}`);
-
-      // The response depends on whether the connection succeeds
-      // If connection fails, it might return 500, but the API structure should be correct
-      expect([200, 500]).toContain(res.status);
-
-      if (res.status === 200) {
-        expect(res.body.success).toBe(true);
-        expect(Array.isArray(res.body.data)).toBe(true);
-        // If services are discovered, check structure
-        if (res.body.data.length > 0) {
-          expect(res.body.data[0]).toMatchObject({
-            name: expect.any(String),
-            serviceStatus: expect.any(String),
-            serviceIP: expect.any(String),
-            namespace: expect.any(String), // optional
-          });
-        }
-      } else {
-        expect(res.body.success).toBe(false);
-        expect(res.body.error).toBe("Internal server error");
-      }
-    });
-
-    test("should return error for non-existent provider", async () => {
-      const nonExistentId = 9999;
-      const res = await app
-        .get(`/api/v1/providers/${nonExistentId}/discover-services`)
-        .set("Authorization", `Bearer ${adminToken}`);
-
-      // Should return 500 as the BL throws an error when provider not found
-      expect(res.status).toBe(500);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toBe("Internal server error");
-    });
-
-    test("should return 400 for invalid provider ID", async () => {
-      const res = await app.get("/api/v1/providers/invalid/discover-services").set("Authorization", `Bearer ${adminToken}`);
-
-      expect(res.status).toBe(400);
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toBe("Invalid provider ID");
-    });
-
-  test('should allow viewer users to discover services', async () => {
-      // Create a viewer user
-      await app.post("/api/v1/users").set("Authorization", `Bearer ${adminToken}`).send({
-        email: "viewer@example.com",
-        fullName: "Viewer User",
-        password: "securepassword",
-        role: Role.Viewer,
-      });
-      const viewerLogin = await app.post("/api/v1/users/login").send({
-        email: "viewer@example.com",
-        password: "securepassword",
-      });
-      const viewerToken = viewerLogin.body.token;
-
-      // Attempt to discover services as viewer
-      const res = await app
-        .get(`/api/v1/providers/${providerId}/discover-services`)
-        .set("Authorization", `Bearer ${viewerToken}`);
-
-      // Viewer should be allowed to discover services (same as other roles)
-      expect([200, 500]).toContain(res.status);
-      expect(res.body).toHaveProperty('success');
-    });
-
-    test("should reject access for unauthenticated request", async () => {
-      const res = await app.get(`/api/v1/providers/${providerId}/discover-services`);
+  describe('Authentication and authorization failures', () => {
+    // Test unauthenticated request rejection
+    test('should return 401 for missing authorization header', async () => {
+      const res = await app.get('/api/v1/providers');
 
       expect(res.status).toBe(401);
       expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Missing or invalid Authorization header');
     });
 
-afterAll(() => {
-  db.close();
-});
+    // Test invalid token rejection
+    test('should return 401 for invalid JWT token', async () => {
+      const res = await app.get('/api/v1/providers').set('Authorization', 'Bearer invalid.jwt.token');
 
-describe('PUT /api/v1/providers/:providerId', () => {
-
-  test('✅ Updates provider successfully and updates DB', async () => {
-    const updateData = {
-      name: 'Updated Provider',
-      providerIP: '192.168.1.1',
-      username: 'admin',
-      publicKey: 'updated.pem',
-      sshPort: 2222
-    };
-
-    const res = await app
-      .put('/api/v1/providers/1')
-      .set('Authorization', `Bearer ${jwtToken}`)
-      .send(updateData);
-
-    expect(res.status).toBe(200);
-    expect(res.body.success).toBe(true);
-    expect(res.body.data.provider_name).toBe('Updated Provider');
-
-    // Confirm DB updated
-    const dbProvider = db.prepare('SELECT * FROM providers WHERE id = 1').get() as any;
-    expect(dbProvider.provider_name).toBe('Updated Provider');
-    expect(dbProvider.username).toBe('admin');
+      expect(res.status).toBe(401);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Invalid or expired token');
+    });
   });
 
-  test('✅ Returns 400 for invalid data (successfully handled)', async () => {
+  describe('Permissions for provider access', () => {
+    // Test admin role access
+    test('should allow admin users to access providers', async () => {
+      const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('providers');
+    });
+
+    // Test editor role access
+    test('should allow editor users to access providers', async () => {
+      const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${editorToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('providers');
+    });
+
+    // Test viewer role access
+    test('should allow viewer users to access providers', async () => {
+      const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${viewerToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('providers');
+    });
+  });
+
+  describe('Response structure validation', () => {
+    // Test response format and required fields
+    test('should return consistent response structure with provider metadata', async () => {
+      await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
+        name: 'Test Provider',
+        providerIP: '192.168.1.200',
+        username: 'testuser',
+        password: 'testpassword',
+        SSHPort: 22,
+        providerType: ProviderType.VM
+      });
+
+      const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        data: {
+          providers: expect.any(Array)
+        }
+      });
+
+      if (res.body.data.providers.length > 0) {
+        const provider = res.body.data.providers[0];
+        expect(provider).toHaveProperty('id');
+        expect(provider).toHaveProperty('name');
+        expect(provider).toHaveProperty('providerIP');
+        expect(provider).toHaveProperty('providerType');
+        expect(provider).toHaveProperty('createdAt');
+      }
+    });
+
+    // Test password field exclusion from response
+    test('should filter out sensitive data from response', async () => {
+      await app.post('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`).send({
+        name: 'Secure Provider',
+        providerIP: '192.168.1.150',
+        username: 'secureuser',
+        password: 'topsecretpassword',
+        SSHPort: 22,
+        providerType: ProviderType.VM
+      });
+
+      const res = await app.get('/api/v1/providers').set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      const provider = res.body.data.providers[0];
+
+      expect(provider).not.toHaveProperty('password');
+      expect(provider).toHaveProperty('name');
+      expect(provider).toHaveProperty('providerIP');
+      expect(provider).toHaveProperty('username');
+    });
+  });
+});
+
+describe('GET /api/v1/providers/:providerId/discover-services', () => {
+  let adminToken: string;
+  let editorToken: string;
+  let viewerToken: string;
+  let providerId: number;
+
+  beforeEach(async () => {
+    // Register admin
+    await app.post("/api/v1/users/register").send({
+      email: "admin@example.com",
+      fullName: "Admin User",
+      password: "securepassword",
+    });
+    const loginRes = await app.post("/api/v1/users/login").send({
+      email: "admin@example.com",
+      password: "securepassword",
+    });
+    adminToken = loginRes.body.token;
+
+    // Create a provider
+    const providerRes = await app.post("/api/v1/providers").set("Authorization", `Bearer ${adminToken}`).send({
+      name: "Test Provider",
+      providerIP: "192.168.1.100",
+      username: "testuser",
+      password: "testpass",
+      SSHPort: 22,
+      providerType: ProviderType.VM,
+    });
+    providerId = providerRes.body.data.id;
+  });
+
+  test("should successfully discover services from valid provider", async () => {
+    // Note: This test assumes the provider connection works or is mocked
+    // In a real scenario, this would attempt to connect to the provider
+    const res = await app.get(`/api/v1/providers/${providerId}/discover-services`).set("Authorization", `Bearer ${adminToken}`);
+
+    // The response depends on whether the connection succeeds
+    // If connection fails, it might return 500, but the API structure should be correct
+    expect([200, 500]).toContain(res.status);
+
+    if (res.status === 200) {
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      // If services are discovered, check structure
+      if (res.body.data.length > 0) {
+        expect(res.body.data[0]).toMatchObject({
+          name: expect.any(String),
+          serviceStatus: expect.any(String),
+          serviceIP: expect.any(String),
+          namespace: expect.any(String), // optional
+        });
+      }
+    } else {
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe("Internal server error");
+    }
+  });
+
+  test("should return error for non-existent provider", async () => {
+    const nonExistentId = 9999;
     const res = await app
-      .put('/api/v1/providers/1')
-      .set('Authorization', `Bearer ${jwtToken}`)
-      .send({ providerIP: '10.0.0.5' }); // missing required fields
+      .get(`/api/v1/providers/${nonExistentId}/discover-services`)
+      .set("Authorization", `Bearer ${adminToken}`);
+
+    // Should return 500 as the BL throws an error when provider not found
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe("Internal server error");
+  });
+
+  test("should return 400 for invalid provider ID", async () => {
+    const res = await app.get("/api/v1/providers/invalid/discover-services").set("Authorization", `Bearer ${adminToken}`);
 
     expect(res.status).toBe(400);
     expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe("Invalid provider ID");
   });
 
-  test('✅ Returns 404 if provider does not exist (successfully handled)', async () => {
-    const res = await app
-      .put('/api/v1/providers/999')
-      .set('Authorization', `Bearer ${jwtToken}`)
-      .send({
-        name: 'Ghost Provider',
-        providerIP: '10.0.0.99',
-        username: 'ghost',
-        publicKey: 'ghost.pem'
-      });
+  test('should allow viewer users to discover services', async () => {
+    // Create a viewer user
+    await app.post("/api/v1/users").set("Authorization", `Bearer ${adminToken}`).send({
+      email: "viewer@example.com",
+      fullName: "Viewer User",
+      password: "securepassword",
+      role: Role.Viewer,
+    });
+    const viewerLogin = await app.post("/api/v1/users/login").send({
+      email: "viewer@example.com",
+      password: "securepassword",
+    });
+    const viewerToken = viewerLogin.body.token;
 
-    expect(res.status).toBe(404);
+    // Attempt to discover services as viewer
+    const res = await app
+      .get(`/api/v1/providers/${providerId}/discover-services`)
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    // Viewer should be allowed to discover services (same as other roles)
+    expect([200, 500]).toContain(res.status);
+    expect(res.body).toHaveProperty('success');
+  });
+
+  test("should reject access for unauthenticated request", async () => {
+    const res = await app.get(`/api/v1/providers/${providerId}/discover-services`);
+
+    expect(res.status).toBe(401);
     expect(res.body.success).toBe(false);
   });
 
-  test('✅ Returns 401 if unauthorized (successfully blocked)', async () => {
-    const res = await app.put('/api/v1/providers/1').send({
-      name: 'Unauthorized Update',
-      providerIP: '10.0.0.50',
-      username: 'noAuth',
-      publicKey: 'none.pem'
+  afterAll(() => {
+    db.close();
+  });
+
+  describe('PUT /api/v1/providers/:providerId', () => {
+
+    test('✅ Updates provider successfully and updates DB', async () => {
+      const updateData = {
+        name: 'Updated Provider',
+        providerIP: '192.168.1.1',
+        username: 'admin',
+        publicKey: 'updated.pem',
+        sshPort: 2222
+      };
+
+      const res = await app
+        .put('/api/v1/providers/1')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send(updateData);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.provider_name).toBe('Updated Provider');
+
+      // Confirm DB updated
+      const dbProvider = db.prepare('SELECT * FROM providers WHERE id = 1').get() as any;
+      expect(dbProvider.provider_name).toBe('Updated Provider');
+      expect(dbProvider.username).toBe('admin');
     });
 
-    expect(res.status).toBe(401);
-  });
+    test('✅ Returns 400 for invalid data (successfully handled)', async () => {
+      const res = await app
+        .put('/api/v1/providers/1')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({ providerIP: '10.0.0.5' }); // missing required fields
 
-  test('✅ Creates audit log entry on update', async () => {
-    await app
-      .put('/api/v1/providers/1')
-      .set('Authorization', `Bearer ${jwtToken}`)
-      .send({
-        name: 'Audited Update',
-        providerIP: '10.1.1.1',
-        username: 'audit',
-        publicKey: 'audit.pem'
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    test('✅ Returns 404 if provider does not exist (successfully handled)', async () => {
+      const res = await app
+        .put('/api/v1/providers/999')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          name: 'Ghost Provider',
+          providerIP: '10.0.0.99',
+          username: 'ghost',
+          publicKey: 'ghost.pem'
+        });
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+
+    test('✅ Returns 401 if unauthorized (successfully blocked)', async () => {
+      const res = await app.put('/api/v1/providers/1').send({
+        name: 'Unauthorized Update',
+        providerIP: '10.0.0.50',
+        username: 'noAuth',
+        publicKey: 'none.pem'
       });
 
-    const logs = db.prepare('SELECT * FROM audit_logs').all();
-    expect(logs.length).toBeGreaterThan(0);
+      expect(res.status).toBe(401);
+    });
 
-    const log: AuditLog = logs[0] as AuditLog;
-    expect(log.actionType).toBe(AuditActionType.UPDATE);
-    expect(log.resourceType).toBe(AuditResourceType.PROVIDER);
-    expect(log.resourceId).toBe('1');
+    test('✅ Creates audit log entry on update', async () => {
+      await app
+        .put('/api/v1/providers/1')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          name: 'Audited Update',
+          providerIP: '10.1.1.1',
+          username: 'audit',
+          publicKey: 'audit.pem'
+        });
+
+      const logs = db.prepare('SELECT * FROM audit_logs').all();
+      expect(logs.length).toBeGreaterThan(0);
+
+      const log: AuditLog = logs[0] as AuditLog;
+      expect(log.actionType).toBe(AuditActionType.UPDATE);
+      expect(log.resourceType).toBe(AuditResourceType.PROVIDER);
+      expect(log.resourceId).toBe('1');
+    });
+
   });
-
 });


### PR DESCRIPTION
- Fixed and Existing TestCase as well

## Issue Reference

Closes #369 
---

## What Was Changed

- Added test cases** for `GET /api/v1/providers` endpoint
- Test basic `provider` listing funcitionality
- Authentication Test
- Test for Independent role access 
- Test Response Format 

---

Also ,

### **Bug Fix** - There was a exitisting Test Case in `apps\server\tests\providers.test.ts` that was failing 
- **Fixed existing test case** that incorrectly expected `403` for viewer users accessing discover-services
- **Corrected expectation** to `200/500` based on actual API behavior (viewers can access GET endpoints)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for provider endpoints: multi-role authentication and authorization checks (admin/editor/viewer), unauthenticated/invalid token cases.
  * Verified provider list and detail responses for correct shape and omission of sensitive fields (e.g., passwords).
  * Added service discovery workflow tests, update/describe scenarios, error/not-found paths, and audit-log verification on updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->