### PR TITLE
[FIX]: Allow deleting alerts without alertUrl or runbookUrl

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
@@ -18,8 +18,8 @@ export interface RowActionsProps {
 
 export const RowActions = ({ alert, onDismissAlert, onUndismissAlert, onDeleteAlert }: RowActionsProps) => {
 	const { alertUrl, runbookUrl, isDismissed } = alert;
-	const hasLinks = Boolean(alertUrl || runbookUrl);
 	const canToggle = (!isDismissed && Boolean(onDismissAlert)) || (isDismissed && Boolean(onUndismissAlert));
+	const hasActions = Boolean(alertUrl || runbookUrl || onDeleteAlert);
 
 	const handleToggle = (event: React.MouseEvent) => {
 		event.stopPropagation();
@@ -41,7 +41,7 @@ export const RowActions = ({ alert, onDismissAlert, onUndismissAlert, onDeleteAl
 
 	return (
 		<div className="flex items-center justify-end gap-1.5">
-			{hasLinks && (
+			{hasActions && (
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
 						<Button


### PR DESCRIPTION
## Bug Fix

Fixes an issue where alerts without `alertUrl` or `runbookUrl` could not be deleted.

**Related Trello Card**: https://trello.com/c/64b3T6oQ

### Problem
The delete button was only accessible through a dropdown menu that only appeared when alerts had links. This prevented deletion of alerts that had no URLs.

### Solution
- Refactored `RowActions` component to show the dropdown menu whenever there are any actions available (links OR delete)
- Removed the `hasLinks` boolean check that was preventing the dropdown from appearing
- The delete button is now always accessible in the dropdown menu when `onDeleteAlert` is provided, regardless of whether the alert has URLs

### Changes
- `apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx`: Replaced `hasLinks` check with `hasActions` check that includes delete action

### Testing
- Verified that alerts without URLs can now be deleted
- Verified that alerts with URLs still show links in the dropdown
- Verified that the delete button appears in the dropdown for all alerts when delete is enabled