### PR TITLE
feat: enrichment improvements — label placeholders, default summary, duplicate rule

### DIFF
--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
+import { useAlerts } from '@/hooks/queries/alerts';
 import { useCreateEnrichment, useUpdateEnrichment } from '@/hooks/queries/enrichments';
 import { EnrichmentPayload } from '@/lib/api';
 import { AlertEnrichment } from '@OpsiMate/shared';
@@ -19,10 +20,14 @@ import { useEffect, useMemo, useState } from 'react';
 
 type KeyValue = { key: string; value: string };
 
+const DEFAULT_SUMMARY_TEMPLATE = '{{summary}}';
+
 interface EnrichmentFormDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	enrichment?: AlertEnrichment | null;
+	// When set (and not editing), opens a new rule pre-filled from this one ("copy from existing").
+	duplicateFrom?: AlertEnrichment | null;
 }
 
 const KeyValueRows = ({
@@ -90,7 +95,7 @@ const KeyValueRows = ({
 	</div>
 );
 
-export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment }: EnrichmentFormDialogProps) => {
+export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicateFrom }: EnrichmentFormDialogProps) => {
 	const isEdit = !!enrichment;
 	const { toast } = useToast();
 	const createMutation = useCreateEnrichment();
@@ -103,24 +108,35 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment }: Enrichm
 	const [summaryTemplate, setSummaryTemplate] = useState('');
 	const [priority, setPriority] = useState('0');
 
+	// Label keys present on current alerts, offered as insertable placeholders.
+	const { data: alerts = [] } = useAlerts();
+	const labelKeys = useMemo(() => {
+		const keys = new Set<string>();
+		alerts.forEach((a) => Object.keys(a.tags ?? {}).forEach((k) => keys.add(k)));
+		return Array.from(keys).sort();
+	}, [alerts]);
+
 	useEffect(() => {
 		if (!open) return;
-		if (enrichment) {
-			setName(enrichment.name);
-			setNameContains(enrichment.nameContains ?? '');
-			setMatchers((enrichment.labelMatchers ?? []).map((m) => ({ ...m })));
-			setAddFields((enrichment.addFields ?? []).map((f) => ({ ...f })));
-			setSummaryTemplate(enrichment.summaryTemplate ?? '');
-			setPriority(String(enrichment.priority ?? 0));
+		// Editing loads the rule; "copy from existing" loads a source rule into a new draft.
+		const source = enrichment ?? duplicateFrom;
+		if (source) {
+			setName(enrichment ? source.name : `${source.name} (copy)`);
+			setNameContains(source.nameContains ?? '');
+			setMatchers((source.labelMatchers ?? []).map((m) => ({ ...m })));
+			setAddFields((source.addFields ?? []).map((f) => ({ ...f })));
+			setSummaryTemplate(source.summaryTemplate ?? '');
+			setPriority(String(source.priority ?? 0));
 		} else {
 			setName('');
 			setNameContains('');
 			setMatchers([]);
 			setAddFields([]);
-			setSummaryTemplate('');
+			// Pre-fill with {{summary}} so the user keeps the existing summary and appends to it.
+			setSummaryTemplate(DEFAULT_SUMMARY_TEMPLATE);
 			setPriority('0');
 		}
-	}, [open, enrichment]);
+	}, [open, enrichment, duplicateFrom]);
 
 	const isValid = useMemo(() => {
 		if (!name.trim()) return false;
@@ -253,10 +269,14 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment }: Enrichm
 							rows={addFields}
 							onChange={setAddFields}
 							keyPlaceholder="field (e.g. disk_alert)"
-							valuePlaceholder="value (e.g. true)"
+							valuePlaceholder="value (e.g. true or {{label.host}})"
 							emptyText="No fields. Added as tags on the alert; existing keys are overridden."
 							addLabel="Fields to add / override"
 						/>
+						<p className="text-xs text-muted-foreground -mt-2">
+							A value can copy a label, e.g. <code className="text-[11px]">owner={'{{label.team}}'}</code>
+							.
+						</p>
 
 						<div className="space-y-2">
 							<Label htmlFor="enrichment-summary" className="text-xs">
@@ -271,10 +291,37 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment }: Enrichm
 							/>
 							<p className="text-xs text-muted-foreground">
 								Replaces the alert summary. Use {'{{summary}}'} for the current summary, plus{' '}
-								{'{{name}}'} and {'{{status}}'}. New lines and basic HTML ({'<b>'}, {'<a>'}, lists) are
-								rendered in the alert details.
+								{'{{name}}'}, {'{{status}}'}, and any label as {'{{label.<key>}}'}. New lines and basic
+								HTML ({'<b>'}, {'<a>'}, lists) are rendered in the alert details.
 							</p>
 						</div>
+
+						{labelKeys.length > 0 && (
+							<div className="space-y-1.5">
+								<p className="text-xs text-muted-foreground">
+									Available labels (click to copy a placeholder):
+								</p>
+								<div className="flex flex-wrap gap-1.5">
+									{labelKeys.map((key) => {
+										const placeholder = `{{label.${key}}}`;
+										return (
+											<button
+												key={key}
+												type="button"
+												onClick={() => {
+													void navigator.clipboard?.writeText(placeholder);
+													toast({ title: 'Copied', description: placeholder });
+												}}
+												className="px-2 py-0.5 rounded-full border bg-background hover:bg-muted text-[11px] font-mono"
+												title={`Copy ${placeholder}`}
+											>
+												{placeholder}
+											</button>
+										);
+									})}
+								</div>
+							</div>
+						)}
 					</div>
 				</div>
 

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -18,7 +18,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
 import { AlertEnrichment } from '@OpsiMate/shared';
