### PR TITLE
feat: alert enrichment — rules that add fields / rewrite summaries on matching alerts

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -65,6 +65,7 @@
 		"cmdk": "^1.0.0",
 		"d3-hierarchy": "^3.1.2",
 		"date-fns": "^3.6.0",
+		"dompurify": "^3.4.10",
 		"embla-carousel-react": "^8.3.0",
 		"express": "^5.1.0",
 		"framer-motion": "^10.18.0",

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -7,7 +7,18 @@ import { Toaster as Sonner } from '@/components/ui/sonner';
 import { Toaster } from '@/components/ui/toaster';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { DashboardProvider, useDashboard } from '@/context/DashboardContext';
-import { Actions, AlertsTVMode, Integrations, Login, NotFound, Register, Settings, Silences, TVMode } from '@/pages';
+import {
+	Actions,
+	AlertsTVMode,
+	Enrichments,
+	Integrations,
+	Login,
+	NotFound,
+	Register,
+	Settings,
+	Silences,
+	TVMode,
+} from '@/pages';
 import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
@@ -59,6 +70,7 @@ const App: React.FC = () => {
 										<Route path="/alerts" element={<Alerts />} />
 										<Route path="/silences" element={<Silences />} />
 										<Route path="/actions" element={<Actions />} />
+										<Route path="/enrichments" element={<Enrichments />} />
 										<Route path="/alerts/tv-mode" element={<AlertsTVMode />} />
 										<Route path="/forgot-password" element={<ForgotPassword />} />
 										<Route path="/reset-password" element={<ResetPasswordByEmail />} />

--- a/apps/client/src/components/Alerts/AlertDetails/AlertSummarySection/AlertSummarySection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertSummarySection/AlertSummarySection.tsx
@@ -1,5 +1,5 @@
+import { FormattedText } from '@/components/shared';
 import { Separator } from '@/components/ui/separator';
-import { Alert } from '@OpsiMate/shared';
 
 interface AlertSummarySectionProps {
 	summary: string;
@@ -10,7 +10,7 @@ export const AlertSummarySection = ({ summary }: AlertSummarySectionProps) => {
 		<>
 			<Separator />
 			<div>
-				<p className="text-sm text-foreground leading-relaxed">{summary}</p>
+				<FormattedText text={summary} className="text-sm text-foreground leading-relaxed" />
 			</div>
 		</>
 	);

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSummaryColumn/AlertSummaryColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSummaryColumn/AlertSummaryColumn.tsx
@@ -1,3 +1,4 @@
+import { stripHtml } from '@/components/shared';
 import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
@@ -8,9 +9,13 @@ export interface AlertSummaryColumnProps {
 }
 
 export const AlertSummaryColumn = ({ alert, className }: AlertSummaryColumnProps) => {
+	// The cell is a single truncated line, so render formatted summaries as plain text here;
+	// the full formatting shows in the details panel.
 	return (
 		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
-			<span className="text-sm text-foreground truncate block">{alert.summary || '-'}</span>
+			<span className="text-sm text-foreground truncate block">
+				{alert.summary ? stripHtml(alert.summary) : '-'}
+			</span>
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -1,0 +1,292 @@
+import { Button } from '@/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { useCreateEnrichment, useUpdateEnrichment } from '@/hooks/queries/enrichments';
+import { EnrichmentPayload } from '@/lib/api';
+import { AlertEnrichment } from '@OpsiMate/shared';
+import { Plus, Sparkles, Tag, Trash2, Wand2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+type KeyValue = { key: string; value: string };
+
+interface EnrichmentFormDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	enrichment?: AlertEnrichment | null;
+}
+
+const KeyValueRows = ({
+	rows,
+	onChange,
+	keyPlaceholder,
+	valuePlaceholder,
+	emptyText,
+	addLabel,
+}: {
+	rows: KeyValue[];
+	onChange: (rows: KeyValue[]) => void;
+	keyPlaceholder: string;
+	valuePlaceholder: string;
+	emptyText: string;
+	addLabel: string;
+}) => (
+	<div className="space-y-2">
+		<div className="flex items-center justify-between">
+			<Label className="text-xs">{addLabel}</Label>
+			<Button
+				type="button"
+				variant="outline"
+				size="sm"
+				onClick={() => onChange([...rows, { key: '', value: '' }])}
+			>
+				<Plus className="h-3.5 w-3.5 mr-1" /> Add
+			</Button>
+		</div>
+		{rows.length === 0 ? (
+			<p className="text-xs text-muted-foreground italic">{emptyText}</p>
+		) : (
+			<div className="space-y-2">
+				{rows.map((row, idx) => (
+					<div key={idx} className="grid grid-cols-[1fr_auto_1fr_auto] items-center gap-2">
+						<Input
+							placeholder={keyPlaceholder}
+							value={row.key}
+							onChange={(e) =>
+								onChange(rows.map((r, i) => (i === idx ? { ...r, key: e.target.value } : r)))
+							}
+						/>
+						<span className="text-muted-foreground text-sm">=</span>
+						<Input
+							placeholder={valuePlaceholder}
+							value={row.value}
+							onChange={(e) =>
+								onChange(rows.map((r, i) => (i === idx ? { ...r, value: e.target.value } : r)))
+							}
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="h-9 w-9"
+							onClick={() => onChange(rows.filter((_, i) => i !== idx))}
+							aria-label="Remove row"
+						>
+							<Trash2 className="h-4 w-4" />
+						</Button>
+					</div>
+				))}
+			</div>
+		)}
+	</div>
+);
+
+export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment }: EnrichmentFormDialogProps) => {
+	const isEdit = !!enrichment;
+	const { toast } = useToast();
+	const createMutation = useCreateEnrichment();
+	const updateMutation = useUpdateEnrichment();
+
+	const [name, setName] = useState('');
+	const [nameContains, setNameContains] = useState('');
+	const [matchers, setMatchers] = useState<KeyValue[]>([]);
+	const [addFields, setAddFields] = useState<KeyValue[]>([]);
+	const [summaryTemplate, setSummaryTemplate] = useState('');
+	const [priority, setPriority] = useState('0');
+
+	useEffect(() => {
+		if (!open) return;
+		if (enrichment) {
+			setName(enrichment.name);
+			setNameContains(enrichment.nameContains ?? '');
+			setMatchers((enrichment.labelMatchers ?? []).map((m) => ({ ...m })));
+			setAddFields((enrichment.addFields ?? []).map((f) => ({ ...f })));
+			setSummaryTemplate(enrichment.summaryTemplate ?? '');
+			setPriority(String(enrichment.priority ?? 0));
+		} else {
+			setName('');
+			setNameContains('');
+			setMatchers([]);
+			setAddFields([]);
+			setSummaryTemplate('');
+			setPriority('0');
+		}
+	}, [open, enrichment]);
+
+	const isValid = useMemo(() => {
+		if (!name.trim()) return false;
+		const hasNameMatcher = nameContains.trim().length > 0;
+		const hasLabelMatchers = matchers.some((m) => m.key.trim() && m.value.trim());
+		if (!hasNameMatcher && !hasLabelMatchers) return false;
+		const hasFields = addFields.some((f) => f.key.trim() && f.value.trim());
+		const hasSummary = summaryTemplate.trim().length > 0;
+		return hasFields || hasSummary;
+	}, [name, nameContains, matchers, addFields, summaryTemplate]);
+
+	const submit = async () => {
+		const clean = (rows: KeyValue[]) =>
+			rows.map((r) => ({ key: r.key.trim(), value: r.value.trim() })).filter((r) => r.key && r.value);
+
+		const payload: EnrichmentPayload = {
+			name: name.trim(),
+			nameContains: nameContains.trim() || null,
+			labelMatchers: clean(matchers),
+			addFields: clean(addFields),
+			summaryTemplate: summaryTemplate.trim() || null,
+			priority: Math.max(0, Math.min(1000, parseInt(priority, 10) || 0)),
+		};
+
+		try {
+			if (isEdit && enrichment) {
+				await updateMutation.mutateAsync({ id: enrichment.id, payload });
+				toast({ title: 'Enrichment updated', description: payload.name });
+			} else {
+				await createMutation.mutateAsync(payload);
+				toast({ title: 'Enrichment created', description: payload.name });
+			}
+			onOpenChange(false);
+		} catch (err) {
+			toast({
+				title: isEdit ? 'Failed to update enrichment' : 'Failed to create enrichment',
+				description: err instanceof Error ? err.message : 'Unknown error',
+				variant: 'destructive',
+			});
+		}
+	};
+
+	const isPending = createMutation.isPending || updateMutation.isPending;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<Sparkles className="h-5 w-5 text-muted-foreground" />
+						{isEdit ? 'Edit enrichment' : 'New enrichment'}
+					</DialogTitle>
+					<DialogDescription>
+						Automatically add fields or rewrite the summary of alerts that match the criteria below. Applied
+						live whenever alerts are fetched.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-5 py-2">
+					<div className="grid grid-cols-[1fr_140px] gap-4">
+						<div className="space-y-2">
+							<Label htmlFor="enrichment-name">Name</Label>
+							<Input
+								id="enrichment-name"
+								placeholder="e.g. Tag disk alerts"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="enrichment-priority">Priority</Label>
+							<Input
+								id="enrichment-priority"
+								type="number"
+								min={0}
+								max={1000}
+								value={priority}
+								onChange={(e) => setPriority(e.target.value)}
+							/>
+						</div>
+					</div>
+					<p className="text-xs text-muted-foreground -mt-3">
+						When an alert matches several rules, they run from the highest priority to the lowest (e.g.
+						priority 10 runs before 7). If two rules set the same field, the higher-priority rule wins;
+						summary templates chain in that order, each seeing the previous result.
+					</p>
+
+					<div className="rounded-lg border bg-muted/30 p-4 space-y-4">
+						<div className="flex items-center gap-2">
+							<Tag className="h-4 w-4 text-muted-foreground" />
+							<h4 className="text-sm font-semibold">Match criteria</h4>
+						</div>
+						<p className="text-xs text-muted-foreground -mt-2">
+							An alert is enriched when its name matches and ALL labels match. At least one criterion is
+							required.
+						</p>
+
+						<div className="space-y-2">
+							<Label htmlFor="enrichment-nameContains" className="text-xs">
+								Alert name contains
+							</Label>
+							<Input
+								id="enrichment-nameContains"
+								placeholder="e.g. Disk, HighCPU, prod-db"
+								value={nameContains}
+								onChange={(e) => setNameContains(e.target.value)}
+							/>
+						</div>
+
+						<KeyValueRows
+							rows={matchers}
+							onChange={setMatchers}
+							keyPlaceholder="key (e.g. severity)"
+							valuePlaceholder="value (e.g. critical)"
+							emptyText="No label matchers. Use these to scope by environment, service, severity, etc."
+							addLabel="Label matchers (key = value)"
+						/>
+					</div>
+
+					<div className="rounded-lg border bg-muted/30 p-4 space-y-4">
+						<div className="flex items-center gap-2">
+							<Wand2 className="h-4 w-4 text-muted-foreground" />
+							<h4 className="text-sm font-semibold">Enrichment</h4>
+						</div>
+						<p className="text-xs text-muted-foreground -mt-2">
+							What to change on matching alerts. At least one field or a summary template is required.
+						</p>
+
+						<KeyValueRows
+							rows={addFields}
+							onChange={setAddFields}
+							keyPlaceholder="field (e.g. disk_alert)"
+							valuePlaceholder="value (e.g. true)"
+							emptyText="No fields. Added as tags on the alert; existing keys are overridden."
+							addLabel="Fields to add / override"
+						/>
+
+						<div className="space-y-2">
+							<Label htmlFor="enrichment-summary" className="text-xs">
+								Summary template (optional)
+							</Label>
+							<Textarea
+								id="enrichment-summary"
+								placeholder="e.g. {{summary}} — contact the help desk, the disk is full"
+								value={summaryTemplate}
+								onChange={(e) => setSummaryTemplate(e.target.value)}
+								rows={3}
+							/>
+							<p className="text-xs text-muted-foreground">
+								Replaces the alert summary. Use {'{{summary}}'} for the current summary, plus{' '}
+								{'{{name}}'} and {'{{status}}'}. New lines and basic HTML ({'<b>'}, {'<a>'}, lists) are
+								rendered in the alert details.
+							</p>
+						</div>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+						Cancel
+					</Button>
+					<Button onClick={submit} disabled={!isValid || isPending}>
+						{isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create enrichment'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/client/src/components/LeftSidebar.tsx
+++ b/apps/client/src/components/LeftSidebar.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Bell, BellOff, LayoutDashboard, Puzzle, Settings, Zap } from 'lucide-react';
+import { Bell, BellOff, LayoutDashboard, Puzzle, Settings, Sparkles, Zap } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
 import { isAdmin, isEditor } from '../lib/auth';
 import { AppIcon } from './icons/AppIcon';
@@ -86,6 +86,17 @@ export const LeftSidebar = ({ collapsed }: LeftSidebarProps) => {
 					<PreserveQueryLink to="/actions">
 						<Zap className="h-5 w-5 flex-shrink-0" />
 						<span className={cn('font-medium', collapsed && 'sr-only')}>Actions</span>
+					</PreserveQueryLink>
+				</Button>
+
+				<Button
+					variant={location.pathname === '/enrichments' ? 'default' : 'ghost'}
+					className={cn('gap-3 h-10', collapsed ? 'w-10 justify-center p-0' : 'w-full justify-start px-3')}
+					asChild
+				>
+					<PreserveQueryLink to="/enrichments">
+						<Sparkles className="h-5 w-5 flex-shrink-0" />
+						<span className={cn('font-medium', collapsed && 'sr-only')}>Enrichment</span>
 					</PreserveQueryLink>
 				</Button>
 			</div>

--- a/apps/client/src/components/shared/FormattedText.tsx
+++ b/apps/client/src/components/shared/FormattedText.tsx
@@ -1,0 +1,78 @@
+import { cn } from '@/lib/utils';
+import DOMPurify from 'dompurify';
+
+// Safe subset of HTML allowed in user/integration-provided text (alert summaries,
+// enrichment templates). Everything else — scripts, event handlers, iframes — is stripped.
+const SANITIZE_CONFIG: DOMPurify.Config = {
+	ALLOWED_TAGS: [
+		'a',
+		'b',
+		'i',
+		'em',
+		'strong',
+		'u',
+		's',
+		'p',
+		'br',
+		'hr',
+		'div',
+		'span',
+		'ul',
+		'ol',
+		'li',
+		'code',
+		'pre',
+		'blockquote',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+	],
+	ALLOWED_ATTR: ['href', 'target', 'rel'],
+};
+
+// Links open in a new tab and can't reach back into the opener.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+	if (node.tagName === 'A') {
+		node.setAttribute('target', '_blank');
+		node.setAttribute('rel', 'noopener noreferrer');
+	}
+});
+
+const HTML_TAG_REGEX = /<\/?[a-z][\s\S]*?>/i;
+
+export const containsHtml = (text: string): boolean => HTML_TAG_REGEX.test(text);
+
+// Plain-text version of possibly-HTML content, for single-line contexts like table cells.
+export const stripHtml = (text: string): string => {
+	if (!containsHtml(text)) return text;
+	const sanitized = DOMPurify.sanitize(text, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+	return sanitized.replace(/\s+/g, ' ').trim();
+};
+
+interface FormattedTextProps {
+	text: string;
+	className?: string;
+}
+
+// Renders user/integration-provided text with formatting: newlines are preserved, and a safe
+// subset of HTML (bold, links, lists, ...) is rendered after sanitization.
+export const FormattedText = ({ text, className }: FormattedTextProps) => {
+	if (!containsHtml(text)) {
+		return <div className={cn('whitespace-pre-line break-words', className)}>{text}</div>;
+	}
+	const safe = DOMPurify.sanitize(text, SANITIZE_CONFIG);
+	return (
+		<div
+			className={cn(
+				'whitespace-pre-line break-words',
+				'[&_a]:text-primary [&_a]:underline [&_ul]:list-disc [&_ol]:list-decimal [&_ul]:pl-5 [&_ol]:pl-5',
+				'[&_code]:bg-muted [&_code]:px-1 [&_code]:rounded [&_code]:font-mono [&_code]:text-xs',
+				'[&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_h4]:text-sm [&_h4]:font-semibold',
+				className
+			)}
+			// Safe: content is sanitized by DOMPurify with an explicit allow-list just above.
+			dangerouslySetInnerHTML={{ __html: safe }}
+		/>
+	);
+};

--- a/apps/client/src/components/shared/index.ts
+++ b/apps/client/src/components/shared/index.ts
@@ -1,5 +1,6 @@
 export { ColumnSettingsModal } from './ColumnSettingsModal';
 export { FilterPanel } from './FilterPanel';
+export { FormattedText, stripHtml, containsHtml } from './FormattedText';
 export type { ActiveFilters, FilterFacet, FilterFacets, FilterPanelConfig } from './FilterPanel';
 export { FilterSidebar } from './FilterSidebar';
 export { UnsavedChangesDialog } from './UnsavedChangesDialog';

--- a/apps/client/src/hooks/queries/enrichments/index.ts
+++ b/apps/client/src/hooks/queries/enrichments/index.ts
@@ -1,0 +1,1 @@
+export { useEnrichments, useCreateEnrichment, useUpdateEnrichment, useDeleteEnrichment } from './useEnrichments';

--- a/apps/client/src/hooks/queries/enrichments/useEnrichments.ts
+++ b/apps/client/src/hooks/queries/enrichments/useEnrichments.ts
@@ -1,0 +1,67 @@
+import { enrichmentsApi, EnrichmentPayload } from '@/lib/api';
+import { AlertEnrichment } from '@OpsiMate/shared';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+export const useEnrichments = () => {
+	return useQuery({
+		queryKey: queryKeys.enrichments,
+		queryFn: async (): Promise<AlertEnrichment[]> => {
+			const response = await enrichmentsApi.listEnrichments();
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to fetch enrichments');
+			}
+			return response.data || [];
+		},
+	});
+};
+
+export const useCreateEnrichment = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (payload: EnrichmentPayload) => {
+			const response = await enrichmentsApi.createEnrichment(payload);
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to create enrichment');
+			}
+			return response.data;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.enrichments });
+			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+		},
+	});
+};
+
+export const useUpdateEnrichment = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({ id, payload }: { id: number; payload: Partial<EnrichmentPayload> }) => {
+			const response = await enrichmentsApi.updateEnrichment(id, payload);
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to update enrichment');
+			}
+			return response.data;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.enrichments });
+			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+		},
+	});
+};
+
+export const useDeleteEnrichment = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (id: number) => {
+			const response = await enrichmentsApi.deleteEnrichment(id);
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to delete enrichment');
+			}
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.enrichments });
+			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+		},
+	});
+};

