### PR TITLE
[FIX]: Added UNIQUE constraint to database and error handling to the server for duplicate providers

### DIFF
--- a/apps/server/src/api/v1/providers/controller.ts
+++ b/apps/server/src/api/v1/providers/controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@OpsiMate/shared';
 import { providerConnectorFactory } from '../../../bl/providers/provider-connector/providerConnectorFactory';
 import { ProviderNotFound } from '../../../bl/providers/ProviderNotFound';
+import { DuplicateProviderError } from '../../../bl/providers/DuplicateProviderError';
 import { ProviderBL } from '../../../bl/providers/provider.bl';
 import { AuthenticatedRequest } from '../../../middleware/auth';
 import { SecretsMetadataRepository } from '../../../dal/secretsMetadataRepository';
@@ -79,6 +80,11 @@ export class ProviderController {
 		} catch (error) {
 			if (isZodError(error)) {
 				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			} else if (error instanceof DuplicateProviderError) {
+				return res.status(409).json({ 
+					success: false, 
+					error: error.message 
+				});
 			} else {
 				logger.error('Error creating provider:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -159,6 +165,11 @@ export class ProviderController {
 		} catch (error) {
 			if (isZodError(error)) {
 				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			} else if (error instanceof DuplicateProviderError) {
+				return res.status(409).json({ 
+					success: false, 
+					error: error.message 
+				});
 			} else if (error instanceof ProviderNotFound) {
 				return res.status(404).json({ success: false, error: `Provider ${error.provider} not found` });
 			} else {

--- a/apps/server/src/bl/providers/DuplicateProviderError.ts
+++ b/apps/server/src/bl/providers/DuplicateProviderError.ts
@@ -1,0 +1,11 @@
+class DuplicateProviderError extends Error {
+	constructor(
+		public name: string,
+		public providerType: string
+	) {
+		super(`Provider with name "${name}" and type "${providerType}" already exists`);
+		this.name = 'DuplicateProviderError';
+	}
+}
+
+export { DuplicateProviderError };

--- a/apps/server/src/bl/providers/DuplicateProviderError.ts
+++ b/apps/server/src/bl/providers/DuplicateProviderError.ts
@@ -1,9 +1,9 @@
 class DuplicateProviderError extends Error {
 	constructor(
-		public name: string,
+		public providerName: string,
 		public providerType: string
 	) {
-		super(`Provider with name "${name}" and type "${providerType}" already exists`);
+		super(`Provider with name "${providerName}" and type "${providerType}" already exists`);
 		this.name = 'DuplicateProviderError';
 	}
 }

--- a/apps/server/src/bl/providers/provider.bl.ts
+++ b/apps/server/src/bl/providers/provider.bl.ts
@@ -1,5 +1,6 @@
 import { DiscoveredService, Provider, Service, Logger, User, ServiceType } from '@OpsiMate/shared';
 import { ProviderNotFound } from './ProviderNotFound';
+import { DuplicateProviderError } from './DuplicateProviderError';
 import { providerConnectorFactory } from './provider-connector/providerConnectorFactory';
 import { ProviderRepository } from '../../dal/providerRepository';
 import { ServiceRepository } from '../../dal/serviceRepository';
@@ -62,6 +63,10 @@ export class ProviderBL {
 
 			return createdProvider;
 		} catch (error) {
+			// Check if it's a UNIQUE constraint violation from the database
+			if (error instanceof Error && error.message.includes('UNIQUE constraint failed')) {
+				throw new DuplicateProviderError(providerToCreate.name, providerToCreate.providerType);
+			}
 			logger.error(`Error creating provider`, error);
 			throw error;
 		}
@@ -100,6 +105,10 @@ export class ProviderBL {
 			});
 			return await this.providerRepo.getProviderById(providerId);
 		} catch (error) {
+			// Check if it's a UNIQUE constraint violation from the database
+			if (error instanceof Error && error.message.includes('UNIQUE constraint failed')) {
+				throw new DuplicateProviderError(providerToUpdate.name, providerToUpdate.providerType);
+			}
 			logger.error(`Error updating provider`, error);
 			throw error;
 		}

--- a/apps/server/src/dal/providerRepository.ts
+++ b/apps/server/src/dal/providerRepository.ts
@@ -133,12 +133,13 @@ export class ProviderRepository {
                     password             TEXT,
                     ssh_port             INTEGER  DEFAULT 22,
                     created_at           DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    provider_type        TEXT NOT NULL
+                    provider_type        TEXT NOT NULL,
                     CHECK (
                         (private_key_filename IS NOT NULL AND TRIM(private_key_filename) <> '')
                             OR
                         (password IS NOT NULL AND TRIM(password) <> '')
-                        )
+                        ),
+                    UNIQUE(provider_name, provider_type)
                 )
             `
 				)


### PR DESCRIPTION
## Issue Reference
Fixes #251 - Added validation to prevent creating duplicate providers with the same name and type combination.

---

## What Was Changed

- Added `UNIQUE(provider_name, provider_type)` constraint to the providers table schema in `providerRepository.ts`
- Created `DuplicateProviderError` custom error class to handle duplicate provider scenarios
- Updated `provider.bl.ts` to catch UNIQUE constraint violations and throw `DuplicateProviderError`
- Modified `controller.ts` to return HTTP 409 Conflict status when duplicate providers are detected

---

## Why Was It Changed

Previously, users could create multiple providers with the same name and type (for example, two "Test" VM providers). This caused confusion and could lead to data problems.

This fix solves the issue by adding a database constraint that prevents duplicate combinations of provider name and type. The database itself enforces this rule, which means it works automatically and safely even when multiple users try to create providers at the same time.

This approach is better than checking for duplicates in the application code because it's faster (only one database operation), more reliable (the database guarantees uniqueness), and follows the same error handling pattern used throughout the project. When someone tries to create a duplicate, the database catches it, the business logic creates a clear error message, and the API returns a 409 Conflict response to the user.

---

## Screenshots

<!-- If UI changes or visual diffs were made, include screenshots here -->

Already created server type provider with the name "test":
<img width="1867" height="883" alt="image" src="https://github.com/user-attachments/assets/c37cf61d-a9f6-4742-af04-3d0b10201106" />

If user tries to create the new provider under server type with the same name "test", it shows the error saying that Provider with name "test" and type "VM" already exists:

<img width="1865" height="888" alt="image" src="https://github.com/user-attachments/assets/743c3655-6c89-45fa-9f4d-3bc1cc704264" />

---

## Additional Context (Optional)

**Database Schema Change:** This PR adds a `UNIQUE(provider_name, provider_type)` constraint to the providers table to ensure atomic enforcement of uniqueness at the database level. This prevents race conditions where two simultaneous requests could create duplicate providers.

However, existing databases created before this change don't have the constraint. To apply it, I deleted `apps/server/data/database/opsimate.db` and recreated the schema. That was what I did on local, but I am sure it would be different on the dev and prod. Please guide me through this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforces uniqueness for provider name + type to prevent duplicate entries.
  * Creating or updating a provider that would duplicate an existing name/type now returns a clear 409 Conflict with a descriptive message instead of a generic error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->