-import { FileText, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
+import { Copy, FileText, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 const MatchBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
@@ -70,6 +70,7 @@ const Enrichments: React.FC = () => {
 	const [search, setSearch] = useState('');
 	const [editing, setEditing] = useState<AlertEnrichment | null>(null);
 	const [creating, setCreating] = useState(false);
+	const [duplicating, setDuplicating] = useState<AlertEnrichment | null>(null);
 	const [deleting, setDeleting] = useState<AlertEnrichment | null>(null);
 
 	const filtered = useMemo(() => {
@@ -208,6 +209,16 @@ const Enrichments: React.FC = () => {
 														variant="ghost"
 														size="icon"
 														className="h-8 w-8"
+														onClick={() => setDuplicating(e)}
+														aria-label="Duplicate enrichment"
+														title="Copy to a new rule"
+													>
+														<Copy className="h-4 w-4" />
+													</Button>
+													<Button
+														variant="ghost"
+														size="icon"
+														className="h-8 w-8"
 														onClick={() => setEditing(e)}
 														aria-label="Edit enrichment"
 													>
@@ -240,6 +251,13 @@ const Enrichments: React.FC = () => {
 					if (!open) setEditing(null);
 				}}
 				enrichment={editing}
+			/>
+			<EnrichmentFormDialog
+				open={!!duplicating}
+				onOpenChange={(open) => {
+					if (!open) setDuplicating(null);
+				}}
+				duplicateFrom={duplicating}
 			/>
 
 			<AlertDialog open={!!deleting} onOpenChange={(open) => !open && setDeleting(null)}>

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -55,13 +55,20 @@ export class EnrichmentBL {
 
 	// Templates may reference the alert's current values; enrichments chain in order, so a
 	// later rule's {{summary}} sees the previous rule's output.
+	// Templates can reference the alert's own values. Besides {{summary}}, {{name}} and
+	// {{status}}, any label/tag is available as {{label.<key>}} (alias {{tag.<key>}}), e.g.
+	// {{label.host}}. Unknown placeholders are left untouched.
 	private static resolveTemplate(template: string, alert: Alert): string {
 		const ctx: Record<string, string> = {
 			summary: alert.summary ?? '',
 			name: alert.alertName ?? '',
 			status: alert.status ?? '',
 		};
-		return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key: string) => (key in ctx ? ctx[key] : match));
+		for (const [key, value] of Object.entries(alert.tags ?? {})) {
+			ctx[`label.${key}`] = String(value);
+			ctx[`tag.${key}`] = String(value);
+		}
+		return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (match, key: string) => (key in ctx ? ctx[key] : match));
 	}
 
 	// claimedKeys tracks fields already set by a higher-priority rule in this pass, so the
@@ -71,7 +78,8 @@ export class EnrichmentBL {
 		const tags = { ...alert.tags };
 		for (const field of enrichment.addFields ?? []) {
 			if (claimedKeys.has(field.key)) continue;
-			tags[field.key] = field.value;
+			// Field values are templated too, so a field can copy a label, e.g. owner={{label.team}}.
+			tags[field.key] = EnrichmentBL.resolveTemplate(field.value, alert);
 			claimedKeys.add(field.key);
 		}
 		const summary =


### PR DESCRIPTION
## Summary
Three usability improvements to alert enrichment.

### 1. Default summary template = `{{summary}}`
A new rule opens with the summary template pre-filled with `{{summary}}`, so you keep the alert's existing summary and just append to it instead of accidentally replacing it.

### 2. Reference labels in templates
Templates can now use any of the alert's labels/tags as `{{label.<key>}}` (alias `{{tag.<key>}}`), in addition to `{{summary}}` / `{{name}}` / `{{status}}`. This works in **both**:
- the **summary template** — e.g. `{{summary}} — host {{label.host}}, sev {{label.severity}}`
- a **field's value** — so a field can copy a label, e.g. `owner_team = {{label.team}}`

The form documents the placeholders and lists the labels found on current alerts as click-to-copy chips.

### 3. Copy from existing
Each rule row gets a **Duplicate** action that opens the create dialog pre-filled from that rule (name suffixed `(copy)`), so building a similar rule is quick. It saves as a new rule; the original is untouched.

## Testing
- Verified end-to-end against a running instance: `{{label.*}}` resolved in both summary and field value (e.g. `owner_team={{label.team}}` → `dba`); default `{{summary}}` pre-filled; Duplicate opens "New enrichment" pre-filled with "… (copy)" and a "Create enrichment" button.
- All CI gates replicated locally: build, lint `--max-warnings=0` (server/shared/custom-actions) + client lint, prettier across packages, server tests 97 ✓, client tests 24 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to duplicate existing enrichment rules from the Enrichments page.
  * Enrichment templates now support additional placeholders: `{{summary}}`, `{{name}}`, `{{status}}`, and `{{label.<key>}}` for alert tags.
  * Clickable chips display available label keys with one-click clipboard copying.
  * Template placeholders are now processed in enrichment field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->