### PR TITLE
[FEAT]: Add pagination feature to Dashboard for services table

### DIFF
--- a/apps/client/src/components/Dashboard/Dashboard.tsx
+++ b/apps/client/src/components/Dashboard/Dashboard.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getAlertServiceId } from "@/utils/alert.utils";
+import DashboardPagination from "@/components/DashboardPagination"
 
 export const Dashboard = () => {
     const navigate = useNavigate()
@@ -87,6 +88,8 @@ export const Dashboard = () => {
     const [filterPanelCollapsed, setFilterPanelCollapsed] = useState(false)
     const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState(false)
     const [columnOrder, setColumnOrder] = useState<string[]>(['name', 'serviceIP', 'serviceStatus', 'provider', 'containerDetails', 'tags', 'alerts'])
+    const [itemsPerPage, setItemsPerPage] = useState<number>(10)
+    const [currentPage, setCurrentPage] = useState<number>(1)
 
     // Enhanced alert calculation: each service gets alerts for ALL its tags
     const servicesWithAlerts = useMemo(() => {
@@ -208,6 +211,17 @@ export const Dashboard = () => {
             });
         });
     }, [servicesWithAlerts, filters]);
+
+
+    // Pagination calculations
+    const servicesCount = filteredServices.length
+    const totalPages = Math.ceil(servicesCount / itemsPerPage)
+    const currentPageServices = useMemo(() => {
+        const start = (currentPage - 1) * itemsPerPage
+        const end = start + itemsPerPage
+        return filteredServices.slice(start, end)
+    }, [filteredServices, currentPage, itemsPerPage])
+    
 
     const toggleFilterPanel = () => {
         setFilterPanelCollapsed(!filterPanelCollapsed)
@@ -519,7 +533,7 @@ export const Dashboard = () => {
                                     />
                                 </div>
                                 <ServiceTable
-                                    services={filteredServices}
+                                    services={currentPageServices}
                                     selectedServices={selectedServices}
                                     onServicesSelect={handleServicesSelect}
                                     onSettingsClick={() => setShowTableSettings(true)}
@@ -530,6 +544,13 @@ export const Dashboard = () => {
                                     columnOrder={columnOrder}
                                     onColumnOrderChange={setColumnOrder}
                                     customFields={customFields}
+                                />
+                                {/* Pagination Controls */}
+                                <DashboardPagination
+                                    setItemsPerPage={setItemsPerPage}
+                                    setCurrentPage={setCurrentPage}
+                                    totalPages={totalPages}
+                                    currentPage={currentPage}
                                 />
                             </div>
                             <div className="flex-shrink-0 p-2 border-t border-border">

--- a/apps/client/src/components/DashboardPagination.tsx
+++ b/apps/client/src/components/DashboardPagination.tsx
@@ -1,0 +1,144 @@
+import React from 'react'
+import { 
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination'
+import ItemsPerPageSelector from './ItemsPerPageSelector'
+
+type DashboardPaginationProps = {
+  setItemsPerPage: (itemsPerPage: number) => void;
+  setCurrentPage: (page: number) => void;
+  currentPage: number;
+  totalPages: number;
+}
+
+const DashboardPagination : React.FC<DashboardPaginationProps> = ({ setItemsPerPage, setCurrentPage, currentPage, totalPages }) => {
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const canGoPrev = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
+  // Render page numbers based on the rules:
+  // 1. If total pages is 3 or fewer, show all pages
+  // 2. Otherwise show: page 1, page 2 (only if current is 1-3), ellipsis, current page, ellipsis, last page
+  const renderPageNumbers = () => {
+    if (totalPages <= 3) {
+      // Show all pages if 3 or fewer
+      return Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+        <PaginationItem key={page}>
+          <PaginationLink
+            href='#'
+            isActive={page === currentPage}
+            onClick={(e) => {
+              e.preventDefault();
+              handlePageChange(page);
+            }}
+          >
+            {page}
+          </PaginationLink>
+        </PaginationItem>
+      ));
+    }
+
+    // For 4+ pages
+    const pages: (number | 'ellipsis-left' | 'ellipsis-right')[] = [];
+
+    // Always show page 1
+    pages.push(1);
+
+    // Show page 2 only if current page is 1, 2, or 3
+    if (currentPage <= 3) {
+      pages.push(2);
+    }
+
+    // Show left ellipsis if current page is more than 3
+    if (currentPage > 3) {
+      pages.push('ellipsis-left');
+    }
+
+    // Show current page if it's not 1, 2, or last page
+    if (currentPage > 2 && currentPage < totalPages) {
+      pages.push(currentPage);
+    }
+
+    // Show right ellipsis if current page is less than totalPages - 1
+    if (currentPage < totalPages - 1) {
+      pages.push('ellipsis-right');
+    }
+
+    // Always show last page
+    pages.push(totalPages);
+
+    return pages.map((page, index) => {
+      if (page === 'ellipsis-left' || page === 'ellipsis-right') {
+        return (
+          <PaginationItem key={`ellipsis-${index}`}>
+            <PaginationEllipsis />
+          </PaginationItem>
+        );
+      }
+
+      return (
+        <PaginationItem key={page}>
+          <PaginationLink
+            href='#'
+            isActive={page === currentPage}
+            onClick={(e) => {
+              e.preventDefault();
+              handlePageChange(page as number);
+            }}
+          >
+            {page}
+          </PaginationLink>
+        </PaginationItem>
+      );
+    });
+  };
+  
+  return (
+    <div className='flex justify-between items-center px-4 py-1'>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href='#'
+              onClick={(e) => {
+                e.preventDefault();
+                if (canGoPrev) handlePageChange(currentPage - 1);
+              }}
+              className={!canGoPrev ? 'pointer-events-none opacity-50' : ''}
+            />
+          </PaginationItem>
+          {renderPageNumbers()}
+          <PaginationItem>
+            <PaginationNext
+              href='#'
+              onClick={(e) => {
+                e.preventDefault();
+                if (canGoNext) handlePageChange(currentPage + 1);
+              }}
+              className={!canGoNext ? 'pointer-events-none opacity-50' : ''}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+      <div className='flex items-center gap-2'>
+        <span className='text-sm whitespace-nowrap'>Items per page:</span>
+        <ItemsPerPageSelector 
+          setItemsPerPage={setItemsPerPage}
+          setCurrentPage={setCurrentPage}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default DashboardPagination

--- a/apps/client/src/components/ItemsPerPageSelector.tsx
+++ b/apps/client/src/components/ItemsPerPageSelector.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+type ItemsPerPageSelectorProps = {
+  setItemsPerPage: (itemsPerPage: number) => void;
+  setCurrentPage: (page: number) => void;
+}
+
+const ItemsPerPageSelector : React.FC<ItemsPerPageSelectorProps> = ({ setItemsPerPage, setCurrentPage }) => {
+
+  const options = [10, 30, 50, 100] // Options for items per page
+
+  const handleSelectItemChange = (value: string) => {
+    const itemsPerPage = parseInt(value, 10)
+    setItemsPerPage(itemsPerPage)
+    setCurrentPage(1) // Reset to first page on items per page change
+  }
+
+  return (
+    <Select defaultValue="10" onValueChange={handleSelectItemChange}>
+      <SelectTrigger className="w-[80px] h-8">
+        <SelectValue placeholder="10" />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map(option => (
+          <SelectItem 
+            className='hover:cursor-pointer hover:bg-muted' 
+            key={option} 
+            value={option.toString()} 
+            >
+            {option}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export default ItemsPerPageSelector


### PR DESCRIPTION
## Issue Reference


- Closes [[Feature] Add pagination to Dashboard services table #340](https://github.com/OpsiMate/OpsiMate/issues/340)

---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->

- Made a component for pagination which handles the pagination logic for the services: `DashboardPagination.tsx`
- Made a component for handling the number of items to be viewed in a single page: `ItemsPerPageSelector.tsx`
- Added the number of pages calculation logic and services to display in the file `Dashboard.tsx`:


---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->
These changes makes scrolling through all the services a lot easier as per needed in issue #340 
---

## Screenshots

<!-- If UI changes or visual diffs were made, include screenshots here -->

<img width="1910" height="1025" alt="image" src="https://github.com/user-attachments/assets/7038d955-5675-4a2e-a701-ee58ec89f983" />
<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/eb6354e1-df02-47e8-84b1-76ee3de154c8" />
<img width="1917" height="1031" alt="image" src="https://github.com/user-attachments/assets/819cc979-f0c6-48f8-a87e-ac07cf0190f1" />


---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->
Currently all the `Items to be displayed per page` is hard coded in the file `ItemsPerPageSelector.tsx`. Do tell me if there's any kind of specific requirement for it.
