### PR TITLE
[Feat] Add coralogix integration

### DIFF
--- a/apps/client/src/components/IntegrationDashboardDropdown.tsx
+++ b/apps/client/src/components/IntegrationDashboardDropdown.tsx
@@ -11,6 +11,7 @@ import {
 import { KibanaIcon } from './icons/KibanaIcon';
 import { GrafanaIcon } from './icons/GrafanaIcon';
 import { DatadogIcon } from './icons/DatadogIcon';
+import { CoralogixIcon } from './icons/CoralogixIcon';
 import { ChevronDown, ExternalLink, Loader2 } from 'lucide-react';
 import { Tag } from '@OpsiMate/shared';
 import { useToast } from '@/hooks/use-toast';
@@ -23,7 +24,7 @@ interface Dashboard {
 
 interface IntegrationDashboardDropdownProps {
 	tags: Tag[];
-	integrationType: 'Kibana' | 'Grafana' | 'Datadog';
+	integrationType: 'Kibana' | 'Grafana' | 'Datadog' | 'Coralogix';
 	className?: string;
 }
 
@@ -46,6 +47,8 @@ export const IntegrationDashboardDropdown = memo(function IntegrationDashboardDr
 				return KibanaIcon;
 			case 'Datadog':
 				return DatadogIcon;
+			case 'Coralogix':
+				return CoralogixIcon;
 			case 'Grafana':
 			default:
 				return GrafanaIcon;

--- a/apps/client/src/components/RightSidebarWithLogs.tsx
+++ b/apps/client/src/components/RightSidebarWithLogs.tsx
@@ -263,6 +263,7 @@ export const RightSidebarWithLogs = memo(function RightSidebarWithLogs({
 				<IntegrationDashboardDropdown tags={serviceTags} integrationType="Grafana" className="w-full" />
 				<IntegrationDashboardDropdown tags={serviceTags} integrationType="Kibana" className="w-full" />
 				<IntegrationDashboardDropdown tags={serviceTags} integrationType="Datadog" className="w-full" />
+				<IntegrationDashboardDropdown tags={serviceTags} integrationType="Coralogix" className="w-full" />
 			</div>
 		);
 	}, [serviceTags]);

--- a/apps/client/src/pages/Integrations.tsx
+++ b/apps/client/src/pages/Integrations.tsx
@@ -169,7 +169,7 @@ const INTEGRATIONS: Integration[] = [
 		tags: ['Logging', 'Analytics', 'Monitoring'],
 		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/overview',
 		configFields: [
-			{ name: 'url', label: 'Coralogix URL', type: 'text', placeholder: 'https://api.coralogix.com/', required: true },
+			{ name: 'url', label: 'Coralogix URL', type: 'text', placeholder: 'https://api.us2.coralogix.com/', required: true },
 			{ name: 'apiKey', label: 'API Key', type: 'password', required: true },
 			{ name: 'applicationName', label: 'Application Name', type: 'text', placeholder: 'Optional', required: false },
 			{ name: 'subsystemName', label: 'Subsystem Name', type: 'text', placeholder: 'Optional', required: false },

--- a/apps/client/src/pages/Integrations.tsx
+++ b/apps/client/src/pages/Integrations.tsx
@@ -52,6 +52,7 @@ enum IntegrationType {
 	Grafana = 'Grafana',
 	Kibana = 'Kibana',
 	Datadog = 'Datadog',
+  Coralogix = 'Coralogix',
 }
 
 interface Integration {
@@ -161,16 +162,17 @@ const INTEGRATIONS: Integration[] = [
 	},
 	{
 		id: 'coralogix',
-		supported: false,
+		supported: true,
 		name: 'Coralogix',
 		description: 'Log analytics platform powered by machine learning.',
 		logo: 'https://cdn.brandfetch.io/idCh7aU0wN/theme/dark/logo.svg?c=1bxid64Mup7aczewSAYMX&t=1667744703603',
 		tags: ['Logging', 'Analytics', 'Monitoring'],
 		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/overview',
 		configFields: [
+			{ name: 'url', label: 'Coralogix URL', type: 'text', placeholder: 'https://api.coralogix.com/', required: true },
 			{ name: 'apiKey', label: 'API Key', type: 'password', required: true },
-			{ name: 'applicationName', label: 'Application Name', type: 'text', required: true },
-			{ name: 'subsystemName', label: 'Subsystem Name', type: 'text', required: true },
+			{ name: 'applicationName', label: 'Application Name', type: 'text', placeholder: 'Optional', required: false },
+			{ name: 'subsystemName', label: 'Subsystem Name', type: 'text', placeholder: 'Optional', required: false },
 		],
 	},
 	{
@@ -733,13 +735,14 @@ const Integrations = () => {
 																selectedIntegration.id.slice(1)
 													);
 
-													// Map integration id to the correct IntegrationType
-													const typeMapping = {
-														grafana: IntegrationType.Grafana,
-														kibana: IntegrationType.Kibana,
-														datadog: IntegrationType.Datadog,
-														// Add other integration types as needed
-													};
+												// Map integration id to the correct IntegrationType
+												const typeMapping = {
+													grafana: IntegrationType.Grafana,
+													kibana: IntegrationType.Kibana,
+													datadog: IntegrationType.Datadog,
+													coralogix: IntegrationType.Coralogix,
+													// Add other integration types as needed
+												};
 
 													// Prepare the integration data
 													let credentials = {};

--- a/apps/server/src/bl/integrations/integration-connector/coralogix-integration-connector.ts
+++ b/apps/server/src/bl/integrations/integration-connector/coralogix-integration-connector.ts
@@ -1,0 +1,46 @@
+import { Integration, IntegrationUrls, Logger } from '@OpsiMate/shared';
+import { IntegrationConnector } from './integration-connector';
+import { CoralogixClient, CoralogixDashboardSummary } from '../../../dal/external-client/coralogix-client';
+import { AlertBL } from '../../alerts/alert.bl';
+
+export class CoralogixIntegrationConnector implements IntegrationConnector {
+	private readonly logger = new Logger('bl/integrations/coralogix-integration-connector');
+
+	async getUrls(integration: Integration, tags: string[]): Promise<IntegrationUrls[]> {
+		try {
+			// Skip if no tags provided
+			if (!tags || tags.length === 0) {
+				this.logger.info('No tags provided for Coralogix integration, skipping');
+				return [];
+			}
+
+			// Check if credentials exist and have the required fields
+			if (!integration.credentials || !integration.credentials['apiKey']) {
+				this.logger.error('Missing Coralogix API key in credentials');
+				return [];
+			}
+
+			const coralogixClient = new CoralogixClient(
+				integration.externalUrl,
+				integration.credentials['apiKey']
+			);
+
+			// Get dashboards matching the provided tags
+			const dashboards = await coralogixClient.getDashboardsByTags(tags);
+			this.logger.info(`Found ${dashboards.length} Coralogix dashboards matching tags: ${tags.join(', ')}`);
+
+			// Transform dashboards to IntegrationUrls format
+			return dashboards
+				.filter((dash: CoralogixDashboardSummary) => !!dash.url) // Filter out dashboards without URLs
+				.map((dash: CoralogixDashboardSummary) => ({
+					name: dash.name,
+					url: dash.url as string, // The URL is already absolute from the CoralogixClient
+				}));
+		} catch (error) {
+			this.logger.error('Error in CoralogixIntegrationConnector.getUrls:', error);
+			return [];
+		}
+	}
+
+	async deleteData(_: Integration, _2: AlertBL): Promise<void> {}
+}

--- a/apps/server/src/bl/integrations/integration-connector/integration-connector-factory.ts
+++ b/apps/server/src/bl/integrations/integration-connector/integration-connector-factory.ts
@@ -3,6 +3,7 @@ import { IntegrationConnector } from './integration-connector';
 import { GrafanaIntegrationConnector } from './grafana-integration-connector';
 import { KibanaIntegrationConnector } from './kibana-integration-connector';
 import { DatadogIntegrationConnector } from './datadog-integration-connector';
+import { CoralogixIntegrationConnector } from './coralogix-integration-connector';
 
 export function integrationConnectorFactory(type: IntegrationType): IntegrationConnector {
 	return integrationsMap[type];
@@ -12,4 +13,5 @@ const integrationsMap = {
 	[IntegrationType.Grafana]: new GrafanaIntegrationConnector(),
 	[IntegrationType.Kibana]: new KibanaIntegrationConnector(),
 	[IntegrationType.Datadog]: new DatadogIntegrationConnector(),
+	[IntegrationType.Coralogix]: new CoralogixIntegrationConnector(),
 };

--- a/apps/server/src/dal/external-client/coralogix-client.ts
+++ b/apps/server/src/dal/external-client/coralogix-client.ts
@@ -1,0 +1,108 @@
+import { Logger } from '@OpsiMate/shared';
+
+const logger = new Logger('dal/external-client/coralogix-client');
+
+export interface CoralogixDashboardSummary {
+  authorId: string,
+  createTime: string,
+  description: string,
+  folder: {
+    id: string,
+    name: string,
+    parentId: string,
+  },
+  id: string,
+  isDefault: boolean,
+  isLocked: boolean,
+  isPinned: boolean,
+  lockerAuthorId: string,
+  name: string,
+  slugName: string,
+  updateTime: string,
+  url?: string,
+}
+
+export class CoralogixClient {
+  constructor(
+    private readonly url: string,
+    private readonly apiKey: string,
+  ) {}
+
+  async getAllDashboard(): Promise<CoralogixDashboardSummary[]> {
+    try {
+      logger.info("Fetching all Coralogix dashboards");
+
+      const baseUrl = this.url.replace(/\/$/, '');
+      const endpoint = `${baseUrl}/mgmt/openapi/latest/v1/dashboards/dashboards/catalog`;
+
+      const response = await fetch(endpoint, {
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.error(`Coralogix API error (${response.status}): ${errorText}`);
+        throw new Error(`Coralogix API error: ${response.status} - ${errorText}`);
+      }
+
+      const data = await response.json() as { items?: CoralogixDashboardSummary[] };
+
+      if (!data.items || !Array.isArray(data.items)) {
+        logger.info('No dashboards found in Coralogix response');
+        return [];
+      }
+
+      logger.info(`Found ${data.items.length} Coralogix dashboards`);
+
+      // Add URL to each dashboard with absolute URL
+      return data.items.map((dashboard) => ({
+        ...dashboard,
+        url: `${baseUrl}/dashboards/${dashboard.id}`,
+      }));
+    } catch (error) {
+      logger.error('Error fetching Coralogix dashboards:', error);
+      return [];
+    }
+  }
+
+  async getDashboardsByTags(tags: string[]): Promise<CoralogixDashboardSummary[]> {
+    try {
+      if (!tags || tags.length === 0) {
+        logger.info('No tags provided, skipping Coralogix dashboard search');
+        return [];
+      }
+
+      logger.info(`Searching Coralogix dashboards with tags: ${tags.join(', ')}`);
+
+      // Get all dashboards first
+      const allDashboards = await this.getAllDashboard();
+
+      if (allDashboards.length === 0) {
+        return [];
+      }
+
+      // Filter dashboards by name content (check if any tag is included in the dashboard name)
+      const matchingDashboards = allDashboards.filter((dashboard) => {
+        if (!dashboard.name) {
+          return false;
+        }
+
+        const dashboardName = dashboard.name.toLowerCase();
+
+        // Check if any of the service tags are included in the dashboard name
+        return tags.some((tag) => dashboardName.includes(tag.toLowerCase()));
+      });
+
+      logger.info(
+        `Found ${matchingDashboards.length} Coralogix dashboards matching tags in name: ${tags.join(', ')}`
+      );
+      return matchingDashboards;
+    } catch (error) {
+      logger.error(`Error searching Coralogix dashboards by tags:`, error);
+      return [];
+    }
+  }
+}

--- a/apps/server/src/dal/external-client/coralogix-client.ts
+++ b/apps/server/src/dal/external-client/coralogix-client.ts
@@ -33,7 +33,7 @@ export class CoralogixClient {
       logger.info("Fetching all Coralogix dashboards");
 
       const baseUrl = this.url.replace(/\/$/, '');
-      const endpoint = `${baseUrl}/mgmt/openapi/latest/v1/dashboards/dashboards/catalog`;
+      const endpoint = `${baseUrl}/mgmt/openapi/latest/dashboards/dashboards/v1/catalog`;
 
       const response = await fetch(endpoint, {
         headers: {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -18,6 +18,7 @@ export enum IntegrationType {
 	Grafana = 'Grafana',
 	Kibana = 'Kibana',
 	Datadog = 'Datadog',
+	Coralogix = 'Coralogix',
 }
 
 export enum ServiceType {


### PR DESCRIPTION
## Issue Reference
Closes #94 

---

## What Was Changed

1. Added Coralogix integration connector
2. Implemented Coralogix client
3. Added Coralogix as a new integration option in the frontend

---

## Why Was It Changed

- Fulfill the feature requirements: Helps unify monitoring and logging tools within the platform for better operational visibility
- Referred from the implementation of Datadog integration

---

## Screenshots
Req:
<img width="800" height="75" alt="Screenshot 2025-11-21 010209" src="https://github.com/user-attachments/assets/e87ffcc6-b6ed-41fd-ab54-88c100b5985b" />

Res:
<img width="800" height="80" alt="Screenshot 2025-11-21 010217" src="https://github.com/user-attachments/assets/f09b96e3-9c78-4594-a835-dceac5c53c36" />

Now the app should be able to get the Json responses from Coralogix

**IMPORTANT:** Should use the right domain for the base URL, example -> `https://api.us2.coralogix.com`
Refs: https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/

---

## Additional Context

TODO: 
1. Querying logs, or linking relevant views based on tags or service context.
2. Documentation
3. Online docs

Welcome further discussion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coralogix is now a fully supported integration option. Users can configure Coralogix with a required URL and optional application/subsystem name fields, select dashboards by tags, and retrieve dashboard URLs for monitoring integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->