### PR TITLE
add class depending on existing links for section visibility change

### DIFF
--- a/apps/client/src/components/RightSidebarWithLogs.tsx
+++ b/apps/client/src/components/RightSidebarWithLogs.tsx
@@ -295,7 +295,7 @@ export const RightSidebarWithLogs = memo(function RightSidebarWithLogs({
 		badge?: string | number;
 		className?: string;
 	}) => (
-		<Collapsible open={isOpen} onOpenChange={onToggle}>
+		<Collapsible open={isOpen} onOpenChange={onToggle} className={className}>
 			<CollapsibleTrigger asChild>
 				<Button
 					variant="ghost"
@@ -431,7 +431,8 @@ export const RightSidebarWithLogs = memo(function RightSidebarWithLogs({
 						icon={ExternalLink}
 						isOpen={sectionsOpen.externalLinks}
 						onToggle={() => toggleSection('externalLinks')}
-					>
+					>className={serviceTags.length > 0 ? 'has-external-links' : 'no-external-links'}
+
 						{integrationDropdowns}
 					</CollapsibleSection>
 

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -151,4 +151,8 @@
 	.dark .services-scrollbar::-webkit-scrollbar-thumb:hover {
 		background-color: rgb(107 114 128);
 	}
+
+	.no-external-links {
+		display: none !important;
+	}
 }


### PR DESCRIPTION
## Issue Reference

https://github.com/OpsiMate/OpsiMate/issues/461
---

## What Was Changed

Added a new class to a section if there are no external links for displaying it as none.

---

## Why Was It Changed

Services with no external links still had the 'External Links' section.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Sidebar sections now conditionally hide when empty, providing a cleaner and more streamlined interface appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->