### PR TITLE
feat: alerts table UX — row highlight, unread bold, bulk archive/delete

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -3,7 +3,7 @@ import { FilterSidebar } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useDashboard } from '@/context/DashboardContext';
-import { useAlerts, useArchivedAlerts, useDeleteArchivedAlert } from '@/hooks/queries/alerts';
+import { useAlerts, useArchivedAlerts, useDeleteArchivedAlert, useMarkAlertRead } from '@/hooks/queries/alerts';
 import {
 	useCreateDashboard,
 	useDeleteDashboard,
@@ -194,9 +194,17 @@ const Alerts = () => {
 		[filteredAlerts, filteredArchivedAlerts]
 	);
 
-	const { handleDismissAlert, handleUndismissAlert, handleDeleteAlert, handleDismissAll, handleAssignOwnerAll } =
-		useAlertActions();
+	const {
+		handleDismissAlert,
+		handleUndismissAlert,
+		handleDeleteAlert,
+		handleDismissAll,
+		handleAssignOwnerAll,
+		handleArchiveAll,
+		handleDeleteForeverAll,
+	} = useAlertActions();
 	const deleteArchivedAlertMutation = useDeleteArchivedAlert();
+	const markAlertReadMutation = useMarkAlertRead();
 
 	const handleDismissAllSelected = async () => {
 		await handleDismissAll(selectedAlerts, () => setSelectedAlerts([]));
@@ -204,6 +212,16 @@ const Alerts = () => {
 
 	const handleAssignOwnerAllSelected = async (ownerId: string | null) => {
 		await handleAssignOwnerAll(selectedAlerts, ownerId, () => setSelectedAlerts([]));
+	};
+
+	const handleArchiveAllSelected = async () => {
+		setSelectedAlert(null);
+		await handleArchiveAll(selectedAlerts, () => setSelectedAlerts([]));
+	};
+
+	const handleDeleteAllSelected = async () => {
+		setSelectedAlert(null);
+		await handleDeleteForeverAll(selectedAlerts, () => setSelectedAlerts([]));
 	};
 
 	const handleDeleteArchivedAlert = async (alertId: string) => {
@@ -234,6 +252,7 @@ const Alerts = () => {
 			visibleColumns={visibleColumns}
 			columnOrder={columnOrder}
 			onAlertClick={handleAlertClick}
+			activeAlertId={syncedSelectedAlert?.id ?? null}
 			tagKeyColumnLabels={allColumnLabels}
 			groupByColumns={dashboardState.groupBy}
 			onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
@@ -302,6 +321,12 @@ const Alerts = () => {
 	};
 
 	const handleAlertClick = (alert: Alert) => {
+		// Opening an unread (active) alert marks it as read, un-bolding its row. The transient
+		// isArchived flag (set on archived rows in the All view) is the guard here — an id-based
+		// check would wrongly skip active alerts that were archived once and re-fired.
+		if (alert.isRead === false && !alert.isArchived) {
+			markAlertReadMutation.mutate(alert.id);
+		}
 		setSelectedAlert((prev) => (prev?.id === alert.id ? null : alert));
 	};
 
@@ -472,6 +497,8 @@ const Alerts = () => {
 										onClearSelection={() => setSelectedAlerts([])}
 										onDismissAll={handleDismissAllSelected}
 										onAssignOwnerAll={handleAssignOwnerAllSelected}
+										onArchiveAll={handleArchiveAllSelected}
+										onDeleteAll={handleDeleteAllSelected}
 									/>
 								</div>
 							</>
@@ -497,6 +524,7 @@ const Alerts = () => {
 									visibleColumns={visibleColumns}
 									columnOrder={columnOrder}
 									onAlertClick={handleAlertClick}
+									activeAlertId={syncedSelectedAlert?.id ?? null}
 									tagKeyColumnLabels={allColumnLabels}
 									groupByColumns={dashboardState.groupBy}
 									onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
@@ -531,6 +559,7 @@ const Alerts = () => {
 									visibleColumns={visibleColumns}
 									columnOrder={columnOrder}
 									onAlertClick={handleAlertClick}
+									activeAlertId={syncedSelectedAlert?.id ?? null}
 									tagKeyColumnLabels={allColumnLabels}
 									groupByColumns={dashboardState.groupBy}
 									onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}

--- a/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
@@ -1,13 +1,27 @@
 import { PersonPicker } from '@/components/PersonPicker';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { useUsers } from '@/hooks/queries/users';
 import { Alert } from '@OpsiMate/shared';
+import { Archive, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
 export interface AlertsSelectionBarProps {
 	selectedAlerts: Alert[];
 	onClearSelection: () => void;
 	onDismissAll: () => void;
 	onAssignOwnerAll?: (ownerId: string | null) => void;
+	onArchiveAll?: () => void;
+	onDeleteAll?: () => void;
 }
 
 export const AlertsSelectionBar = ({
@@ -15,8 +29,11 @@ export const AlertsSelectionBar = ({
 	onClearSelection,
 	onDismissAll,
 	onAssignOwnerAll,
+	onArchiveAll,
+	onDeleteAll,
 }: AlertsSelectionBarProps) => {
 	const { data: users = [] } = useUsers();
+	const [confirmDelete, setConfirmDelete] = useState(false);
 
 	if (selectedAlerts.length === 0) {
 		return null;
@@ -50,10 +67,53 @@ export const AlertsSelectionBar = ({
 						Dismiss all
 					</Button>
 				)}
+				{onArchiveAll && (
+					<Button variant="outline" size="sm" onClick={onArchiveAll} className="gap-1.5">
+						<Archive className="h-3.5 w-3.5" />
+						Archive
+					</Button>
+				)}
+				{onDeleteAll && (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setConfirmDelete(true)}
+						className="gap-1.5 text-destructive hover:text-destructive"
+					>
+						<Trash2 className="h-3.5 w-3.5" />
+						Delete
+					</Button>
+				)}
 				<Button variant="outline" size="sm" onClick={onClearSelection}>
 					Clear selection
 				</Button>
 			</div>
+
+			<AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							Delete {selectedAlerts.length} alert{selectedAlerts.length !== 1 ? 's' : ''}?
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently deletes the selected alert{selectedAlerts.length !== 1 ? 's' : ''} — they
+							will not appear in the archive. This cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => {
+								setConfirmDelete(false);
+								onDeleteAll?.();
+							}}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -20,6 +20,8 @@ export interface AlertRowProps {
 	orderedColumns: string[];
 	onSelectAlert: (alert: Alert) => void;
 	onAlertClick?: (alert: Alert) => void;
+	// True when this alert is the one open in the details panel.
+	isActiveRow?: boolean;
 	onDismissAlert?: (alertId: string) => void;
 	onUndismissAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
@@ -37,6 +39,7 @@ export const AlertRow = ({
 	orderedColumns,
 	onSelectAlert,
 	onAlertClick,
+	isActiveRow = false,
 	onDismissAlert,
 	onUndismissAlert,
 	onDeleteAlert,
@@ -65,7 +68,15 @@ export const AlertRow = ({
 
 	return (
 		<TableRow
-			className={cn('h-8 cursor-pointer hover:bg-muted/50', isSelected && 'bg-muted/50')}
+			className={cn(
+				'h-8 cursor-pointer hover:bg-muted/50',
+				isSelected && 'bg-muted/50',
+				// Unread alerts render bold until someone opens them.
+				alert.isRead === false && 'font-bold',
+				// The alert currently open in the details panel: tinted row + accent edge,
+				// inset shadow instead of a border so the columns don't shift.
+				isActiveRow && 'bg-primary/10 hover:bg-primary/15 shadow-[inset_3px_0_0_0] shadow-primary'
+			)}
 			onClick={handleRowClick}
 		>
 			{onSelectAlerts && (

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -10,7 +10,14 @@ export interface AlertNameColumnProps {
 export const AlertNameColumn = ({ alert, className }: AlertNameColumnProps) => {
 	return (
 		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
-			<span className="text-sm font-medium truncate block text-foreground" title={alert.alertName}>
+			<span
+				className={cn(
+					'text-sm truncate block text-foreground',
+					// Unread alerts: bold the name (the row's own font-medium would otherwise win).
+					alert.isRead === false ? 'font-bold' : 'font-medium'
+				)}
+				title={alert.alertName}
+			>
 				{alert.alertName}
 			</span>
 		</TableCell>

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -38,6 +38,7 @@ export const AlertsTable = ({
 	visibleColumns = DEFAULT_VISIBLE_COLUMNS,
 	columnOrder = DEFAULT_COLUMN_ORDER,
 	onAlertClick,
+	activeAlertId = null,
 	tagKeyColumnLabels = {},
 	groupByColumns: controlledGroupBy,
 	onGroupByChange,
@@ -241,6 +242,7 @@ export const AlertsTable = ({
 									onToggleGroup={toggleGroup}
 									onSelectAlert={handleSelectAlert}
 									onAlertClick={onAlertClick}
+									activeAlertId={activeAlertId}
 									onDismissAlert={onDismissAlert}
 									onUndismissAlert={onUndismissAlert}
 									onDeleteAlert={onDeleteAlert}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -27,6 +27,8 @@ export interface AlertsTableProps {
 	visibleColumns?: string[];
 	columnOrder?: string[];
 	onAlertClick?: (alert: Alert) => void;
+	// Alert currently open in the details panel; its row is highlighted.
+	activeAlertId?: string | null;
 	tagKeyColumnLabels?: Record<string, string>;
 	groupByColumns?: string[];
 	onGroupByChange?: (cols: string[]) => void;

--- a/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
@@ -14,6 +14,7 @@ interface VirtualizedAlertListProps {
 	onToggleGroup: (key: string) => void;
 	onSelectAlert: (alert: Alert) => void;
 	onAlertClick?: (alert: Alert) => void;
+	activeAlertId?: string | null;
 	onDismissAlert?: (alertId: string) => void;
 	onUndismissAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
@@ -34,6 +35,7 @@ export const VirtualizedAlertList = ({
 	onToggleGroup,
 	onSelectAlert,
 	onAlertClick,
+	activeAlertId = null,
 	onDismissAlert,
 	onUndismissAlert,
 	onDeleteAlert,
@@ -110,6 +112,7 @@ export const VirtualizedAlertList = ({
 									orderedColumns={orderedColumns}
 									onSelectAlert={onSelectAlert}
 									onAlertClick={onAlertClick}
+									isActiveRow={alert.id === activeAlertId}
 									onDismissAlert={onDismissAlert}
 									onUndismissAlert={onUndismissAlert}
 									onDeleteAlert={onDeleteAlert}

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -1,4 +1,10 @@
-import { useDeleteAlert, useDismissAlert, useSetAlertOwner, useUndismissAlert } from '@/hooks/queries/alerts';
+import {
+	useDeleteAlert,
+	useDeleteArchivedAlert,
+	useDismissAlert,
+	useSetAlertOwner,
+	useUndismissAlert,
+} from '@/hooks/queries/alerts';
 import { useToast } from '@/hooks/use-toast';
 import { Alert } from '@OpsiMate/shared';
 
@@ -7,6 +13,7 @@ export const useAlertActions = () => {
 	const undismissAlertMutation = useUndismissAlert();
 	const deleteAlertMutation = useDeleteAlert();
 	const setAlertOwnerMutation = useSetAlertOwner();
+	const deleteArchivedAlertMutation = useDeleteArchivedAlert();
 	const { toast } = useToast();
 
 	const handleDismissAlert = async (alertId: string) => {
@@ -90,11 +97,61 @@ export const useAlertActions = () => {
 		onComplete();
 	};
 
+	// Bulk-archive the selected active alerts (active "delete" == archive).
+	const handleArchiveAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
+		const results = await Promise.allSettled(
+			selectedAlerts.map((alert) => deleteAlertMutation.mutateAsync(alert.id))
+		);
+		const successCount = results.filter((r) => r.status === 'fulfilled').length;
+		const failCount = results.length - successCount;
+		toast(
+			failCount > 0
+				? {
+						title: 'Partial archive',
+						description: `Archived ${successCount} alerts, ${failCount} failed`,
+						variant: 'destructive',
+					}
+				: {
+						title: 'Alerts archived',
+						description: `Moved ${successCount} alert${successCount !== 1 ? 's' : ''} to archive`,
+					}
+		);
+		onComplete();
+	};
+
+	// Permanently delete the selected active alerts: archive each one, then remove it from
+	// the archive (permanent delete only exists for archived alerts).
+	const handleDeleteForeverAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
+		const results = await Promise.allSettled(
+			selectedAlerts.map(async (alert) => {
+				await deleteAlertMutation.mutateAsync(alert.id);
+				await deleteArchivedAlertMutation.mutateAsync(alert.id);
+			})
+		);
+		const successCount = results.filter((r) => r.status === 'fulfilled').length;
+		const failCount = results.length - successCount;
+		toast(
+			failCount > 0
+				? {
+						title: 'Partial delete',
+						description: `Deleted ${successCount} alerts, ${failCount} failed`,
+						variant: 'destructive',
+					}
+				: {
+						title: 'Alerts deleted',
+						description: `Permanently deleted ${successCount} alert${successCount !== 1 ? 's' : ''}`,
+					}
+		);
+		onComplete();
+	};
+
 	return {
 		handleDismissAlert,
 		handleUndismissAlert,
 		handleDeleteAlert,
 		handleDismissAll,
 		handleAssignOwnerAll,
+		handleArchiveAll,
+		handleDeleteForeverAll,
 	};
 };

--- a/apps/client/src/hooks/queries/alerts/index.ts
+++ b/apps/client/src/hooks/queries/alerts/index.ts
@@ -3,6 +3,7 @@ export { useArchivedAlerts } from './useArchivedAlerts';
 export { useDeleteAlert } from './useDeleteAlert';
 export { useDeleteArchivedAlert } from './useDeleteArchivedAlert';
 export { useDismissAlert } from './useDismissAlert';
+export { useMarkAlertRead } from './useMarkAlertRead';
 export { useUndismissAlert } from './useUndismissAlert';
 export { useSetAlertOwner } from './useSetAlertOwner';
 export { useSetArchivedAlertOwner } from './useSetArchivedAlertOwner';

--- a/apps/client/src/hooks/queries/alerts/useMarkAlertRead.ts
+++ b/apps/client/src/hooks/queries/alerts/useMarkAlertRead.ts
@@ -1,0 +1,38 @@
+import { alertsApi } from '@/lib/api';
+import { Alert } from '@OpsiMate/shared';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+// Marks an alert as read (unread alerts render bold). Optimistic so the row un-bolds
+// immediately on click. Note: useAlerts keys its query as [...queryKeys.alerts, mode],
+// so we use prefix-matching setQueriesData rather than a single setQueryData.
+export const useMarkAlertRead = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (alertId: string) => {
+			const response = await alertsApi.markAlertRead(alertId);
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to mark alert as read');
+			}
+			return response.data?.alert;
+		},
+		onMutate: async (alertId: string) => {
+			await queryClient.cancelQueries({ queryKey: queryKeys.alerts });
+			const previous = queryClient.getQueriesData<Alert[]>({ queryKey: queryKeys.alerts });
+			queryClient.setQueriesData<Alert[]>({ queryKey: queryKeys.alerts }, (old) => {
+				if (!old) return old;
+				return old.map((alert) => (alert.id === alertId ? { ...alert, isRead: true } : alert));
+			});
+			return { previous };
+		},
+		onError: (_err, _alertId, context) => {
+			for (const [key, data] of context?.previous ?? []) {
+				queryClient.setQueryData(key, data);
+			}
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+		},
+	});
+};

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -556,6 +556,11 @@ export const alertsApi = {
 		return await apiRequest<void>(`/alerts/${alertId}`, 'DELETE');
 	},
 
+	// Mark alert as read (unread alerts render bold in the table)
+	async markAlertRead(alertId: string): Promise<ApiResponse<{ alert: SharedAlert }>> {
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/read`, 'PATCH');
+	},
+
 	getAlertHistory: (alertId: string) => {
 		return apiRequest<AlertHistory>(`/alerts/${alertId}/history`, 'GET');
 	},

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -368,6 +368,23 @@ export class AlertController {
 		}
 	}
 
+	async markAlertRead(req: Request, res: Response) {
+		try {
+			const alertId = req.params.id;
+			if (!alertId) {
+				return res.status(400).json({ success: false, error: 'Invalid alert ID' });
+			}
+			const alert = await this.alertBL.markAlertRead(alertId);
+			if (!alert) {
+				return res.status(404).json({ success: false, error: 'Alert not found' });
+			}
+			return res.json({ success: true, data: { alert } });
+		} catch (error) {
+			logger.error('Error marking alert as read:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
 	async deleteAlert(req: Request, res: Response) {
 		try {
 			const alertId = req.params.alertId;

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -19,6 +19,7 @@ export default function createAlertRouter(controller: AlertController) {
 	// Dismiss Unsimiss an alert
 	router.patch('/:id/dismiss', controller.dismissAlert.bind(controller));
 	router.patch('/:id/undismiss', controller.undismissAlert.bind(controller));
+	router.patch('/:id/read', controller.markAlertRead.bind(controller));
 
 	// Set alert owner
 	router.patch('/:id/owner', controller.setAlertOwner.bind(controller));

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -64,6 +64,16 @@ export class AlertBL {
 		}
 	}
 
+	async markAlertRead(id: string): Promise<Alert | null> {
+		try {
+			logger.info(`Marking alert as read: ${id}`);
+			return await this.alertRepo.markAlertRead(id);
+		} catch (error) {
+			logger.error('Error marking alert as read', error);
+			throw error;
+		}
+	}
+
 	async undismissAlert(id: string): Promise<Alert | null> {
 		try {
 			logger.info(`Undismissing alert with id: ${id}`);

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -72,6 +72,9 @@ export class AlertRepository {
 
 			// Backward compatibility: ensure tags column exists
 			const columns = this.db.prepare(`PRAGMA table_info(alerts)`).all() as TableInfoRow[];
+			if (!columns.some((col: TableInfoRow) => col.name === 'is_read')) {
+				this.db.prepare(`ALTER TABLE alerts ADD COLUMN is_read BOOLEAN DEFAULT 0`).run();
+			}
 			const hasTags = columns.some((col: TableInfoRow) => col.name === 'tags');
 
 			if (!hasTags) {
@@ -102,6 +105,7 @@ export class AlertRepository {
 			runbookUrl: row.runbook_url,
 			createdAt: row.created_at,
 			isDismissed: row.is_dismissed ? true : false,
+			isRead: row.is_read ? true : false,
 			ownerId: row.owner_id != null ? String(row.owner_id) : null,
 		};
 	};
@@ -117,6 +121,14 @@ export class AlertRepository {
 	async dismissAlert(id: string): Promise<SharedAlert | null> {
 		return runAsync(() => {
 			this.db.prepare('UPDATE alerts SET is_dismissed = 1 WHERE id = ?').run(id);
+			const row = this.db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow | undefined;
+			return row ? this.toSharedAlert(row) : null;
+		});
+	}
+
+	async markAlertRead(id: string): Promise<SharedAlert | null> {
+		return runAsync(() => {
+			this.db.prepare('UPDATE alerts SET is_read = 1 WHERE id = ?').run(id);
 			const row = this.db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow | undefined;
 			return row ? this.toSharedAlert(row) : null;
 		});

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -64,6 +64,7 @@ export type AlertRow = {
 	runbook_url?: string;
 	created_at: string;
 	is_dismissed: boolean;
+	is_read?: boolean | number | null;
 	owner_id?: number | null;
 };
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -134,6 +134,8 @@ export interface Alert {
 	runbookUrl?: string;
 	createdAt: string;
 	isDismissed: boolean;
+	// False until someone opens the alert; unread alerts render bold in the table.
+	isRead?: boolean;
 	// Transient: set at fetch time when an active silence rule matches this alert. Not persisted.
 	isSilenced?: boolean;
 	// Transient: set client-side in the combined "All" view so a row knows it came from the


### PR DESCRIPTION
## Summary
Four interaction improvements to the alerts table.

### 1. Active-row highlight
Clicking an alert highlights its row (subtle tint + a left accent edge via inset shadow, so columns don't shift) — you can always see which alert the details panel is showing. Threaded as `activeAlertId` through `AlertsTable → VirtualizedAlertList → AlertRow`.

### 2. New alerts are bold until opened
New/unread alerts render **bold** (name, summary, started-at) and un-bold once opened. Backed by a transient `Alert.isRead` flag persisted server-side:
- `is_read` column on `alerts` (with migration; new alerts default unread)
- `PATCH /alerts/:id/read` → `markAlertRead` in repository/BL/controller
- client `useMarkAlertRead` (optimistic, prefix-matches the `useAlerts` query keys); opening an alert marks it read
- the **Alert Name** column explicitly bolds when unread (its `font-medium` otherwise beat the row's cascade)

### 3. Bulk archive
The multi-select bar gains **Archive** — moves all selected active alerts to the archive.

### 4. Bulk delete
**Delete** permanently removes the selected alerts (confirm dialog). Active alerts have no permanent-delete endpoint, so it archives each then removes it from the archive.

## Notes
- The active-row guard uses the transient `isArchived` flag (not an id check), because an alert that was archived once and re-fired shares its id with an archived row — an id check would wrongly skip marking it read.

## Testing
- All CI gates replicated locally: build, lint `--max-warnings=0` (server/shared/custom-actions) + client lint, prettier across packages, server tests 97 ✓, client tests 24 ✓.
- Verified end-to-end against a running instance: `is_read` migration + default-unread, the read endpoint (persists across refetch), bold→click→un-bold + highlight in the browser, and both bulk flows (archive: active→archived; delete: gone from both lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert read status tracking—alerts automatically mark as read when opened
  * Bulk archive and delete operations for multiple selected alerts
  * Visual indicators: unread alerts display as bold; currently open alert row is highlighted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->