### PR TITLE
[FIX]: Update sync-version.yml for PAT and author format

### DIFF
--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ secrets.ADMIN_PAT }}  
 
       - name: Get released version
         id: get_version
@@ -41,6 +42,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: "chore: sync version to ${{ env.NEXT_VERSION }} on release"
-          author_name: github-actions[bot]
-          author_email: github-actions[bot]@users.noreply.github.com
           branch: main
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}  # Important: replace default token with PAT


### PR DESCRIPTION
Updated the GitHub Actions workflow to use a personal access token for authentication and modified the commit author format.

The current version uses github action but this is not the right way to do it since we have a **protected branch** which does not allow direct commit to main so instead of github bot we will use admin PAT. 

 But to make this work @idanlodzki we need to create a new admin PAT and store it in repository secrets ADMIN_PAT.

I have tried this version with a protected branch on opsimate fork:

https://github.com/KaranNegi20Feb/Karan-Fork-Opsimate/actions/runs/18624918894/job/53101658747

and file to it is similar to the proposed change:

https://github.com/KaranNegi20Feb/Karan-Fork-Opsimate/actions/runs/18624918894/workflow

Do let me know when you are free to create a PAT and also test it out.


The change applies on this file

https://github.com/KaranNegi20Feb/Karan-Fork-Opsimate/blob/main/package.json

changes the version number after release published.
