### PR TITLE
[FIX] Add integration button should be in active state (#465)

### DIFF
--- a/apps/client/src/pages/Integrations.tsx
+++ b/apps/client/src/pages/Integrations.tsx
@@ -381,15 +381,17 @@ export default function Integrations() {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredIntegrations.map(integration => (
+          {filteredIntegrations.map(integration => {
+            const hasConfiguredInstances = configuredInstances[integration.id] > 0;
+            return (
             <Card
               key={integration.id}
               className={cn(
                 "transition-all duration-200 overflow-hidden",
-                hoveredCard === integration.id && configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                hoveredCard === integration.id && hasConfiguredInstances
                   ? "border-primary shadow-md"
                   : "",
-                configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                hasConfiguredInstances
                   ? "border-muted/60 hover:shadow-md"
                   : "border-muted/20 bg-gray-100 dark:bg-gray-800/40"
               )}
@@ -404,7 +406,7 @@ export default function Integrations() {
               }
               <CardHeader className={cn(
                 "pb-2",
-                configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                hasConfiguredInstances
                   ? ""
                   : "opacity-75"
               )}>
@@ -412,7 +414,7 @@ export default function Integrations() {
                   <div className="flex items-center gap-3">
                     <div className={cn(
                       "h-10 w-10 rounded-md overflow-hidden border flex items-center justify-center",
-                      configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                      hasConfiguredInstances
                         ? "bg-background"
                         : "bg-gray-200 dark:bg-gray-700"
                     )}>
@@ -421,7 +423,7 @@ export default function Integrations() {
                         alt={`${integration.name} logo`}
                         className={cn(
                           "h-8 w-8 object-contain",
-                          configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                          hasConfiguredInstances
                             ? ""
                             : "opacity-50 grayscale"
                         )}
@@ -441,7 +443,7 @@ export default function Integrations() {
               </CardHeader>
               <CardContent className={cn(
                 "pb-2",
-                configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                hasConfiguredInstances
                   ? ""
                   : "opacity-75"
               )}>
@@ -456,10 +458,10 @@ export default function Integrations() {
                       variant="outline"
                       className={cn(
                         "text-xs px-2 py-0.5 flex items-center",
-                        configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                        hasConfiguredInstances
                           ? TAG_COLORS[tag]?.bg || "bg-gray-100 dark:bg-gray-800"
                           : "bg-gray-200 dark:bg-gray-700",
-                        configuredInstances[integration.id] && configuredInstances[integration.id] > 0
+                        hasConfiguredInstances
                           ? TAG_COLORS[tag]?.text || "text-gray-700 dark:text-gray-300"
                           : "text-gray-500 dark:text-gray-400"
                       )}
@@ -474,10 +476,10 @@ export default function Integrations() {
               <CardFooter className="pt-2 flex gap-2">
                 <Button
                     disabled={!integration.supported}
-                  variant={configuredInstances[integration.id] && configuredInstances[integration.id] > 0 ? "default" : "secondary"}
+
                   className={cn(
                     "w-full transition-all",
-                    hoveredCard === integration.id && configuredInstances[integration.id] && configuredInstances[integration.id] > 0 ? "ring-2 ring-primary-foreground/20" : "",
+                    hoveredCard === integration.id && hasConfiguredInstances ? "ring-2 ring-primary-foreground/20" : "",
                     !integration.supported ? "border-dashed bg-gray-200 text-gray-600 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600" : "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 active:scale-95"
                   )}
                   onClick={() => {
@@ -509,15 +511,15 @@ export default function Integrations() {
 
                     setSelectedIntegration(integration);
                   }}
-                  title={configuredInstances[integration.id] && configuredInstances[integration.id] > 0 ?
+                  title={hasConfiguredInstances ?
                     `Configure ${integration.name} integration` :
                     `Add ${integration.name} integration`}
                 >
                   <Settings className="mr-2 h-4 w-4" />
-                  {configuredInstances[integration.id] && configuredInstances[integration.id] > 0 ? "Configure" : "Add Integration"}
+                  {hasConfiguredInstances ? "Configure" : "Add Integration"}
                 </Button>
               </CardFooter>
-              {configuredInstances[integration.id] && configuredInstances[integration.id] > 0 ? (
+              {hasConfiguredInstances ? (
                 <div className="px-6 pb-3 flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
                   <Server className="h-3 w-3" />
                   <span>{configuredInstances[integration.id]} {configuredInstances[integration.id] === 1 ? 'instance' : 'instances'} configured</span>
@@ -528,8 +530,8 @@ export default function Integrations() {
                   <span>Not configured</span>
                 </div>
               )}
-            </Card>
-          ))}
+            </Card>);
+})}
 
           {filteredIntegrations.length === 0 && (
             <div className="col-span-full flex flex-col items-center justify-center p-8 text-center">


### PR DESCRIPTION
## Issue Reference
See (#465 )

---

## What Was Changed
Fixed the "Add Integration" button styling to display primary background color instead of gray when the integration is supported but not yet configured


---

## Why Was It Changed
The "Add Integration" button was incorrectly showing gray styling for supported integrations with no configured instances, making it appear disabled when it was actually functional. This created a confusing user experience where users couldn't visually distinguish between:


---

## Screenshots

**After:**
<img width="1919" height="966" alt="Screenshot 2025-10-17 173254" src="https://github.com/user-attachments/assets/d9cead2b-37f7-40ea-a03e-8d80b8f66133" />


---

## Additional Context (Optional)
The simplified logic uses `!integration.supported` as the single source of truth for both the `disabled` prop and gray styling, preventing edge cases where stale data could cause visual inconsistencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated repeated configuration state checks into a unified flag, improving code clarity and consistency across the integrations interface.

* **Style**
  * Enhanced card hover effects and visual indicators with improved styling based on integration configuration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->