### PR TITLE
[Fix] Update Datadog logo in Integrations page

### DIFF
--- a/apps/client/src/pages/Integrations.tsx
+++ b/apps/client/src/pages/Integrations.tsx
@@ -116,7 +116,7 @@ const INTEGRATIONS: Integration[] = [
 		supported: true,
 		name: 'Datadog',
 		description: 'Cloud monitoring and analytics platform for infrastructure, applications, and logs.',
-		logo: 'https://imgix.datadoghq.com/img/dd_logo_n_70x75.png',
+		logo: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/datadog.svg',
 		tags: ['Monitoring', 'APM', 'Logs', 'Metrics'],
 		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/datadog',
 		configFields: [


### PR DESCRIPTION
## Issue Reference

Closes #557 

---

## What Was Changed

1. Replace Datadog icon's source

---

## Why Was It Changed

1. The original Datadog logo URL `https://imgix.datadoghq.com/img/dd_logo_n_70x75.png` was broken and not loading

---

## Screenshots

<img width="669" height="518" alt="Screenshot 2025-11-21 014414" src="https://github.com/user-attachments/assets/6b06b727-5ed2-460e-b2d1-2b2a2d7acfef" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Datadog integration logo asset source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->