### PR TITLE
feat: add 'All' alerts tab (active + archived combined)

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -15,7 +15,7 @@ import { useServices } from '@/hooks/queries/services';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Bell, Columns2 } from 'lucide-react';
+import { Archive, Bell, Columns2, LayoutList } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertsFilterPanel } from '.';
@@ -72,7 +72,8 @@ const Alerts = () => {
 	const allAlerts = useMemo(() => [...alerts, ...archivedAlerts], [alerts, archivedAlerts]);
 	const tagKeys = useAlertTagKeys(allAlerts);
 
-	const currentAlertData = activeTab === AlertTab.Active ? alerts : archivedAlerts;
+	const currentAlertData =
+		activeTab === AlertTab.Active ? alerts : activeTab === AlertTab.Archived ? archivedAlerts : allAlerts;
 	const syncedSelectedAlert = useMemo(() => {
 		if (!selectedAlert) return null;
 		const updatedAlert = currentAlertData.find((alert) => alert.id === selectedAlert.id);
@@ -86,7 +87,7 @@ const Alerts = () => {
 		isRefreshing: isRefreshingActive,
 		handleManualRefresh: handleManualRefreshActive,
 	} = useAlertsRefresh(refetch, {
-		shouldPause: shouldPauseRefresh || activeTab !== AlertTab.Active,
+		shouldPause: shouldPauseRefresh || (activeTab !== AlertTab.Active && activeTab !== AlertTab.All),
 	});
 
 	const {
@@ -94,12 +95,25 @@ const Alerts = () => {
 		isRefreshing: isRefreshingArchived,
 		handleManualRefresh: handleManualRefreshArchived,
 	} = useAlertsRefresh(refetchArchived, {
-		shouldPause: shouldPauseRefresh || activeTab !== AlertTab.Archived,
+		shouldPause: shouldPauseRefresh || (activeTab !== AlertTab.Archived && activeTab !== AlertTab.All),
 	});
 
-	const lastRefresh = activeTab === AlertTab.Active ? lastRefreshActive : lastRefreshArchived;
-	const isRefreshing = activeTab === AlertTab.Active ? isRefreshingActive : isRefreshingArchived;
-	const handleManualRefresh = activeTab === AlertTab.Active ? handleManualRefreshActive : handleManualRefreshArchived;
+	const lastRefresh = activeTab === AlertTab.Archived ? lastRefreshArchived : lastRefreshActive;
+	const isRefreshing =
+		activeTab === AlertTab.Active
+			? isRefreshingActive
+			: activeTab === AlertTab.Archived
+				? isRefreshingArchived
+				: isRefreshingActive || isRefreshingArchived;
+	const handleManualRefresh =
+		activeTab === AlertTab.Active
+			? handleManualRefreshActive
+			: activeTab === AlertTab.Archived
+				? handleManualRefreshArchived
+				: () => {
+						handleManualRefreshActive();
+						handleManualRefreshArchived();
+					};
 
 	const { visibleColumns, columnOrder, handleColumnToggle, allColumnLabels, enabledTagKeys } = useColumnManagement({
 		tagKeys,
@@ -171,6 +185,15 @@ const Alerts = () => {
 	// Split the active, filtered alerts by assignment for the side-by-side view.
 	const unassignedAlerts = useMemo(() => filteredAlerts.filter((a) => !a.ownerId), [filteredAlerts]);
 	const assignedAlerts = useMemo(() => filteredAlerts.filter((a) => !!a.ownerId), [filteredAlerts]);
+
+	// Combined "All" view: active alerts followed by archived ones tagged so each row can route
+	// its own actions. archivedIds lets shared callbacks tell which list an alert belongs to.
+	const archivedIds = useMemo(() => new Set(archivedAlerts.map((a) => a.id)), [archivedAlerts]);
+	const filteredAllAlerts = useMemo(
+		() => [...filteredAlerts, ...filteredArchivedAlerts.map((a) => ({ ...a, isArchived: true }))],
+		[filteredAlerts, filteredArchivedAlerts]
+	);
+
 	const { handleDismissAlert, handleUndismissAlert, handleDeleteAlert, handleDismissAll, handleAssignOwnerAll } =
 		useAlertActions();
 	const deleteArchivedAlertMutation = useDeleteArchivedAlert();
@@ -185,6 +208,15 @@ const Alerts = () => {
 
 	const handleDeleteArchivedAlert = async (alertId: string) => {
 		await deleteArchivedAlertMutation.mutateAsync(alertId);
+	};
+
+	// In the combined "All" view, route delete to the right mutation based on the alert's list.
+	const handleDeleteAnyAlert = (alertId: string) => {
+		if (archivedIds.has(alertId)) {
+			void handleDeleteArchivedAlert(alertId);
+		} else {
+			void handleDeleteAlert(alertId);
+		}
 	};
 
 	// Active-tab alerts table, parameterized by the alert list so it can render full-width
@@ -346,11 +378,26 @@ const Alerts = () => {
 										<Archive className="h-4 w-4" />
 										<span>Archived</span>
 									</ToggleGroupItem>
+									<ToggleGroupItem
+										value={AlertTab.All}
+										aria-label="All alerts"
+										size="sm"
+										className="gap-1.5 bg-transparent text-foreground hover:bg-muted hover:text-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground [&_svg]:text-current data-[state=on]:[&_svg]:text-primary-foreground"
+									>
+										<LayoutList className="h-4 w-4" />
+										<span>All</span>
+									</ToggleGroupItem>
 								</ToggleGroup>
 								<span className="text-sm text-muted-foreground whitespace-nowrap">
-									{activeTab === AlertTab.Active
-										? `${filteredAlerts.length} Alert${filteredAlerts.length !== 1 ? 's' : ''}`
-										: `${filteredArchivedAlerts.length} Alert${filteredArchivedAlerts.length !== 1 ? 's' : ''}`}
+									{(() => {
+										const count =
+											activeTab === AlertTab.Active
+												? filteredAlerts.length
+												: activeTab === AlertTab.Archived
+													? filteredArchivedAlerts.length
+													: filteredAllAlerts.length;
+										return `${count} Alert${count !== 1 ? 's' : ''}`;
+									})()}
 								</span>
 
 								<div className="flex-1 min-w-0">
@@ -428,7 +475,7 @@ const Alerts = () => {
 									/>
 								</div>
 							</>
-						) : (
+						) : activeTab === AlertTab.Archived ? (
 							<div
 								className={cn(
 									'flex-1 min-h-0',
@@ -462,19 +509,59 @@ const Alerts = () => {
 									renderToolbar={false}
 								/>
 							</div>
+						) : (
+							<div
+								className={cn(
+									'flex-1 min-h-0',
+									filteredAllAlerts.length === 0 &&
+										!isLoading &&
+										!isLoadingArchived &&
+										'flex items-center justify-center'
+								)}
+							>
+								<AlertsTable
+									alerts={filteredAllAlerts}
+									services={services}
+									onDismissAlert={handleDismissAlert}
+									onUndismissAlert={handleUndismissAlert}
+									onDeleteAlert={handleDeleteAnyAlert}
+									onSelectAlerts={undefined}
+									selectedAlerts={[]}
+									isLoading={isLoading || isLoadingArchived}
+									visibleColumns={visibleColumns}
+									columnOrder={columnOrder}
+									onAlertClick={handleAlertClick}
+									tagKeyColumnLabels={allColumnLabels}
+									groupByColumns={dashboardState.groupBy}
+									onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
+									onColumnToggle={handleColumnToggle}
+									tagKeys={tagKeys}
+									timeRange={dashboardState.timeRange}
+									onTimeRangeChange={(range) => updateDashboardField('timeRange', range)}
+									searchTerm={dashboardState.query}
+									onSearchTermChange={(term) => updateDashboardField('query', term)}
+									renderToolbar={false}
+								/>
+							</div>
 						)}
 					</div>
 
-					{syncedSelectedAlert && (
-						<AlertDetailsPanel
-							alert={syncedSelectedAlert}
-							isActive={activeTab === AlertTab.Active}
-							onClose={() => setSelectedAlert(null)}
-							onDismiss={handleDismissAlert}
-							onUndismiss={handleUndismissAlert}
-							onDelete={activeTab === AlertTab.Active ? handleDeleteAlert : handleDeleteArchivedAlert}
-						/>
-					)}
+					{syncedSelectedAlert &&
+						(() => {
+							const selectedIsArchived =
+								activeTab === AlertTab.Archived ||
+								(activeTab === AlertTab.All && archivedIds.has(syncedSelectedAlert.id));
+							return (
+								<AlertDetailsPanel
+									alert={syncedSelectedAlert}
+									isActive={!selectedIsArchived}
+									onClose={() => setSelectedAlert(null)}
+									onDismiss={handleDismissAlert}
+									onUndismiss={handleUndismissAlert}
+									onDelete={selectedIsArchived ? handleDeleteArchivedAlert : handleDeleteAlert}
+								/>
+							);
+						})()}
 				</div>
 			</div>
 

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertOwnerColumn/AlertOwnerColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertOwnerColumn/AlertOwnerColumn.tsx
@@ -16,7 +16,9 @@ export const AlertOwnerColumn = ({ alert, className, isArchived = false }: Alert
 	const setOwnerMutation = useSetAlertOwner();
 	const setArchivedOwnerMutation = useSetArchivedAlertOwner();
 
-	const mutation = isArchived ? setArchivedOwnerMutation : setOwnerMutation;
+	// Prefer the per-row transient flag (set in the combined "All" view) over the table-level prop.
+	const rowIsArchived = isArchived || Boolean(alert.isArchived);
+	const mutation = rowIsArchived ? setArchivedOwnerMutation : setOwnerMutation;
 
 	const handleOwnerChange = (userId: string | null) => {
 		mutation.mutate({ alertId: alert.id, ownerId: userId });

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
@@ -18,8 +18,13 @@ export interface RowActionsProps {
 
 export const RowActions = ({ alert, onDismissAlert, onUndismissAlert, onDeleteAlert }: RowActionsProps) => {
 	const { alertUrl, runbookUrl, isDismissed } = alert;
-	const isActive = Boolean(onDismissAlert);
-	const canToggle = (!isDismissed && Boolean(onDismissAlert)) || (isDismissed && Boolean(onUndismissAlert));
+	// In the combined "All" view a row carries a transient isArchived flag so it can present
+	// archived behaviour (permanent delete, no dismiss/archive) even though the table-level
+	// callbacks are shared across active and archived rows.
+	const isArchivedAlert = Boolean(alert.isArchived);
+	const isActive = !isArchivedAlert && Boolean(onDismissAlert);
+	const canToggle =
+		!isArchivedAlert && ((!isDismissed && Boolean(onDismissAlert)) || (isDismissed && Boolean(onUndismissAlert)));
 	const hasActions = Boolean(alertUrl || runbookUrl || onDeleteAlert);
 
 	const handleToggle = (event: React.MouseEvent) => {

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -6,6 +6,7 @@ import { ReactNode } from 'react';
 export enum AlertTab {
 	Active = 'active',
 	Archived = 'archived',
+	All = 'all',
 }
 
 export type AlertSortField = string;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -136,6 +136,9 @@ export interface Alert {
 	isDismissed: boolean;
 	// Transient: set at fetch time when an active silence rule matches this alert. Not persisted.
 	isSilenced?: boolean;
+	// Transient: set client-side in the combined "All" view so a row knows it came from the
+	// archived list and can route its own actions. Not persisted.
+	isArchived?: boolean;
 	ownerId?: string | null;
 }
 


### PR DESCRIPTION
Add a third toggle on the Alerts page — Active | Archived | All — where All shows active and archived alerts together in one list.

- transient Alert.isArchived flag tags archived rows in the combined list
- RowActions and AlertOwnerColumn route per-row by isArchived, so archived rows show permanent delete / archived owner mutation while active rows keep archive/dismiss behaviour (backward compatible with the existing tabs)
- delete routes to the right mutation via a Set of archived ids; the detail panel routes its actions by the selected alert's list
- count, filter facets and refresh cover the combined set
- bulk multi-select is disabled in All mode (kept on the dedicated tabs)

No backend changes.

## Issue Reference

<!-- Link to the related issue or ticket, e.g. Closes #123 -->

---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->

---

## Screenshots

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an "All" alerts tab to view active and archived alerts simultaneously
  * Manage, filter, and delete alerts from both states within a unified display

* **Improvements**
  * Alert count displays now accurately reflect the selected tab's filtered alerts
  * Unified refresh behavior and status indicators across all alert views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->