### PR TITLE
test(providers): add API tests for bulk create endpoint (+ fix 400 validation)

### DIFF
--- a/apps/server/src/api/v1/providers/controller.ts
+++ b/apps/server/src/api/v1/providers/controller.ts
@@ -80,22 +80,31 @@ export class ProviderController {
 	}
 
 	async createProviderBulk(req: AuthenticatedRequest, res: Response) {
-		const providerToCreate = CreateProviderBulkSchema.parse(req.body);
+		try {
+			const providerToCreate = CreateProviderBulkSchema.parse(req.body);
 
-		const created = Date.now().toString();
+			const created = Date.now().toString();
 
-		const providesPromises = providerToCreate.providers.map((provider) => {
-			return this.providerBL.createProvider(
-				{
-					...provider,
-					createdAt: created,
-				},
-				req.user as User
-			);
-		});
-		const providers = await Promise.all(providesPromises);
-		const providerIds = providers.map((provider) => provider.id);
-		return res.status(201).json({ success: true, data: { providerIds } });
+			const providesPromises = providerToCreate.providers.map((provider) => {
+				return this.providerBL.createProvider(
+					{
+						...provider,
+						createdAt: created,
+					},
+					req.user as User
+				);
+			});
+			const providers = await Promise.all(providesPromises);
+			const providerIds = providers.map((provider) => provider.id);
+			return res.status(201).json({ success: true, data: { providerIds } });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			} else {
+				logger.error('Error creating providers in bulk:', error);
+				return res.status(500).json({ success: false, error: 'Internal server error' });
+			}
+		}
 	}
 
 	async testConnection(req: Request, res: Response) {

--- a/apps/server/tests/providers.test.ts
+++ b/apps/server/tests/providers.test.ts
@@ -182,6 +182,107 @@ describe('Providers API', () => {
 		expect(bulkProvider2).toBeDefined();
 	});
 
+	test('bulk creation should return a well-formed response structure', async () => {
+		const providersData = [
+			{
+				name: 'Structured Provider',
+				providerIP: '10.0.1.1',
+				username: 'structureduser',
+				password: 'structuredpassword',
+				SSHPort: 22,
+				providerType: 'VM',
+			},
+		];
+
+		const bulkRes = await app
+			.post('/api/v1/providers/bulk')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ providers: providersData });
+
+		expect(bulkRes.status).toBe(201);
+		expect(bulkRes.body).toMatchObject({ success: true });
+		expect(bulkRes.body.data).toBeDefined();
+		expect(Array.isArray(bulkRes.body.data.providerIds)).toBe(true);
+		expect(bulkRes.body.data.providerIds.length).toBe(providersData.length);
+		// every returned id should be a number
+		bulkRes.body.data.providerIds.forEach((id: unknown) => {
+			expect(typeof id).toBe('number');
+		});
+	});
+
+	test('bulk creation should require authentication', async () => {
+		const bulkRes = await app.post('/api/v1/providers/bulk').send({
+			providers: [
+				{
+					name: 'Unauthorized Bulk Provider',
+					providerIP: '10.0.2.1',
+					username: 'unauthuser',
+					password: 'unauthpassword',
+					SSHPort: 22,
+					providerType: 'VM',
+				},
+			],
+		});
+
+		expect(bulkRes.status).toBe(401);
+	});
+
+	test('bulk creation should reject an empty providers array with 400', async () => {
+		const bulkRes = await app
+			.post('/api/v1/providers/bulk')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ providers: [] });
+
+		expect(bulkRes.status).toBe(400);
+		expect(bulkRes.body.success).toBe(false);
+		expect(bulkRes.body.error).toBe('Validation error');
+	});
+
+	test('bulk creation should reject a missing providers field with 400', async () => {
+		const bulkRes = await app.post('/api/v1/providers/bulk').set('Authorization', `Bearer ${jwtToken}`).send({});
+
+		expect(bulkRes.status).toBe(400);
+		expect(bulkRes.body.success).toBe(false);
+	});
+
+	test('bulk creation should reject the whole batch when one provider is invalid (partial failure)', async () => {
+		const providersData = [
+			{
+				name: 'Valid Provider',
+				providerIP: '10.0.3.1',
+				username: 'validuser',
+				password: 'validpassword',
+				SSHPort: 22,
+				providerType: 'VM',
+			},
+			{
+				// invalid: unknown providerType and no password/secret
+				name: 'Invalid Provider',
+				providerIP: '10.0.3.2',
+				username: 'invaliduser',
+				SSHPort: 22,
+				providerType: 'NOT_A_REAL_TYPE',
+			},
+		];
+
+		const bulkRes = await app
+			.post('/api/v1/providers/bulk')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ providers: providersData });
+
+		expect(bulkRes.status).toBe(400);
+		expect(bulkRes.body.success).toBe(false);
+		expect(bulkRes.body.error).toBe('Validation error');
+
+		// validation happens before any insert, so no provider from the batch should be persisted
+		const getRes = await app.get('/api/v1/providers').set('Authorization', `Bearer ${jwtToken}`);
+		expect(getRes.status).toBe(200);
+		const validProvider = getRes.body.data.providers.find((p: Provider) => p.name === 'Valid Provider');
+		expect(validProvider).toBeUndefined();
+		// only the seeded provider should remain
+		expect(getRes.body.data.providers.length).toBe(1);
+	});
+
 	// todo: add tests to the following routes:
 	// router.post('/:providerId/refresh', controller.refreshProvider.bind(controller));
 	// router.post('/test-connection', controller.testConnection.bind(controller));


