### PR TITLE
[FEAT]: Kubernetes with helm charts

### DIFF
--- a/infrastructure/helm/Chart.yaml
+++ b/infrastructure/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: opsimate
+description: Helm chart for deploying OpsiMate
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infrastructure/helm/README.md
+++ b/infrastructure/helm/README.md
@@ -1,0 +1,49 @@
+# OpsiMate Helm Chart
+
+Deploys OpsiMate (frontend, backend, worker) to Kubernetes.
+
+## Structure
+
+```
+opsimate/
+├── Chart.yaml                      # Chart metadata
+├── values.yaml                     # Default configuration (change the values here)
+├── README.md
+└── templates/
+    ├── _helpers.tpl                # Template helpers
+    ├── deployment-backend.yaml     # Backend API server
+    ├── deployment-frontend.yaml    # Frontend UI
+    ├── deployment-worker.yaml      # Background worker
+    ├── service-backend.yaml        # Internal service for backend
+    ├── service-frontend.yaml       # External service for frontend
+    ├── secret.yaml                 # API token
+    └── pvc.yaml                    # Persistent storage
+```
+
+## Quick Start
+
+kubectl create namespace opsimate
+helm install opsimate ./infrastructure/helm/opsimate -n opsimate
+
+## Access the Dashboard
+
+# Port forward
+kubectl port-forward svc/opsimate-frontend 8080:80 -n opsimate
+
+# Open http://localhost:8080
+
+## Configuration
+
+See `values.yaml` for all configurable options. Common overrides:
+
+# Use NodePort instead of LoadBalancer
+helm install opsimate ./infrastructure/helm/opsimate -n opsimate \
+  --set frontend.service.type=NodePort
+
+# Disable persistence
+helm install opsimate ./infrastructure/helm/opsimate -n opsimate \
+  --set persistence.enabled=false
+
+## Uninstall
+
+helm uninstall opsimate -n opsimate

--- a/infrastructure/helm/templates/_helpers.tpl
+++ b/infrastructure/helm/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Chart name */}}
+{{- define "opsimate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Fullname */}}
+{{- define "opsimate.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "opsimate.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "opsimate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Backend selector labels */}}
+{{- define "opsimate.backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "opsimate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: backend
+{{- end }}
+
+{{/* Worker selector labels */}}
+{{- define "opsimate.worker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "opsimate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: worker
+{{- end }}
+
+{{/* Frontend selector labels */}}
+{{- define "opsimate.frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "opsimate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: frontend
+{{- end }}

--- a/infrastructure/helm/templates/deployment-backend.yaml
+++ b/infrastructure/helm/templates/deployment-backend.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opsimate.fullname" . }}-backend
+  labels:
+    {{- include "opsimate.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "opsimate.backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "opsimate.backend.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.backend.port }}
+          env:
+            - name: NODE_ENV
+              value: {{ .Values.env.nodeEnv }}
+            - name: HOST
+              value: "0.0.0.0"
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opsimate.fullname" . }}-secret
+                  key: API_TOKEN
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /app/data/database
+              subPath: database
+            - name: data
+              mountPath: /app/data/private-keys
+              subPath: private-keys
+            {{- end }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "opsimate.fullname" . }}-data
+        {{- end }}

--- a/infrastructure/helm/templates/deployment-frontend.yaml
+++ b/infrastructure/helm/templates/deployment-frontend.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opsimate.fullname" . }}-frontend
+  labels:
+    {{- include "opsimate.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "opsimate.frontend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "opsimate.frontend.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.frontend.port }}
+          env:
+            - name: NODE_ENV
+              value: {{ .Values.env.nodeEnv }}
+            - name: HOST
+              value: "0.0.0.0"
+            - name: API_URL
+              value: "http://{{ include "opsimate.fullname" . }}-backend:{{ .Values.backend.port }}"
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/infrastructure/helm/templates/deployment-worker.yaml
+++ b/infrastructure/helm/templates/deployment-worker.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opsimate.fullname" . }}-worker
+  labels:
+    {{- include "opsimate.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "opsimate.worker.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "opsimate.worker.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: worker
+          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          command: ["node", "apps/server/dist/worker.js"]
+          env:
+            - name: NODE_ENV
+              value: {{ .Values.env.nodeEnv }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /app/data/database
+              subPath: database
+            - name: data
+              mountPath: /app/data/private-keys
+              subPath: private-keys
+            {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "opsimate.fullname" . }}-data
+        {{- end }}

--- a/infrastructure/helm/templates/pvc.yaml
+++ b/infrastructure/helm/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "opsimate.fullname" . }}-data
+  labels:
+    {{- include "opsimate.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/infrastructure/helm/templates/secret.yaml
+++ b/infrastructure/helm/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "opsimate.fullname" . }}-secret
+  labels:
+    {{- include "opsimate.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  API_TOKEN: {{ .Values.env.apiToken }}

--- a/infrastructure/helm/templates/service-backend.yaml
+++ b/infrastructure/helm/templates/service-backend.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opsimate.fullname" . }}-backend
+  labels:
+    {{- include "opsimate.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.backend.port }}
+      targetPort: {{ .Values.backend.port }}
+  selector:
+    {{- include "opsimate.backend.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/templates/service-frontend.yaml
+++ b/infrastructure/helm/templates/service-frontend.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opsimate.fullname" . }}-frontend
+  labels:
+    {{- include "opsimate.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: {{ .Values.frontend.port }}
+  selector:
+    {{- include "opsimate.frontend.selectorLabels" . | nindent 4 }}

--- a/infrastructure/helm/values.yaml
+++ b/infrastructure/helm/values.yaml
@@ -1,0 +1,58 @@
+# OpsiMate Helm Values
+
+backend:
+  image:
+    repository: opsimate/backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  port: 3001
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+worker:
+  image:
+    repository: opsimate/backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+frontend:
+  image:
+    repository: opsimate/frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  port: 8080
+  service:
+    type: LoadBalancer
+    port: 80
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+
+env:
+  nodeEnv: production
+  apiToken: opsimate
+
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClass: ""
+  accessMode: ReadWriteOnce


### PR DESCRIPTION
## Issue Reference

Working on #245

---

## What Was Changed

Added Helm chart for deploying OpsiMate to Kubernetes (infrastructure/helm/opsimate/):

- Deployments for frontend, backend, and worker
- Services for frontend (LoadBalancer) and backend (ClusterIP)
- PersistentVolumeClaim for database and private keys
- Secret for API token

---

## Why Was It Changed

Currently there's no easy way for developers to spin up OpsiMate on Kubernetes. This Helm chart provides a one-command deployment for testing and development.


---

## Screenshots

<img width="1920" height="162" alt="image" src="https://github.com/user-attachments/assets/a28a9795-0767-455f-a7ca-4c201c6276c3" />

<img width="690" height="576" alt="image" src="https://github.com/user-attachments/assets/5ab75292-0429-4050-8347-11942ede11d9" />

---

## Additional Context (Optional)

Usage:

```kubectl create namespace opsimate```
```helm install opsimate ./infrastructure/helm/opsimate -n opsimate```
```kubectl port-forward svc/opsimate-frontend 8080:80 -n opsimate```

Terraform for AWS EKS deployment will follow in a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart support enabling Kubernetes deployment with pre-configured templates for all services.

* **Chores**
  * Added persistent volume configuration, secret management templates, and resource specifications for production deployments.

* **Documentation**
  * Added comprehensive deployment guide and configuration values reference for Kubernetes environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->