--- a/apps/client/src/hooks/queries/index.ts
+++ b/apps/client/src/hooks/queries/index.ts
@@ -10,6 +10,7 @@ export * from './audit';
 export * from './custom-fields';
 export * from './custom-actions';
 export * from './silences';
+export * from './enrichments';
 export * from './actions';
 
 // Export query keys

--- a/apps/client/src/hooks/queries/queryKeys.ts
+++ b/apps/client/src/hooks/queries/queryKeys.ts
@@ -20,5 +20,6 @@ export const queryKeys = {
 	dashboards: ['dashboards'] as const,
 	dashboardTags: ['dashboardTags'] as const,
 	silences: ['silences'] as const,
+	enrichments: ['enrichments'] as const,
 	actions: ['actions'] as const,
 };

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -8,6 +8,7 @@ import {
 	ActionTestResult,
 	ActionType,
 	AlertHistory,
+	AlertEnrichment,
 	AlertSilence,
 	AuditLog,
 	DiscoveredService,
@@ -627,6 +628,24 @@ export const silencesApi = {
 	updateSilence: (id: number, payload: Partial<SilencePayload>) =>
 		apiRequest<AlertSilence>(`/silences/${id}`, 'PUT', payload),
 	deleteSilence: (id: number) => apiRequest<void>(`/silences/${id}`, 'DELETE'),
+};
+
+export type EnrichmentPayload = {
+	name: string;
+	nameContains?: string | null;
+	labelMatchers?: { key: string; value: string }[];
+	addFields?: { key: string; value: string }[];
+	summaryTemplate?: string | null;
+	priority?: number;
+};
+
+export const enrichmentsApi = {
+	listEnrichments: () => apiRequest<AlertEnrichment[]>('/enrichments'),
+	getEnrichment: (id: number) => apiRequest<AlertEnrichment>(`/enrichments/${id}`),
+	createEnrichment: (payload: EnrichmentPayload) => apiRequest<AlertEnrichment>('/enrichments', 'POST', payload),
+	updateEnrichment: (id: number, payload: Partial<EnrichmentPayload>) =>
+		apiRequest<AlertEnrichment>(`/enrichments/${id}`, 'PUT', payload),
+	deleteEnrichment: (id: number) => apiRequest<void>(`/enrichments/${id}`, 'DELETE'),
 };
 
 export type ActionPayload = {

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -1,0 +1,273 @@
+import { DashboardLayout } from '@/components/DashboardLayout';
+import { EnrichmentFormDialog } from '@/components/Enrichments/EnrichmentFormDialog';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useToast } from '@/hooks/use-toast';
+import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
+import { AlertEnrichment } from '@OpsiMate/shared';
+import { FileText, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+const MatchBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
+	<div className="flex flex-wrap gap-1.5">
+		{enrichment.nameContains && (
+			<Badge variant="secondary" className="font-mono text-xs">
+				name ~ "{enrichment.nameContains}"
+			</Badge>
+		)}
+		{(enrichment.labelMatchers ?? []).map((m, idx) => (
+			<Badge key={idx} variant="outline" className="font-mono text-xs">
+				{m.key}={m.value}
+			</Badge>
+		))}
+		{!enrichment.nameContains && (enrichment.labelMatchers ?? []).length === 0 && (
+			<span className="text-xs text-muted-foreground italic">no matchers</span>
+		)}
+	</div>
+);
+
+const EffectBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
+	<div className="flex flex-wrap gap-1.5">
+		{(enrichment.addFields ?? []).map((f, idx) => (
+			<Badge
+				key={idx}
+				variant="outline"
+				className="font-mono text-xs bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30"
+			>
+				+{f.key}={f.value}
+			</Badge>
+		))}
+		{enrichment.summaryTemplate && (
+			<Badge
+				variant="outline"
+				className="text-xs bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30 max-w-[260px]"
+			>
+				<FileText className="h-3 w-3 mr-1 flex-shrink-0" />
+				<span className="truncate">summary: {enrichment.summaryTemplate}</span>
+			</Badge>
+		)}
+	</div>
+);
+
+const Enrichments: React.FC = () => {
+	const { data: enrichments = [], isLoading } = useEnrichments();
+	const deleteMutation = useDeleteEnrichment();
+	const { toast } = useToast();
+
+	const [search, setSearch] = useState('');
+	const [editing, setEditing] = useState<AlertEnrichment | null>(null);
+	const [creating, setCreating] = useState(false);
+	const [deleting, setDeleting] = useState<AlertEnrichment | null>(null);
+
+	const filtered = useMemo(() => {
+		// Display in execution order: highest priority first, ties by creation order.
+		const ranked = [...enrichments].sort((a, b) => b.priority - a.priority || a.id - b.id);
+		if (!search.trim()) return ranked;
+		const q = search.toLowerCase();
+		return ranked.filter((e) => {
+			if (e.name.toLowerCase().includes(q)) return true;
+			if (e.nameContains?.toLowerCase().includes(q)) return true;
+			if (e.summaryTemplate?.toLowerCase().includes(q)) return true;
+			if (e.labelMatchers?.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q)))
+				return true;
+			return e.addFields?.some((f) => f.key.toLowerCase().includes(q) || f.value.toLowerCase().includes(q));
+		});
+	}, [enrichments, search]);
+
+	const handleDelete = async () => {
+		if (!deleting) return;
+		try {
+			await deleteMutation.mutateAsync(deleting.id);
+			toast({ title: 'Enrichment deleted', description: deleting.name });
+			setDeleting(null);
+		} catch (err) {
+			toast({
+				title: 'Failed to delete enrichment',
+				description: err instanceof Error ? err.message : 'Unknown error',
+				variant: 'destructive',
+			});
+		}
+	};
+
+	return (
+		<DashboardLayout>
+			<div className="container max-w-6xl mx-auto px-4 sm:px-6 py-6 space-y-6">
+				<div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+					<div>
+						<div className="flex items-center gap-2">
+							<Sparkles className="h-6 w-6 text-muted-foreground" />
+							<h1 className="text-2xl font-semibold tracking-tight">Enrichment</h1>
+						</div>
+						<p className="text-sm text-muted-foreground mt-1">
+							Automatically add fields or rewrite the summary of matching alerts — e.g. tag every "Disk"
+							alert with disk_alert=true and append help-desk instructions to its summary. Rules run in
+							priority order (highest first); on conflicts the higher-priority rule wins.
+						</p>
+					</div>
+					<Button onClick={() => setCreating(true)}>
+						<Plus className="h-4 w-4 mr-1" /> New enrichment
+					</Button>
+				</div>
+
+				<Card>
+					<CardContent className="p-0">
+						<div className="flex items-center gap-2 p-4 border-b">
+							<div className="relative flex-1 max-w-md">
+								<Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+								<Input
+									className="pl-9"
+									placeholder="Search by name, match, or field"
+									value={search}
+									onChange={(e) => setSearch(e.target.value)}
+								/>
+							</div>
+							<div className="ml-auto text-xs text-muted-foreground">
+								{filtered.length} of {enrichments.length}
+							</div>
+						</div>
+
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Name</TableHead>
+									<TableHead className="w-[90px]">Priority</TableHead>
+									<TableHead>Match</TableHead>
+									<TableHead>Enrichment</TableHead>
+									<TableHead className="text-right">Actions</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{isLoading ? (
+									<TableRow>
+										<TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+											Loading enrichments…
+										</TableCell>
+									</TableRow>
+								) : filtered.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={5} className="py-12">
+											<div className="flex flex-col items-center gap-2 text-center">
+												<div className="h-12 w-12 rounded-full bg-muted flex items-center justify-center">
+													<Sparkles className="h-6 w-6 text-muted-foreground" />
+												</div>
+												<p className="font-medium">
+													{enrichments.length === 0
+														? 'No enrichments yet'
+														: 'No enrichments match your search'}
+												</p>
+												<p className="text-sm text-muted-foreground max-w-sm">
+													{enrichments.length === 0
+														? 'Create a rule to automatically add fields or rewrite summaries on matching alerts.'
+														: 'Try a different search term.'}
+												</p>
+												{enrichments.length === 0 && (
+													<Button
+														className="mt-2"
+														onClick={() => setCreating(true)}
+														size="sm"
+													>
+														<Plus className="h-4 w-4 mr-1" /> New enrichment
+													</Button>
+												)}
+											</div>
+										</TableCell>
+									</TableRow>
+								) : (
+									filtered.map((e) => (
+										<TableRow key={e.id} className="align-top">
+											<TableCell className="max-w-[220px]">
+												<div className="font-medium truncate">{e.name}</div>
+											</TableCell>
+											<TableCell>
+												<Badge variant="secondary" className="font-mono text-xs">
+													{e.priority}
+												</Badge>
+											</TableCell>
+											<TableCell className="max-w-[260px]">
+												<MatchBadges enrichment={e} />
+											</TableCell>
+											<TableCell className="max-w-[340px]">
+												<EffectBadges enrichment={e} />
+											</TableCell>
+											<TableCell className="text-right">
+												<div className="flex items-center justify-end gap-1">
+													<Button
+														variant="ghost"
+														size="icon"
+														className="h-8 w-8"
+														onClick={() => setEditing(e)}
+														aria-label="Edit enrichment"
+													>
+														<Pencil className="h-4 w-4" />
+													</Button>
+													<Button
+														variant="ghost"
+														size="icon"
+														className="h-8 w-8 text-destructive hover:text-destructive"
+														onClick={() => setDeleting(e)}
+														aria-label="Delete enrichment"
+													>
+														<Trash2 className="h-4 w-4" />
+													</Button>
+												</div>
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</CardContent>
+				</Card>
+			</div>
+
+			<EnrichmentFormDialog open={creating} onOpenChange={setCreating} />
+			<EnrichmentFormDialog
+				open={!!editing}
+				onOpenChange={(open) => {
+					if (!open) setEditing(null);
+				}}
+				enrichment={editing}
+			/>
+
+			<AlertDialog open={!!deleting} onOpenChange={(open) => !open && setDeleting(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete enrichment?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will remove "{deleting?.name}". Matching alerts will immediately stop being enriched.
+							This cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={(e) => {
+								e.preventDefault();
+								handleDelete();
+							}}
+							disabled={deleteMutation.isPending}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							{deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</DashboardLayout>
+	);
+};
+
+export default Enrichments;

--- a/apps/client/src/pages/index.ts
+++ b/apps/client/src/pages/index.ts
@@ -2,6 +2,7 @@ export { default as Actions } from './Actions';
 export { Alerts } from '../components/Alerts';
 export { default as AlertsTVMode } from '../components/Alerts/AlertsTVMode';
 export { Dashboards } from '../components/Dashboards';
+export { default as Enrichments } from './Enrichments';
 export { default as Integrations } from './Integrations';
 export { default as Login } from './Login';
 export { default as NotFound } from './NotFound';

--- a/apps/server/src/api/v1/enrichments/controller.ts
+++ b/apps/server/src/api/v1/enrichments/controller.ts
@@ -1,0 +1,102 @@
+import { Request, Response } from 'express';
+import {
+	AlertEnrichmentIdSchema,
+	CreateAlertEnrichmentSchema,
+	Logger,
+	UpdateAlertEnrichmentSchema,
+} from '@OpsiMate/shared';
+import { EnrichmentBL } from '../../../bl/enrichments/enrichment.bl';
+import { isZodError } from '../../../utils/isZodError';
+
+const logger = new Logger('api/v1/enrichments/controller');
+
+export class EnrichmentController {
+	constructor(private enrichmentBL: EnrichmentBL) {}
+
+	listHandler = async (_req: Request, res: Response) => {
+		try {
+			const enrichments = await this.enrichmentBL.list();
+			return res.json({ success: true, data: enrichments });
+		} catch (error) {
+			logger.error('Error listing enrichments', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	getHandler = async (req: Request, res: Response) => {
+		try {
+			const { enrichmentId } = AlertEnrichmentIdSchema.parse({ enrichmentId: req.params.enrichmentId });
+			const enrichment = await this.enrichmentBL.get(enrichmentId);
+			if (!enrichment) {
+				return res.status(404).json({ success: false, error: 'Enrichment not found' });
+			}
+			return res.json({ success: true, data: enrichment });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error getting enrichment', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	createHandler = async (req: Request, res: Response) => {
+		try {
+			const data = CreateAlertEnrichmentSchema.parse(req.body);
+			const enrichment = await this.enrichmentBL.create({
+				name: data.name,
+				nameContains: data.nameContains ?? null,
+				labelMatchers: data.labelMatchers ?? [],
+				addFields: data.addFields ?? [],
+				summaryTemplate: data.summaryTemplate ?? null,
+				priority: data.priority ?? 0,
+			});
+			return res.status(201).json({ success: true, data: enrichment, message: 'Enrichment created' });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error creating enrichment', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	updateHandler = async (req: Request, res: Response) => {
+		try {
+			const { enrichmentId } = AlertEnrichmentIdSchema.parse({ enrichmentId: req.params.enrichmentId });
+			const data = UpdateAlertEnrichmentSchema.parse(req.body);
+
+			const existing = await this.enrichmentBL.get(enrichmentId);
+			if (!existing) {
+				return res.status(404).json({ success: false, error: 'Enrichment not found' });
+			}
+
+			const updated = await this.enrichmentBL.update(enrichmentId, data);
+			return res.json({ success: true, data: updated, message: 'Enrichment updated' });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error updating enrichment', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	deleteHandler = async (req: Request, res: Response) => {
+		try {
+			const { enrichmentId } = AlertEnrichmentIdSchema.parse({ enrichmentId: req.params.enrichmentId });
+			const existing = await this.enrichmentBL.get(enrichmentId);
+			if (!existing) {
+				return res.status(404).json({ success: false, error: 'Enrichment not found' });
+			}
+			await this.enrichmentBL.delete(enrichmentId);
+			return res.json({ success: true, message: 'Enrichment deleted' });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error deleting enrichment', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+}

--- a/apps/server/src/api/v1/enrichments/router.ts
+++ b/apps/server/src/api/v1/enrichments/router.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import PromiseRouter from 'express-promise-router';
+import { EnrichmentController } from './controller';
+
+export default function createEnrichmentRouter(enrichmentController: EnrichmentController) {
+	const router = PromiseRouter();
+
+	router.get('/', enrichmentController.listHandler);
+	router.post('/', enrichmentController.createHandler);
+	router.get('/:enrichmentId', enrichmentController.getHandler);
+	router.put('/:enrichmentId', enrichmentController.updateHandler);
+	router.delete('/:enrichmentId', enrichmentController.deleteHandler);
+
+	return router;
+}

--- a/apps/server/src/api/v1/v1.ts
+++ b/apps/server/src/api/v1/v1.ts
@@ -23,6 +23,8 @@ import { SecretsController } from './secrets/controller';
 import createSecretsRouter from './secrets/router';
 import { ServiceController } from './services/controller';
 import serviceRouter from './services/router';
+import { EnrichmentController } from './enrichments/controller';
+import createEnrichmentRouter from './enrichments/router';
 import { SilenceController } from './silences/controller';
 import createSilenceRouter from './silences/router';
 import { TagController } from './tags/controller';
@@ -44,6 +46,7 @@ export default function createV1Router(
 	customActionsController: CustomActionsController,
 	playgroundController: PlaygroundController,
 	silenceController: SilenceController,
+	enrichmentController: EnrichmentController,
 	actionController: ActionController
 ) {
 	const router = PromiseRouter();
@@ -71,6 +74,7 @@ export default function createV1Router(
 	router.use('/custom-fields', createCustomFieldsRouter(customFieldsController));
 	router.use('/custom-actions', createCustomActionsRouter(customActionsController));
 	router.use('/silences', createSilenceRouter(silenceController));
+	router.use('/enrichments', createEnrichmentRouter(enrichmentController));
 	router.use('/actions', createActionRouter(actionController));
 	// All other /users endpoints (except /register and /login) are protected
 	router.use('/users', usersRouter(usersController));

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -13,6 +13,7 @@ import { PlaygroundController } from './api/v1/playground/controller';
 import { ProviderController } from './api/v1/providers/controller';
 import { SecretsController } from './api/v1/secrets/controller';
 import { ServiceController } from './api/v1/services/controller';
+import { EnrichmentController } from './api/v1/enrichments/controller';
 import { SilenceController } from './api/v1/silences/controller';
 import { TagController } from './api/v1/tags/controller';
 import { UsersController } from './api/v1/users/controller';
@@ -27,6 +28,7 @@ import { IntegrationBL } from './bl/integrations/integration.bl';
 import { ProviderBL } from './bl/providers/provider.bl';
 import { SecretsMetadataBL } from './bl/secrets/secretsMetadata.bl';
 import { ServicesBL } from './bl/services/services.bl';
+import { EnrichmentBL } from './bl/enrichments/enrichment.bl';
 import { SilenceBL } from './bl/silences/silence.bl';
 import { TagBL } from './bl/tags/tag.bl';
 import { UserBL } from './bl/users/user.bl';
@@ -45,6 +47,7 @@ import { SecretsMetadataRepository } from './dal/secretsMetadataRepository';
 import { ServiceCustomFieldRepository } from './dal/serviceCustomFieldRepository';
 import { ServiceCustomFieldValueRepository } from './dal/serviceCustomFieldValueRepository';
 import { ServiceRepository } from './dal/serviceRepository';
+import { EnrichmentRepository } from './dal/enrichmentRepository';
 import { SilenceRepository } from './dal/silenceRepository';
 import { TagRepository } from './dal/tagRepository';
 import { UserRepository } from './dal/userRepository';
@@ -122,6 +125,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const customActionRepo = new CustomActionRepository(db);
 	const playgroundRepo = new PlaygroundRepository(db);
 	const silenceRepo = new SilenceRepository(db);
+	const enrichmentRepo = new EnrichmentRepository(db);
 	const actionRepo = new ActionRepository(db);
 
 	// Initialize Mail Service
@@ -139,6 +143,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 		customActionRepo.initCustomActionsTable(),
 		playgroundRepo.initPlaygroundTable(),
 		silenceRepo.initSilencesTable(),
+		enrichmentRepo.initEnrichmentsTable(),
 		actionRepo.initActionsTable(),
 	]);
 
@@ -153,6 +158,8 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const playgroundBL = new PlaygroundBL(playgroundRepo, mailClient);
 	const silenceBL = new SilenceBL(silenceRepo);
 	alertBL.setSilenceBL(silenceBL);
+	const enrichmentBL = new EnrichmentBL(enrichmentRepo);
+	alertBL.setEnrichmentBL(enrichmentBL);
 	const actionBL = new ActionBL(actionRepo);
 
 	// Controllers (only for SERVER)
@@ -176,6 +183,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const customActionsController = new CustomActionsController(customActionBL);
 	const playgroundController = new PlaygroundController(playgroundBL);
 	const silenceController = new SilenceController(silenceBL);
+	const enrichmentController = new EnrichmentController(enrichmentBL);
 	const actionController = new ActionController(actionBL);
 
 	// Routes (only for SERVER)
@@ -196,6 +204,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 			customActionsController,
 			playgroundController,
 			silenceController,
+			enrichmentController,
 			actionController
 		)
 	);

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -2,12 +2,14 @@ import { AlertRepository } from '../../dal/alertRepository';
 import { ArchivedAlertRepository } from '../../dal/archivedAlertRepository';
 import { Alert, AlertComment, AlertHistory, AlertType, Logger } from '@OpsiMate/shared';
 import { AlertCommentsRepository } from '../../dal/alertCommentsRepository.ts';
+import { EnrichmentBL } from '../enrichments/enrichment.bl';
 import { SilenceBL } from '../silences/silence.bl';
 
 const logger = new Logger('bl/alert.bl');
 
 export class AlertBL {
 	private silenceBL: SilenceBL | null = null;
+	private enrichmentBL: EnrichmentBL | null = null;
 
 	constructor(
 		private alertRepo: AlertRepository,
@@ -17,6 +19,10 @@ export class AlertBL {
 
 	setSilenceBL(silenceBL: SilenceBL): void {
 		this.silenceBL = silenceBL;
+	}
+
+	setEnrichmentBL(enrichmentBL: EnrichmentBL): void {
+		this.enrichmentBL = enrichmentBL;
 	}
 
 	// region active
@@ -33,7 +39,11 @@ export class AlertBL {
 	async getAllAlerts(): Promise<Alert[]> {
 		try {
 			logger.info('Fetching all alerts');
-			const alerts = await this.alertRepo.getAllAlerts();
+			let alerts = await this.alertRepo.getAllAlerts();
+			// Enrich before silencing so silence rules can match enrichment-added tags.
+			if (this.enrichmentBL) {
+				alerts = await this.enrichmentBL.applyEnrichments(alerts);
+			}
 			if (this.silenceBL) {
 				return await this.silenceBL.markSilenced(alerts);
 			}

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -1,0 +1,113 @@
+import { Alert, AlertEnrichment, Logger } from '@OpsiMate/shared';
+import { CreateEnrichmentInput, EnrichmentRepository, UpdateEnrichmentInput } from '../../dal/enrichmentRepository';
+
+const logger = new Logger('bl/enrichment.bl');
+
+export class EnrichmentBL {
+	constructor(private enrichmentRepo: EnrichmentRepository) {}
+
+	async create(data: CreateEnrichmentInput): Promise<AlertEnrichment> {
+		const { lastID } = await this.enrichmentRepo.createEnrichment(data);
+		const created = await this.enrichmentRepo.getEnrichmentById(lastID);
+		if (!created) {
+			throw new Error('Failed to retrieve created enrichment');
+		}
+		return created;
+	}
+
+	async list(): Promise<AlertEnrichment[]> {
+		return this.enrichmentRepo.getAllEnrichments();
+	}
+
+	async get(id: number): Promise<AlertEnrichment | undefined> {
+		return this.enrichmentRepo.getEnrichmentById(id);
+	}
+
+	async update(id: number, data: UpdateEnrichmentInput): Promise<AlertEnrichment | undefined> {
+		await this.enrichmentRepo.updateEnrichment(id, data);
+		return this.enrichmentRepo.getEnrichmentById(id);
+	}
+
+	async delete(id: number): Promise<void> {
+		await this.enrichmentRepo.deleteEnrichment(id);
+	}
+
+	// Same matching semantics as silences: nameContains is a case-insensitive substring match
+	// on the alert name, and every label matcher must equal the alert's tag value.
+	static enrichmentMatchesAlert(enrichment: AlertEnrichment, alert: Alert): boolean {
+		const hasName = !!enrichment.nameContains && enrichment.nameContains.trim().length > 0;
+		const matchers = enrichment.labelMatchers ?? [];
+
+		if (!hasName && matchers.length === 0) return false;
+
+		if (hasName) {
+			const needle = enrichment.nameContains!.trim().toLowerCase();
+			if (!alert.alertName?.toLowerCase().includes(needle)) return false;
+		}
+
+		for (const matcher of matchers) {
+			const tagValue = alert.tags?.[matcher.key];
+			if (tagValue === undefined) return false;
+			if (String(tagValue) !== matcher.value) return false;
+		}
+		return true;
+	}
+
+	// Templates may reference the alert's current values; enrichments chain in order, so a
+	// later rule's {{summary}} sees the previous rule's output.
+	private static resolveTemplate(template: string, alert: Alert): string {
+		const ctx: Record<string, string> = {
+			summary: alert.summary ?? '',
+			name: alert.alertName ?? '',
+			status: alert.status ?? '',
+		};
+		return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key: string) => (key in ctx ? ctx[key] : match));
+	}
+
+	// claimedKeys tracks fields already set by a higher-priority rule in this pass, so the
+	// higher-priority rule's value wins same-key conflicts (rules may still override the
+	// alert's original tags).
+	private static applyToAlert(enrichment: AlertEnrichment, alert: Alert, claimedKeys: Set<string>): Alert {
+		const tags = { ...alert.tags };
+		for (const field of enrichment.addFields ?? []) {
+			if (claimedKeys.has(field.key)) continue;
+			tags[field.key] = field.value;
+			claimedKeys.add(field.key);
+		}
+		const summary =
+			enrichment.summaryTemplate && enrichment.summaryTemplate.trim().length > 0
+				? EnrichmentBL.resolveTemplate(enrichment.summaryTemplate, alert)
+				: alert.summary;
+		return { ...alert, tags, summary };
+	}
+
+	// Decorate alerts with all matching enrichment rules. Applied at fetch time only —
+	// nothing is persisted on the alerts themselves.
+	//
+	// When an alert matches several rules they chain by rank: highest priority first
+	// (ties break by creation order, oldest first). Each rule sees the previous rule's
+	// output, so summary templates compose in priority order, and on a conflicting field
+	// key the higher-priority rule wins. A rule can also match on tags added by an
+	// earlier (higher-priority) rule in the same pass.
+	async applyEnrichments(alerts: Alert[]): Promise<Alert[]> {
+		try {
+			const enrichments = (await this.enrichmentRepo.getAllEnrichments()).sort(
+				(a, b) => b.priority - a.priority || a.id - b.id
+			);
+			if (enrichments.length === 0) return alerts;
+			return alerts.map((alert) => {
+				let enriched = alert;
+				const claimedKeys = new Set<string>();
+				for (const enrichment of enrichments) {
+					if (EnrichmentBL.enrichmentMatchesAlert(enrichment, enriched)) {
+						enriched = EnrichmentBL.applyToAlert(enrichment, enriched, claimedKeys);
+					}
+				}
+				return enriched;
+			});
+		} catch (err) {
+			logger.error('Failed to apply alert enrichments, returning alerts unchanged', err);
+			return alerts;
+		}
+	}
+}

--- a/apps/server/src/dal/enrichmentRepository.ts
+++ b/apps/server/src/dal/enrichmentRepository.ts
@@ -1,0 +1,152 @@
+import Database from 'better-sqlite3';
+import { AlertEnrichment, AlertEnrichmentField, AlertSilenceLabelMatcher } from '@OpsiMate/shared';
+import { runAsync } from './db';
+
+interface EnrichmentRow {
+	id: number;
+	name: string;
+	name_contains: string | null;
+	label_matchers: string | null;
+	add_fields: string | null;
+	summary_template: string | null;
+	priority: number | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export type CreateEnrichmentInput = Omit<AlertEnrichment, 'id' | 'createdAt' | 'updatedAt'>;
+export type UpdateEnrichmentInput = Partial<Omit<AlertEnrichment, 'id' | 'createdAt' | 'updatedAt'>>;
+
+const parseJsonArray = <T>(raw: string | null): T[] => {
+	if (!raw) return [];
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return Array.isArray(parsed) ? (parsed as T[]) : [];
+	} catch {
+		return [];
+	}
+};
+
+export class EnrichmentRepository {
+	constructor(private db: Database.Database) {}
+
+	private toShared = (row: EnrichmentRow): AlertEnrichment => ({
+		id: row.id,
+		name: row.name,
+		nameContains: row.name_contains,
+		labelMatchers: parseJsonArray<AlertSilenceLabelMatcher>(row.label_matchers),
+		addFields: parseJsonArray<AlertEnrichmentField>(row.add_fields),
+		summaryTemplate: row.summary_template,
+		priority: row.priority ?? 0,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	});
+
+	async initEnrichmentsTable(): Promise<void> {
+		return runAsync(() => {
+			this.db
+				.prepare(
+					`
+					CREATE TABLE IF NOT EXISTS alert_enrichments (
+						id               INTEGER PRIMARY KEY AUTOINCREMENT,
+						name             TEXT NOT NULL,
+						name_contains    TEXT,
+						label_matchers   TEXT,
+						add_fields       TEXT,
+						summary_template TEXT,
+						priority         INTEGER DEFAULT 0,
+						created_at       DATETIME DEFAULT CURRENT_TIMESTAMP,
+						updated_at       DATETIME DEFAULT CURRENT_TIMESTAMP
+					)
+				`
+				)
+				.run();
+
+			// Migrate older installs that predate the priority column.
+			const columns = this.db.prepare(`PRAGMA table_info(alert_enrichments)`).all() as { name: string }[];
+			if (!columns.some((c) => c.name === 'priority')) {
+				this.db.prepare(`ALTER TABLE alert_enrichments ADD COLUMN priority INTEGER DEFAULT 0`).run();
+			}
+		});
+	}
+
+	async createEnrichment(data: CreateEnrichmentInput): Promise<{ lastID: number }> {
+		return runAsync(() => {
+			const stmt = this.db.prepare(
+				`INSERT INTO alert_enrichments (name, name_contains, label_matchers, add_fields, summary_template, priority)
+				 VALUES (?, ?, ?, ?, ?, ?)`
+			);
+			const result = stmt.run(
+				data.name,
+				data.nameContains ?? null,
+				JSON.stringify(data.labelMatchers ?? []),
+				JSON.stringify(data.addFields ?? []),
+				data.summaryTemplate ?? null,
+				data.priority ?? 0
+			);
+			return { lastID: result.lastInsertRowid as number };
+		});
+	}
+
+	async getAllEnrichments(): Promise<AlertEnrichment[]> {
+		return runAsync(() => {
+			const rows = this.db
+				.prepare(`SELECT * FROM alert_enrichments ORDER BY created_at DESC`)
+				.all() as EnrichmentRow[];
+			return rows.map(this.toShared);
+		});
+	}
+
+	async getEnrichmentById(id: number): Promise<AlertEnrichment | undefined> {
+		return runAsync(() => {
+			const row = this.db.prepare(`SELECT * FROM alert_enrichments WHERE id = ?`).get(id) as
+				| EnrichmentRow
+				| undefined;
+			return row ? this.toShared(row) : undefined;
+		});
+	}
+
+	async updateEnrichment(id: number, data: UpdateEnrichmentInput): Promise<void> {
+		return runAsync(() => {
+			const updates: string[] = [];
+			const values: unknown[] = [];
+
+			if (data.name !== undefined) {
+				updates.push('name = ?');
+				values.push(data.name);
+			}
+			if (data.nameContains !== undefined) {
+				updates.push('name_contains = ?');
+				values.push(data.nameContains);
+			}
+			if (data.labelMatchers !== undefined) {
+				updates.push('label_matchers = ?');
+				values.push(JSON.stringify(data.labelMatchers));
+			}
+			if (data.addFields !== undefined) {
+				updates.push('add_fields = ?');
+				values.push(JSON.stringify(data.addFields));
+			}
+			if (data.summaryTemplate !== undefined) {
+				updates.push('summary_template = ?');
+				values.push(data.summaryTemplate);
+			}
+			if (data.priority !== undefined) {
+				updates.push('priority = ?');
+				values.push(data.priority);
+			}
+
+			if (updates.length === 0) return;
+
+			updates.push('updated_at = CURRENT_TIMESTAMP');
+			values.push(id);
+			this.db.prepare(`UPDATE alert_enrichments SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+		});
+	}
+
+	async deleteEnrichment(id: number): Promise<void> {
+		return runAsync(() => {
+			this.db.prepare(`DELETE FROM alert_enrichments WHERE id = ?`).run(id);
+		});
+	}
+}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -362,6 +362,59 @@ export const AlertSilenceIdSchema = z.object({
 	}),
 });
 
+// ---- Alert enrichments ----
+
+const enrichmentFieldSchema = z.object({
+	key: z.string().min(1, 'Field key is required').max(200),
+	value: z.string().min(1, 'Field value is required').max(1000),
+});
+
+// At least one effect: a field to add/override or a summary template.
+const enrichmentEffectRefinement = (data: { addFields?: unknown[]; summaryTemplate?: string | null }) => {
+	const hasFields = Array.isArray(data.addFields) && data.addFields.length > 0;
+	const hasSummary = !!data.summaryTemplate && data.summaryTemplate.trim().length > 0;
+	return hasFields || hasSummary;
+};
+
+export const CreateAlertEnrichmentSchema = z
+	.object({
+		name: z.string().min(1, 'Name is required').max(200),
+		nameContains: z.string().max(500).optional().nullable(),
+		labelMatchers: z.array(labelMatcherSchema).max(20).optional().default([]),
+		addFields: z.array(enrichmentFieldSchema).max(20).optional().default([]),
+		summaryTemplate: z.string().max(5000).optional().nullable(),
+		priority: z.number().int().min(0).max(1000).optional().default(0),
+	})
+	.refine(silenceMatchersRefinement, {
+		message: 'Provide at least a name match or one label matcher',
+		path: ['nameContains'],
+	})
+	.refine(enrichmentEffectRefinement, {
+		message: 'Provide at least one field to add or a summary template',
+		path: ['addFields'],
+	});
+
+// Partial update: effect refinement is not enforced here because omitted fields mean
+// "leave unchanged" (the client form always submits the full validated shape anyway).
+export const UpdateAlertEnrichmentSchema = z.object({
+	name: z.string().min(1).max(200).optional(),
+	nameContains: z.string().max(500).optional().nullable(),
+	labelMatchers: z.array(labelMatcherSchema).max(20).optional(),
+	addFields: z.array(enrichmentFieldSchema).max(20).optional(),
+	summaryTemplate: z.string().max(5000).optional().nullable(),
+	priority: z.number().int().min(0).max(1000).optional(),
+});
+
+export const AlertEnrichmentIdSchema = z.object({
+	enrichmentId: z.string().transform((val) => {
+		const parsed = parseInt(val);
+		if (isNaN(parsed)) {
+			throw new Error('Invalid enrichment ID');
+		}
+		return parsed;
+	}),
+});
+
 // ---- Actions ----
 
 const actionNameSchema = z.string().min(1, 'Name is required').max(200);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -269,6 +269,29 @@ export interface AlertSilence {
 	updatedAt: string;
 }
 
+// Alert enrichment: a rule that matches alerts (like silences: name-contains + label matchers)
+// and decorates them at fetch time — adding/overriding tag fields and/or rewriting the summary.
+// The summary template may reference the current values via {{summary}}, {{name}}, {{status}}.
+// Applied transiently when alerts are fetched; nothing is persisted on the alert itself.
+export interface AlertEnrichmentField {
+	key: string;
+	value: string;
+}
+
+export interface AlertEnrichment {
+	id: number;
+	name: string;
+	nameContains?: string | null;
+	labelMatchers: AlertSilenceLabelMatcher[];
+	addFields: AlertEnrichmentField[];
+	summaryTemplate?: string | null;
+	// Rank: rules apply highest-priority first. When two rules set the same field the higher
+	// priority wins; summary templates chain in priority order. Ties break by creation order.
+	priority: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
 // Actions are reusable, user-configured integrations that can be run against an alert
 // (e.g. notify a Slack/Teams channel, open a Jira ticket, or fire an arbitrary HTTP request).
 // This phase only covers configuring them; wiring them to alerts comes later.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      dompurify:
+        specifier: ^3.4.10
+        version: 3.4.10
       embla-carousel-react:
         specifier: ^8.3.0
         version: 8.6.0(react@18.3.1)
@@ -2631,6 +2634,9 @@ packages:
   '@types/tinycolor2@1.4.6':
     resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/uuid@11.0.0':
     resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
     deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
@@ -3600,6 +3606,9 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
@@ -8915,6 +8924,9 @@ snapshots:
 
   '@types/tinycolor2@1.4.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/uuid@11.0.0':
     dependencies:
       uuid: 13.0.0
@@ -10024,6 +10036,10 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.3
       csstype: 3.1.3
+
+  dompurify@3.4.10:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-case@2.1.1:
     dependencies:


### PR DESCRIPTION
## Summary
Adds an **Enrichment** page: rules that match alerts (name-contains + label matchers, same style as Silences) and automatically decorate them — adding/overriding tag fields and/or rewriting the summary. Applied transiently at fetch time; nothing is persisted on the alerts.

Example (the motivating use case): every alert whose name contains `Disk` gets `disk_alert=true` and its summary becomes `{{summary}} - contact the help desk, the disk is full`.

## What's included

### Enrichment rules
- **Match criteria**: alert name contains + label matchers (ALL must match), like Silences.
- **Effects**: fields to add/override (become alert tags — visible in the table, filters, detail panel) and/or a **summary template** with `{{summary}}` / `{{name}}` / `{{status}}` placeholders.
- **Priority**: rules run highest-priority first (e.g. 10 before 7). On a conflicting field the higher-priority rule wins; summary templates chain in that order, each seeing the previous result; ties break by creation order. The semantics are explained in the form and the page lists rules in execution order.
- Applied in `AlertBL.getAllAlerts` **before** silence marking, so silence rules can match enrichment-added tags.

### Formatted summaries (general improvement, not enrichment-only)
- Alert summaries now render **new lines and a safe HTML subset** (bold, links, lists, code, headings) in the alert details panel via a shared `FormattedText` component.
- Sanitized with **DOMPurify** (explicit allow-list; scripts/event handlers/iframes stripped; links forced `target=_blank rel=noopener`). An actual XSS payload (`<script>`, `<img onerror>`) was injected through a template during testing and verified blocked while legit formatting rendered.
- The one-line table cell strips tags; full formatting shows in the panel.

## Implementation
Follows the Silences blueprint end-to-end: shared types/zod schemas → `alert_enrichments` table (+ priority migration) → repository → BL (matching/chaining/priority logic) → CRUD API under `/api/v1/enrichments` → client api/hooks/page/dialog/route/sidebar. New client dependency: `dompurify`.

## Testing
- All CI gates replicated locally: turbo build (4 pkgs), lint `--max-warnings=0` (server/shared/custom-actions) + client lint, prettier checks across packages, server tests 97 ✓, client tests 24 ✓.
- Verified end-to-end against a running instance with real alerts: CRUD + validation (missing matcher/effect → 400), the Disk example (fields + summary rewrite applied on fetch, reverted on delete), multi-rule chaining with priority (10 ran before 7, won the field conflict), migration of pre-priority rows, and UI screenshots of the page/dialog/alert details (formatted summary with bold/list/link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Enrichments management interface to create, edit, and delete enrichment rules that enrich alerts with additional fields and customize alert summaries
  * Enrichments support flexible alert matching via name patterns and label criteria with priority-based ordering
  * Enhanced alert display formatting with improved HTML sanitization and support for rich text rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->