### PR DESCRIPTION
Closes #371

## Summary
Adds API tests for the bulk create providers endpoint (`POST /api/v1/providers/bulk`), which previously had only a single happy-path test. Covers the scenarios requested in the issue: valid bulk create, partial-failure/invalid data, permissions, and response structure.

## Test scenarios added
| Scenario | Expected | Status |
|---|---|---|
| ✅ Valid bulk create returns well-formed response (`success`, numeric `providerIds`) | 201 | ✔ |
| 🔒 Missing authentication | 401 | ✔ |
| ❌ Empty `providers` array | 400 `Validation error` | ✔ |
| ❌ Missing `providers` field | 400 | ✔ |
| ❌ One invalid provider in the batch → whole batch rejected, **nothing persisted** | 400 | ✔ |

## Bug found & fixed while writing the tests
Writing the invalid-data tests surfaced a real inconsistency:

- `createProvider` wraps `CreateProviderSchema.parse()` in `try/catch` and returns **400** on `ZodError`.
- `createProviderBulk` did **not** wrap `CreateProviderBulkSchema.parse()`. Because routes use `express-promise-router`, the rejected promise was forwarded to Express's default error handler and returned **500** for invalid input.

I fixed `createProviderBulk` to mirror `createProvider`'s handling, so validation failures now return:
```json
{ "success": false, "error": "Validation error", "details": [ ... ] }
```

This also aligns with the error-handling consistency goal in #1378.

## Verification
- `npx vitest run tests/providers.test.ts` → **11 passed** (6 existing + 5 new).
- `prettier --check` clean on both changed files.
- The fix is a verbatim mirror of the existing `createProvider` error branch.

> Note: I kept the change minimal and scoped to validation handling. If you'd prefer the test-only change without the controller fix, happy to split it — but the invalid-data test is only meaningful once bulk returns 400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk provider creation with a structured response that returns the created provider IDs.
* **Bug Fixes**
  * Improved error handling for bulk provider creation, including clear validation errors for invalid requests and a server error response for unexpected failures.
  * Ensures bulk creation is all-or-nothing, so invalid entries do not result in partial saves.
* **Tests**
  * Added coverage for authentication, input validation, successful bulk creation, and rejection of invalid batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->