### PR TITLE
feat: split alerts by owner (assigned vs unassigned)

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -1,5 +1,6 @@
 import { DashboardLayout } from '@/components/DashboardLayout';
 import { FilterSidebar } from '@/components/shared';
+import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useDashboard } from '@/context/DashboardContext';
 import { useAlerts, useArchivedAlerts, useDeleteArchivedAlert } from '@/hooks/queries/alerts';
@@ -14,13 +15,15 @@ import { useServices } from '@/hooks/queries/services';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Bell } from 'lucide-react';
+import { Archive, Bell, Columns2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertsFilterPanel } from '.';
 import { AlertDetailsPanel } from './AlertDetails';
 import { AlertsSelectionBar } from './AlertsSelectionBar';
 import { AlertsTable } from './AlertsTable';
+import { AssignmentPane } from './AssignmentPane';
+import { VerticalSplit } from './VerticalSplit';
 import { ACTIONS_COLUMN } from './AlertsTable/AlertsTable.constants';
 import { AlertTab } from './AlertsTable/AlertsTable.types';
 import { SearchBar } from './AlertsTable/SearchBar';
@@ -64,6 +67,7 @@ const Alerts = () => {
 	const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
 	const [filterPanelCollapsed, setFilterPanelCollapsed] = useState(false);
 	const [showDashboardSettings, setShowDashboardSettings] = useState(false);
+	const [splitByAssignment, setSplitByAssignment] = useState(false);
 
 	const allAlerts = useMemo(() => [...alerts, ...archivedAlerts], [alerts, archivedAlerts]);
 	const tagKeys = useAlertTagKeys(allAlerts);
@@ -163,6 +167,10 @@ const Alerts = () => {
 		filters: dashboardState.filters,
 		timeRange: dashboardState.timeRange,
 	});
+
+	// Split the active, filtered alerts by assignment for the side-by-side view.
+	const unassignedAlerts = useMemo(() => filteredAlerts.filter((a) => !a.ownerId), [filteredAlerts]);
+	const assignedAlerts = useMemo(() => filteredAlerts.filter((a) => !!a.ownerId), [filteredAlerts]);
 	const { handleDismissAlert, handleUndismissAlert, handleDeleteAlert, handleDismissAll, handleAssignOwnerAll } =
 		useAlertActions();
 	const deleteArchivedAlertMutation = useDeleteArchivedAlert();
