### PR TITLE
feat(server): audit logging for enrichment mutations

### DIFF
--- a/apps/server/src/api/v1/enrichments/controller.ts
+++ b/apps/server/src/api/v1/enrichments/controller.ts
@@ -53,7 +53,7 @@ export class EnrichmentController {
 					summaryTemplate: data.summaryTemplate ?? null,
 					priority: data.priority ?? 0,
 				},
-				req.user?.fullName
+				req.user
 			);
 			return res.status(201).json({ success: true, data: enrichment, message: 'Enrichment created' });
 		} catch (error) {
@@ -75,7 +75,7 @@ export class EnrichmentController {
 				return res.status(404).json({ success: false, error: 'Enrichment not found' });
 			}
 
-			const updated = await this.enrichmentBL.update(enrichmentId, data, req.user?.fullName);
+			const updated = await this.enrichmentBL.update(enrichmentId, data, req.user);
 			return res.json({ success: true, data: updated, message: 'Enrichment updated' });
 		} catch (error) {
 			if (isZodError(error)) {
@@ -86,14 +86,14 @@ export class EnrichmentController {
 		}
 	};
 
-	deleteHandler = async (req: Request, res: Response) => {
+	deleteHandler = async (req: AuthenticatedRequest, res: Response) => {
 		try {
 			const { enrichmentId } = AlertEnrichmentIdSchema.parse({ enrichmentId: req.params.enrichmentId });
 			const existing = await this.enrichmentBL.get(enrichmentId);
 			if (!existing) {
 				return res.status(404).json({ success: false, error: 'Enrichment not found' });
 			}
-			await this.enrichmentBL.delete(enrichmentId);
+			await this.enrichmentBL.delete(enrichmentId, req.user);
 			return res.json({ success: true, message: 'Enrichment deleted' });
 		} catch (error) {
 			if (isZodError(error)) {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -171,7 +171,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const playgroundBL = new PlaygroundBL(playgroundRepo, mailClient);
 	const silenceBL = new SilenceBL(silenceRepo);
 	alertBL.setSilenceBL(silenceBL);
-	const enrichmentBL = new EnrichmentBL(enrichmentRepo);
+	const enrichmentBL = new EnrichmentBL(enrichmentRepo, auditBL);
 	alertBL.setEnrichmentBL(enrichmentBL);
 	const actionBL = new ActionBL(actionRepo, alertHistoryRepo);
 

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -40,9 +40,10 @@ export class EnrichmentBL {
 	}
 
 	async update(id: number, data: UpdateEnrichmentInput, actor?: User | null): Promise<AlertEnrichment | undefined> {
+		const shouldAudit = this.hasUpdateData(data);
 		await this.enrichmentRepo.updateEnrichment(id, data, actor?.fullName);
 		const updated = await this.enrichmentRepo.getEnrichmentById(id);
-		if (updated) {
+		if (updated && shouldAudit) {
 			await this.recordAuditAction(AuditActionType.UPDATE, updated, actor, JSON.stringify(data));
 		}
 		return updated;
@@ -62,6 +63,17 @@ export class EnrichmentBL {
 			userId: Number.isFinite(parsedUserId) ? parsedUserId : API_TOKEN_ACTOR_ID,
 			userName: actor?.fullName ?? API_TOKEN_ACTOR_NAME,
 		};
+	}
+
+	private hasUpdateData(data: UpdateEnrichmentInput): boolean {
+		return (
+			data.name !== undefined ||
+			data.nameContains !== undefined ||
+			data.labelMatchers !== undefined ||
+			data.addFields !== undefined ||
+			data.summaryTemplate !== undefined ||
+			data.priority !== undefined
+		);
 	}
 
 	private async recordAuditAction(

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -1,17 +1,33 @@
-import { Alert, AlertEnrichment, AppliedEnrichment, Logger } from '@OpsiMate/shared';
+import {
+	Alert,
+	AlertEnrichment,
+	AppliedEnrichment,
+	AuditActionType,
+	AuditResourceType,
+	Logger,
+	User,
+} from '@OpsiMate/shared';
 import { CreateEnrichmentInput, EnrichmentRepository, UpdateEnrichmentInput } from '../../dal/enrichmentRepository';
+import { AuditBL } from '../audit/audit.bl';
 
 const logger = new Logger('bl/enrichment.bl');
 
-export class EnrichmentBL {
-	constructor(private enrichmentRepo: EnrichmentRepository) {}
+const API_TOKEN_ACTOR_ID = 0;
+const API_TOKEN_ACTOR_NAME = 'API Token';
 
-	async create(data: CreateEnrichmentInput, actor?: string | null): Promise<AlertEnrichment> {
-		const { lastID } = await this.enrichmentRepo.createEnrichment(data, actor);
+export class EnrichmentBL {
+	constructor(
+		private enrichmentRepo: EnrichmentRepository,
+		private auditBL: AuditBL
+	) {}
+
+	async create(data: CreateEnrichmentInput, actor?: User | null): Promise<AlertEnrichment> {
+		const { lastID } = await this.enrichmentRepo.createEnrichment(data, actor?.fullName);
 		const created = await this.enrichmentRepo.getEnrichmentById(lastID);
 		if (!created) {
 			throw new Error('Failed to retrieve created enrichment');
 		}
+		await this.recordAuditAction(AuditActionType.CREATE, created, actor);
 		return created;
 	}
 
@@ -23,13 +39,51 @@ export class EnrichmentBL {
 		return this.enrichmentRepo.getEnrichmentById(id);
 	}
 
-	async update(id: number, data: UpdateEnrichmentInput, actor?: string | null): Promise<AlertEnrichment | undefined> {
-		await this.enrichmentRepo.updateEnrichment(id, data, actor);
-		return this.enrichmentRepo.getEnrichmentById(id);
+	async update(id: number, data: UpdateEnrichmentInput, actor?: User | null): Promise<AlertEnrichment | undefined> {
+		await this.enrichmentRepo.updateEnrichment(id, data, actor?.fullName);
+		const updated = await this.enrichmentRepo.getEnrichmentById(id);
+		if (updated) {
+			await this.recordAuditAction(AuditActionType.UPDATE, updated, actor, JSON.stringify(data));
+		}
+		return updated;
 	}
 
-	async delete(id: number): Promise<void> {
+	async delete(id: number, actor?: User | null): Promise<void> {
+		const existing = await this.enrichmentRepo.getEnrichmentById(id);
 		await this.enrichmentRepo.deleteEnrichment(id);
+		if (existing) {
+			await this.recordAuditAction(AuditActionType.DELETE, existing, actor);
+		}
+	}
+
+	private getAuditActor(actor?: User | null): { userId: number; userName: string } {
+		const parsedUserId = actor?.id !== undefined ? Number(actor.id) : NaN;
+		return {
+			userId: Number.isFinite(parsedUserId) ? parsedUserId : API_TOKEN_ACTOR_ID,
+			userName: actor?.fullName ?? API_TOKEN_ACTOR_NAME,
+		};
+	}
+
+	private async recordAuditAction(
+		actionType: AuditActionType,
+		enrichment: AlertEnrichment,
+		actor?: User | null,
+		details?: string
+	): Promise<void> {
+		try {
+			const auditActor = this.getAuditActor(actor);
+			await this.auditBL.logAction({
+				actionType,
+				resourceType: AuditResourceType.ENRICHMENT,
+				resourceId: String(enrichment.id),
+				userId: auditActor.userId,
+				userName: auditActor.userName,
+				resourceName: enrichment.name,
+				details,
+			});
+		} catch (error) {
+			logger.error(`Failed to record enrichment audit event (${actionType}) for ${enrichment.id}`, error);
+		}
 	}
 
 	// Same matching semantics as silences: nameContains is a case-insensitive substring match

--- a/apps/server/tests/audit.test.ts
+++ b/apps/server/tests/audit.test.ts
@@ -58,6 +58,37 @@ describe('Audit Logs API', () => {
 		expect(log.resourceName).toBeDefined();
 	});
 
+	test('should log enrichment creation and retrieve audit logs', async () => {
+		const enrichmentData = {
+			name: 'Audit Enrichment Rule',
+			nameContains: 'CPU',
+			addFields: [{ key: 'owner', value: 'platform' }],
+			priority: 5,
+		};
+
+		const createRes = await app
+			.post('/api/v1/enrichments')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send(enrichmentData);
+
+		expect(createRes.status).toBe(201);
+		expect(createRes.body.success).toBe(true);
+
+		const auditRes = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
+		expect(auditRes.status).toBe(200);
+		expect(Array.isArray(auditRes.body.logs)).toBe(true);
+		expect(auditRes.body.logs.length).toBe(1);
+
+		const log: AuditLog = auditRes.body.logs[0];
+		expect(log.actionType).toBe(AuditActionType.CREATE);
+		expect(log.resourceType).toBe(AuditResourceType.ENRICHMENT);
+		expect(log.resourceId).toBe(String(createRes.body.data.id));
+		expect(log.resourceName).toBe(enrichmentData.name);
+		expect(log.userName).toBe('Provider User');
+		expect(log.userId).toBeDefined();
+		expect(log.timestamp).toBeDefined();
+	});
+
 	test('should support pagination', async () => {
 		// Create multiple providers to generate audit logs
 		for (let i = 0; i < 5; i++) {

--- a/apps/server/tests/audit.test.ts
+++ b/apps/server/tests/audit.test.ts
@@ -16,9 +16,14 @@ beforeAll(async () => {
 	db = await setupDB();
 	app = await setupExpressApp(db);
 	jwtToken = await setupUserWithToken(app);
-	const testUser = db.prepare('SELECT id FROM users WHERE email = ?').get('provideruser@example.com') as {
-		id: number;
-	};
+	const testUser = db.prepare('SELECT id FROM users WHERE email = ?').get('provideruser@example.com') as
+		| {
+				id: number;
+		  }
+		| undefined;
+	if (!testUser) {
+		throw new Error('Expected test user provideruser@example.com to exist');
+	}
 	testUserId = testUser.id;
 });
 
@@ -92,6 +97,86 @@ describe('Audit Logs API', () => {
 		expect(log.userName).toBe('Provider User');
 		expect(log.userId).toBe(testUserId);
 		expect(log.timestamp).toBeDefined();
+	});
+
+	test('should log enrichment update and delete audit entries', async () => {
+		const createRes = await app
+			.post('/api/v1/enrichments')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({
+				name: 'Audit Enrichment Lifecycle',
+				nameContains: 'Disk',
+				addFields: [{ key: 'team', value: 'storage' }],
+				priority: 1,
+			});
+
+		expect(createRes.status).toBe(201);
+		expect(createRes.body.success).toBe(true);
+
+		const resourceId = String(createRes.body.data.id);
+		const updateRes = await app
+			.put(`/api/v1/enrichments/${resourceId}`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ name: 'Audit Enrichment Lifecycle Updated' });
+
+		expect(updateRes.status).toBe(200);
+		expect(updateRes.body.success).toBe(true);
+
+		const deleteRes = await app
+			.delete(`/api/v1/enrichments/${resourceId}`)
+			.set('Authorization', `Bearer ${jwtToken}`);
+
+		expect(deleteRes.status).toBe(200);
+		expect(deleteRes.body.success).toBe(true);
+
+		const auditRes = await app.get('/api/v1/audit?page=1&pageSize=10').set('Authorization', `Bearer ${jwtToken}`);
+		expect(auditRes.status).toBe(200);
+
+		const logs = auditRes.body.logs as AuditLog[];
+		const enrichmentLogs = logs.filter(
+			(log) => log.resourceType === AuditResourceType.ENRICHMENT && log.resourceId === resourceId
+		);
+
+		expect(enrichmentLogs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ actionType: AuditActionType.CREATE }),
+				expect.objectContaining({ actionType: AuditActionType.UPDATE }),
+				expect.objectContaining({ actionType: AuditActionType.DELETE }),
+			])
+		);
+		for (const log of enrichmentLogs) {
+			expect(log.userId).toBe(testUserId);
+			expect(log.userName).toBe('Provider User');
+		}
+	});
+
+	test('should not log enrichment update audit entry for empty payload', async () => {
+		const createRes = await app
+			.post('/api/v1/enrichments')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({
+				name: 'Audit Enrichment No-op Update',
+				nameContains: 'Memory',
+				addFields: [{ key: 'team', value: 'platform' }],
+				priority: 1,
+			});
+
+		expect(createRes.status).toBe(201);
+		expect(createRes.body.success).toBe(true);
+
+		db.exec('DELETE FROM audit_logs');
+
+		const updateRes = await app
+			.put(`/api/v1/enrichments/${createRes.body.data.id}`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({});
+
+		expect(updateRes.status).toBe(200);
+		expect(updateRes.body.success).toBe(true);
+
+		const auditRes = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
+		expect(auditRes.status).toBe(200);
+		expect(auditRes.body.logs).toHaveLength(0);
 	});
 
 	test('should support pagination', async () => {

--- a/apps/server/tests/audit.test.ts
+++ b/apps/server/tests/audit.test.ts
@@ -6,6 +6,7 @@ import { setupDB, setupExpressApp, setupUserWithToken } from './setup.ts';
 let app: SuperTest<Test>;
 let db: Database.Database;
 let jwtToken: string;
+let testUserId: number;
 
 const seedProviders = () => {
 	db.exec('DELETE FROM audit_logs');
@@ -15,6 +16,10 @@ beforeAll(async () => {
 	db = await setupDB();
 	app = await setupExpressApp(db);
 	jwtToken = await setupUserWithToken(app);
+	const testUser = db.prepare('SELECT id FROM users WHERE email = ?').get('provideruser@example.com') as {
+		id: number;
+	};
+	testUserId = testUser.id;
 });
 
 beforeEach(() => {
@@ -85,7 +90,7 @@ describe('Audit Logs API', () => {
 		expect(log.resourceId).toBe(String(createRes.body.data.id));
 		expect(log.resourceName).toBe(enrichmentData.name);
 		expect(log.userName).toBe('Provider User');
-		expect(log.userId).toBeDefined();
+		expect(log.userId).toBe(testUserId);
 		expect(log.timestamp).toBeDefined();
 	});
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,8 +7,8 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,10 +4,10 @@
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
-	"types": "./src/index.ts",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./src/index.ts",
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
 		}
 	},

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,11 +4,11 @@
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
+	"types": "./src/index.ts",
 	"exports": {
 		".": {
-			"import": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./src/index.ts",
+			"import": "./dist/index.js"
 		}
 	},
 	"scripts": {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -200,6 +200,7 @@ export enum AuditResourceType {
 	USER = 'USER',
 	DASHBOARD = 'DASHBOARD',
 	SECRET = 'SECRET',
+	ENRICHMENT = 'ENRICHMENT',
 	// Add more as needed
 }
 


### PR DESCRIPTION
## Issue Reference
Closes #653 

---

## What Was Changed
- Added ENRICHMENT to AuditResourceType.
- Injected AuditBL into EnrichmentBL.
- Added audit logging after enrichment create, update, and delete mutations.
- Passed the authenticated req.user from enrichment controller methods into the BL.
- Added graceful fallback actor handling for API-token requests with no req.user.
- Made enrichment audit writes best-effort, so audit failures do not fail the mutation.
- Added a server test asserting enrichment creation writes anaudit row.

---

## Why Was It Changed
- Enrichment rules change alert content for all users, so create/update/delete actions need historical traceability.
- last_modified_by only stores the latest editor, not a full audit history.
- Existing resources already use audit logging, so enrichments now follow the same pattern.
- API-token authenticated requests should keep working even without a user object.
- Audit logging should not block the actual enrichment mutation if the audit insert fails.
- The new test prevents regressions for create audit behavior.

---

## Test Result
Ran `pnpm test`

### Step 1 - create enrichment
<img width="1301" height="884" alt="Screenshot 2026-07-05 at 9 41 47 AM" src="https://github.com/user-attachments/assets/9bb7f1ca-b896-43ec-ab46-c9679f721bd9" />

### Step 2 - update enrichment
<img width="1300" height="886" alt="Screenshot 2026-07-05 at 9 42 09 AM" src="https://github.com/user-attachments/assets/890723dd-b1c6-4908-9dbf-8cf93ff2f926" />

### Step 3 - delete enrichment
<img width="1301" height="888" alt="Screenshot 2026-07-05 at 9 42 33 AM" src="https://github.com/user-attachments/assets/ed961855-d8c5-43ec-b97b-724761c0d9f3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enrichment create, update, and delete actions now emit audit entries tagged to an **ENRICHMENT** resource type, including the acting user.
* **Bug Fixes**
  * Improved audit attribution to consistently use authenticated user context for enrichment actions, including accurate actor details.
  * Enrichment audit logs are recorded only when appropriate (e.g., no audit for empty update payloads).
* **Tests**
  * Added coverage for enrichment audit lifecycle (create/update/delete) and verified no audit entries are produced for empty update payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->