@@ -178,6 +186,34 @@ const Alerts = () => {
 	const handleDeleteArchivedAlert = async (alertId: string) => {
 		await deleteArchivedAlertMutation.mutateAsync(alertId);
 	};
+
+	// Active-tab alerts table, parameterized by the alert list so it can render full-width
+	// or inside one of the split-by-assignment panes without duplicating the prop wiring.
+	const renderActiveAlertsTable = (list: Alert[]) => (
+		<AlertsTable
+			alerts={list}
+			services={services}
+			onDismissAlert={handleDismissAlert}
+			onUndismissAlert={handleUndismissAlert}
+			onDeleteAlert={handleDeleteAlert}
+			onSelectAlerts={setSelectedAlerts}
+			selectedAlerts={selectedAlerts}
+			isLoading={isLoading}
+			visibleColumns={visibleColumns}
+			columnOrder={columnOrder}
+			onAlertClick={handleAlertClick}
+			tagKeyColumnLabels={allColumnLabels}
+			groupByColumns={dashboardState.groupBy}
+			onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
+			onColumnToggle={handleColumnToggle}
+			tagKeys={tagKeys}
+			timeRange={dashboardState.timeRange}
+			onTimeRangeChange={(range) => updateDashboardField('timeRange', range)}
+			searchTerm={dashboardState.query}
+			onSearchTermChange={(term) => updateDashboardField('query', term)}
+			renderToolbar={false}
+		/>
+	);
 
 	const handleLaunchTVMode = () => {
 		setSelectedAlert(null); // Close alert details panel before navigating
@@ -324,6 +360,19 @@ const Alerts = () => {
 									/>
 								</div>
 
+								{activeTab === AlertTab.Active && (
+									<Button
+										variant={splitByAssignment ? 'default' : 'outline'}
+										size="sm"
+										onClick={() => setSplitByAssignment((v) => !v)}
+										className="gap-1.5 flex-shrink-0"
+										title="Split into Unassigned and Assigned"
+									>
+										<Columns2 className="h-4 w-4" />
+										<span className="hidden lg:inline">Split by owner</span>
+									</Button>
+								)}
+
 								<TimeFilter
 									value={dashboardState.timeRange ?? createEmptyTimeRange()}
 									onChange={(range) => updateDashboardField('timeRange', range)}
@@ -333,36 +382,42 @@ const Alerts = () => {
 
 						{activeTab === AlertTab.Active ? (
 							<>
-								<div
-									className={cn(
-										'flex-1 min-h-0',
-										alerts.length === 0 && !isLoading && 'flex items-center justify-center'
-									)}
-								>
-									<AlertsTable
-										alerts={filteredAlerts}
-										services={services}
-										onDismissAlert={handleDismissAlert}
-										onUndismissAlert={handleUndismissAlert}
-										onDeleteAlert={handleDeleteAlert}
-										onSelectAlerts={setSelectedAlerts}
-										selectedAlerts={selectedAlerts}
-										isLoading={isLoading}
-										visibleColumns={visibleColumns}
-										columnOrder={columnOrder}
-										onAlertClick={handleAlertClick}
-										tagKeyColumnLabels={allColumnLabels}
-										groupByColumns={dashboardState.groupBy}
-										onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
-										onColumnToggle={handleColumnToggle}
-										tagKeys={tagKeys}
-										timeRange={dashboardState.timeRange}
-										onTimeRangeChange={(range) => updateDashboardField('timeRange', range)}
-										searchTerm={dashboardState.query}
-										onSearchTermChange={(term) => updateDashboardField('query', term)}
-										renderToolbar={false}
+								{splitByAssignment ? (
+									<VerticalSplit
+										className="flex-1"
+										top={
+											<AssignmentPane
+												title="Unassigned"
+												count={unassignedAlerts.length}
+												tone="amber"
+												isEmpty={unassignedAlerts.length === 0 && !isLoading}
+												emptyText="Nothing waiting — all alerts are assigned."
+											>
+												{renderActiveAlertsTable(unassignedAlerts)}
+											</AssignmentPane>
+										}
+										bottom={
+											<AssignmentPane
+												title="Assigned"
+												count={assignedAlerts.length}
+												tone="emerald"
+												isEmpty={assignedAlerts.length === 0 && !isLoading}
+												emptyText="No alerts assigned yet."
+											>
+												{renderActiveAlertsTable(assignedAlerts)}
+											</AssignmentPane>
+										}
 									/>
-								</div>
+								) : (
+									<div
+										className={cn(
+											'flex-1 min-h-0',
+											alerts.length === 0 && !isLoading && 'flex items-center justify-center'
+										)}
+									>
+										{renderActiveAlertsTable(filteredAlerts)}
+									</div>
+								)}
 
 								<div className="flex-shrink-0">
 									<AlertsSelectionBar

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -49,6 +49,7 @@ export const AlertsTable = ({
 	onTimeRangeChange,
 	isArchived = false,
 	renderToolbar = true,
+	heading,
 }: AlertsTableProps) => {
 	const parentRef = useRef<HTMLDivElement>(null);
 
@@ -107,6 +108,11 @@ export const AlertsTable = ({
 				<AlertsEmptyState />
 			) : (
 				<div className="border rounded-lg overflow-hidden flex-1 flex flex-col min-h-0">
+					{heading && (
+						<div className="flex items-center gap-2 px-3 py-1.5 border-b flex-shrink-0 bg-muted/30">
+							{heading}
+						</div>
+					)}
 					<div className="border-b flex-shrink-0">
 						<Table className="table-fixed w-full">
 							<TableHeader>

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -1,6 +1,7 @@
 import { TimeRange } from '@/context/DashboardContext';
 import { TagKeyInfo } from '@/types';
 import { Alert } from '@OpsiMate/shared';
+import { ReactNode } from 'react';
 
 export enum AlertTab {
 	Active = 'active',
@@ -35,6 +36,9 @@ export interface AlertsTableProps {
 	searchTerm: string;
 	onSearchTermChange: (term: string) => void;
 	renderToolbar?: boolean;
+	// Optional caption rendered flush at the top of the table container (e.g. a section
+	// title + count), so callers don't need a separate header row above the table.
+	heading?: ReactNode;
 }
 
 export interface SortConfig {

--- a/apps/client/src/components/Alerts/AssignmentPane.tsx
+++ b/apps/client/src/components/Alerts/AssignmentPane.tsx
@@ -1,0 +1,55 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { cloneElement, isValidElement, ReactElement, ReactNode } from 'react';
+
+type PaneTone = 'amber' | 'emerald';
+
+const TONE_CLASS: Record<PaneTone, string> = {
+	amber: 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30',
+	emerald: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30',
+};
+
+// Compact "Title 428" caption rendered inside the table (via AlertsTable's `heading` prop)
+// so the split panes don't need a separate header row above the table.
+const PaneHeading = ({ title, count, tone }: { title: string; count: number; tone: PaneTone }) => (
+	<>
+		<span className="text-xs font-semibold uppercase tracking-wide text-foreground">{title}</span>
+		<Badge variant="outline" className={cn('h-5 px-1.5 text-[11px]', TONE_CLASS[tone])}>
+			{count}
+		</Badge>
+	</>
+);
+
+interface AssignmentPaneProps {
+	title: string;
+	count: number;
+	tone: PaneTone;
+	isEmpty?: boolean;
+	emptyText?: string;
+	/** An <AlertsTable /> element; the pane injects the heading caption into it. */
+	children: ReactNode;
+}
+
+// One pane of the split-by-assignment view. When it has alerts it renders the table with the
+// count caption injected; when empty it shows the same caption over a short message so both
+// panes always stay labelled.
+export const AssignmentPane = ({ title, count, tone, isEmpty, emptyText, children }: AssignmentPaneProps) => {
+	const heading = <PaneHeading title={title} count={count} tone={tone} />;
+
+	if (isEmpty) {
+		return (
+			<div className="h-full min-w-0 flex flex-col min-h-0 border rounded-lg overflow-hidden">
+				<div className="flex items-center gap-2 px-3 py-1.5 border-b flex-shrink-0 bg-muted/30">{heading}</div>
+				<div className="flex-1 flex items-center justify-center p-6 text-center text-sm text-muted-foreground">
+					{emptyText ?? 'No alerts.'}
+				</div>
+			</div>
+		);
+	}
+
+	const table = isValidElement(children)
+		? cloneElement(children as ReactElement<{ heading?: ReactNode }>, { heading })
+		: children;
+
+	return <div className="h-full min-w-0 flex flex-col min-h-0">{table}</div>;
+};

--- a/apps/client/src/components/Alerts/VerticalSplit.tsx
+++ b/apps/client/src/components/Alerts/VerticalSplit.tsx
@@ -1,0 +1,71 @@
+import { cn } from '@/lib/utils';
+import { ReactNode, useCallback, useRef, useState } from 'react';
+
+interface VerticalSplitProps {
+	top: ReactNode;
+	bottom: ReactNode;
+	/** Top pane's initial share of the height, 0..1. */
+	defaultRatio?: number;
+	/** Smallest share either pane can shrink to. */
+	minRatio?: number;
+	className?: string;
+}
+
+// A two-pane vertical layout with a draggable divider. No external dependency — the divider
+// updates a flex ratio on pointer drag, and each pane keeps its own internal scroll.
+export const VerticalSplit = ({ top, bottom, defaultRatio = 0.5, minRatio = 0.15, className }: VerticalSplitProps) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const draggingRef = useRef(false);
+	const [ratio, setRatio] = useState(defaultRatio);
+
+	const onPointerMove = useCallback(
+		(e: PointerEvent) => {
+			if (!draggingRef.current || !containerRef.current) return;
+			const rect = containerRef.current.getBoundingClientRect();
+			if (rect.height === 0) return;
+			const next = (e.clientY - rect.top) / rect.height;
+			setRatio(Math.min(1 - minRatio, Math.max(minRatio, next)));
+		},
+		[minRatio]
+	);
+
+	const stopDragging = useCallback(() => {
+		draggingRef.current = false;
+		window.removeEventListener('pointermove', onPointerMove);
+		window.removeEventListener('pointerup', stopDragging);
+		document.body.style.userSelect = '';
+		document.body.style.cursor = '';
+	}, [onPointerMove]);
+
+	const startDragging = useCallback(
+		(e: React.PointerEvent) => {
+			e.preventDefault();
+			draggingRef.current = true;
+			window.addEventListener('pointermove', onPointerMove);
+			window.addEventListener('pointerup', stopDragging);
+			document.body.style.userSelect = 'none';
+			document.body.style.cursor = 'row-resize';
+		},
+		[onPointerMove, stopDragging]
+	);
+
+	return (
+		<div ref={containerRef} className={cn('flex flex-col min-h-0', className)}>
+			<div className="min-h-0" style={{ flex: `${ratio} 1 0%` }}>
+				{top}
+			</div>
+			<div
+				role="separator"
+				aria-orientation="horizontal"
+				onPointerDown={startDragging}
+				className="group flex-shrink-0 h-2 my-0.5 flex items-center justify-center cursor-row-resize"
+				title="Drag to resize"
+			>
+				<div className="h-1 w-12 rounded-full bg-border group-hover:bg-primary/60 transition-colors" />
+			</div>
+			<div className="min-h-0" style={{ flex: `${1 - ratio} 1 0%` }}>
+				{bottom}
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
## Summary
Adds a **"Split by owner"** toggle on the Alerts page (Active tab) that gives clear visibility into **assigned vs unassigned** alerts — the unassigned queue is the backlog you triage, the assigned list shows what's already owned.

When enabled, the filtered active alerts stack into two panes:
- **Unassigned** (amber count) on top — the backlog
- **Assigned** (emerald count) below

## Highlights
- **Draggable divider** (`VerticalSplit`, no new dependency) — resize the panes to give the backlog or the assigned list more room (clamped 15–85%).
- **Counts live inside each table** as a compact caption (`AlertsTable` gains an optional `heading` prop), so there's no separate header row eating vertical space.
- **Handles many unassigned**: each pane reuses the existing virtualized table with its own scroll, so a large backlog never pushes the other section off-screen.
- **Clear the backlog fast**: the existing multi-select + bulk **"Assign to…"** bar works across the panes (reused as-is).
- Toggle only shows on the Active tab; the normal single-table view is unchanged when off.

## Implementation
- `Alerts.tsx`: `splitByAssignment` state + toolbar toggle; splits `filteredAlerts` by `ownerId`; a `renderActiveAlertsTable(list)` helper so table props aren't duplicated across single/split modes.
- New `VerticalSplit.tsx` (draggable vertical panes) and `AssignmentPane.tsx` (labelled pane + empty state; injects the count caption into the table via `cloneElement`).
- `AlertsTable` / types: optional `heading` caption rendered flush above the column headers.
- **No backend changes** — reuses the existing owner-assignment endpoints/hooks and bulk-assign flow.

## Testing
- Client typechecks clean; eslint + prettier clean.
- Verified end-to-end in a running instance (playground): toggling split, the integrated count captions (Unassigned 428 / Assigned 72), independent per-pane scrolling, and dragging the divider to resize — all confirmed via screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional "Split by Assignment" toggle on the Active alerts tab to display unassigned and assigned alerts in separate side-by-side panes.
  * Implemented draggable divider between alert panes for custom pane sizing.
  * Enhanced alert table headers with optional headings for improved clarity in split view mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->