### PR TITLE
Feat/alert severity

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
@@ -5,6 +5,8 @@ import { useUsers } from '@/hooks/queries/users';
 import { Alert, AlertStatus } from '@OpsiMate/shared';
 import { Sparkles } from 'lucide-react';
 import { IntegrationAvatar, resolveAlertIntegration } from '../../IntegrationAvatar';
+import { SeverityBadge } from '../../SeverityBadge';
+import { getAlertSeverity } from '../../utils/severity.utils';
 
 interface AlertInfoSectionProps {
 	alert: Alert;
@@ -37,6 +39,7 @@ export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 				<span className="text-sm text-muted-foreground">Owner:</span>
 				<PersonPicker selectedUserId={alert.ownerId} onSelect={handleOwnerChange} users={users} />
 				<div className="ml-auto flex items-center gap-2">
+					<SeverityBadge severity={getAlertSeverity(alert)} showLabel />
 					<Badge
 						variant={
 							alert.isDismissed

--- a/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
@@ -1,9 +1,9 @@
 import { PersonPicker } from '@/components/PersonPicker';
-import { Badge } from '@/components/ui/badge';
 import { useSetAlertOwner } from '@/hooks/queries/alerts';
+import { cn } from '@/lib/utils';
 import { useUsers } from '@/hooks/queries/users';
 import { Alert, AlertStatus } from '@OpsiMate/shared';
-import { Sparkles } from 'lucide-react';
+import { BellOff, CircleCheck, Flame, Sparkles } from 'lucide-react';
 import { IntegrationAvatar, resolveAlertIntegration } from '../../IntegrationAvatar';
 import { SeverityBadge } from '../../SeverityBadge';
 import { getAlertSeverity } from '../../utils/severity.utils';
@@ -12,10 +12,19 @@ interface AlertInfoSectionProps {
 	alert: Alert;
 }
 
+// Icon + color for the alert's lifecycle state, shown icon-only (tooltip carries the label)
+// to keep the owner row compact.
+const getStatusIndicator = (alert: Alert) => {
+	if (alert.isDismissed) return { Icon: BellOff, label: 'Dismissed', className: 'text-muted-foreground' };
+	if (alert.status === AlertStatus.FIRING) return { Icon: Flame, label: 'Firing', className: 'text-red-500' };
+	return { Icon: CircleCheck, label: 'Resolved', className: 'text-emerald-500' };
+};
+
 export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 	const integration = resolveAlertIntegration(alert);
 	const { data: users = [] } = useUsers();
 	const { mutate: setOwner } = useSetAlertOwner();
+	const status = getStatusIndicator(alert);
 
 	const handleOwnerChange = (userId: string | null) => {
 		setOwner({ alertId: alert.id, ownerId: userId });
@@ -38,29 +47,20 @@ export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 			<div className="flex items-center gap-2 flex-wrap">
 				<span className="text-sm text-muted-foreground">Owner:</span>
 				<PersonPicker selectedUserId={alert.ownerId} onSelect={handleOwnerChange} users={users} />
+				{/* Icon-only indicators (severity, status, enriched) — labels live in tooltips
+				    so the owner row stays compact even in a narrow panel. */}
 				<div className="ml-auto flex items-center gap-2">
-					<SeverityBadge severity={getAlertSeverity(alert)} showLabel />
-					<Badge
-						variant={
-							alert.isDismissed
-								? 'secondary'
-								: alert.status === AlertStatus.FIRING
-									? 'destructive'
-									: 'secondary'
-						}
-						className="flex-shrink-0 text-xs px-1.5 py-0.5"
-					>
-						{alert.isDismissed ? 'dismissed' : alert.status}
-					</Badge>
+					<SeverityBadge severity={getAlertSeverity(alert)} />
+					<span className={cn('flex-shrink-0', status.className)} title={`Status: ${status.label}`}>
+						<status.Icon className="h-3.5 w-3.5" aria-label={status.label} />
+					</span>
 					{alert.appliedEnrichments && alert.appliedEnrichments.length > 0 && (
-						<Badge
-							variant="secondary"
-							className="flex-shrink-0 gap-1 text-xs px-1.5 py-0.5 bg-violet-500/15 text-violet-700 dark:text-violet-300 border-violet-500/30"
+						<span
+							className="flex-shrink-0 text-violet-500"
 							title={`Enriched by: ${alert.appliedEnrichments.map((e) => e.name).join(', ')}`}
 						>
-							<Sparkles className="h-3 w-3" />
-							Enriched
-						</Badge>
+							<Sparkles className="h-3.5 w-3.5" aria-label="Enriched" />
+						</span>
 					)}
 				</div>
 			</div>

--- a/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
@@ -1,4 +1,5 @@
 import { PersonPicker } from '@/components/PersonPicker';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useSetAlertOwner } from '@/hooks/queries/alerts';
 import { useUsers } from '@/hooks/queries/users';
 import { Alert } from '@OpsiMate/shared';
@@ -44,12 +45,19 @@ export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 					<SeverityBadge severity={getAlertSeverity(alert)} />
 					<StatusBadge alert={alert} />
 					{alert.appliedEnrichments && alert.appliedEnrichments.length > 0 && (
-						<span
-							className="flex-shrink-0 text-violet-500"
-							title={`Enriched by: ${alert.appliedEnrichments.map((e) => e.name).join(', ')}`}
-						>
-							<Sparkles className="h-3.5 w-3.5" aria-label="Enriched" />
-						</span>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span
+									className="flex-shrink-0 text-violet-500"
+									aria-label={`Enriched by: ${alert.appliedEnrichments.map((e) => e.name).join(', ')}`}
+								>
+									<Sparkles className="h-3.5 w-3.5" aria-hidden />
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>
+								Enriched by: {alert.appliedEnrichments.map((e) => e.name).join(', ')}
+							</TooltipContent>
+						</Tooltip>
 					)}
 				</div>
 			</div>

--- a/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
@@ -1,30 +1,21 @@
 import { PersonPicker } from '@/components/PersonPicker';
 import { useSetAlertOwner } from '@/hooks/queries/alerts';
-import { cn } from '@/lib/utils';
 import { useUsers } from '@/hooks/queries/users';
-import { Alert, AlertStatus } from '@OpsiMate/shared';
-import { BellOff, CircleCheck, Flame, Sparkles } from 'lucide-react';
+import { Alert } from '@OpsiMate/shared';
+import { Sparkles } from 'lucide-react';
 import { IntegrationAvatar, resolveAlertIntegration } from '../../IntegrationAvatar';
 import { SeverityBadge } from '../../SeverityBadge';
+import { StatusBadge } from '../../StatusBadge';
 import { getAlertSeverity } from '../../utils/severity.utils';
 
 interface AlertInfoSectionProps {
 	alert: Alert;
 }
 
-// Icon + color for the alert's lifecycle state, shown icon-only (tooltip carries the label)
-// to keep the owner row compact.
-const getStatusIndicator = (alert: Alert) => {
-	if (alert.isDismissed) return { Icon: BellOff, label: 'Dismissed', className: 'text-muted-foreground' };
-	if (alert.status === AlertStatus.FIRING) return { Icon: Flame, label: 'Firing', className: 'text-red-500' };
-	return { Icon: CircleCheck, label: 'Resolved', className: 'text-emerald-500' };
-};
-
 export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 	const integration = resolveAlertIntegration(alert);
 	const { data: users = [] } = useUsers();
 	const { mutate: setOwner } = useSetAlertOwner();
-	const status = getStatusIndicator(alert);
 
 	const handleOwnerChange = (userId: string | null) => {
 		setOwner({ alertId: alert.id, ownerId: userId });
@@ -51,9 +42,7 @@ export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 				    so the owner row stays compact even in a narrow panel. */}
 				<div className="ml-auto flex items-center gap-2">
 					<SeverityBadge severity={getAlertSeverity(alert)} />
-					<span className={cn('flex-shrink-0', status.className)} title={`Status: ${status.label}`}>
-						<status.Icon className="h-3.5 w-3.5" aria-label={status.label} />
-					</span>
+					<StatusBadge alert={alert} />
 					{alert.appliedEnrichments && alert.appliedEnrichments.length > 0 && (
 						<span
 							className="flex-shrink-0 text-violet-500"

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -15,7 +15,7 @@ import { useServices } from '@/hooks/queries/services';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Bell, Columns2, LayoutList } from 'lucide-react';
+import { Archive, Bell, Columns2, LayoutList, Palette } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertsFilterPanel } from '.';
@@ -37,6 +37,7 @@ import {
 	useAlertTagKeys,
 	useArchivedTabStatusFilterReset,
 	useColumnManagement,
+	useSeverityColors,
 } from './hooks';
 
 const Alerts = () => {
@@ -68,6 +69,7 @@ const Alerts = () => {
 	const [filterPanelCollapsed, setFilterPanelCollapsed] = useState(false);
 	const [showDashboardSettings, setShowDashboardSettings] = useState(false);
 	const [splitByAssignment, setSplitByAssignment] = useState(false);
+	const { severityColors, toggleSeverityColors } = useSeverityColors();
 
 	const allAlerts = useMemo(() => [...alerts, ...archivedAlerts], [alerts, archivedAlerts]);
 	const tagKeys = useAlertTagKeys(allAlerts);
@@ -263,6 +265,7 @@ const Alerts = () => {
 			searchTerm={dashboardState.query}
 			onSearchTermChange={(term) => updateDashboardField('query', term)}
 			renderToolbar={false}
+			severityColors={severityColors}
 		/>
 	);
 
@@ -445,6 +448,17 @@ const Alerts = () => {
 									</Button>
 								)}
 
+								<Button
+									variant={severityColors ? 'default' : 'outline'}
+									size="sm"
+									onClick={toggleSeverityColors}
+									className="gap-1.5 flex-shrink-0"
+									title="Color rows by severity"
+								>
+									<Palette className="h-4 w-4" />
+									<span className="hidden lg:inline">Severity colors</span>
+								</Button>
+
 								<TimeFilter
 									value={dashboardState.timeRange ?? createEmptyTimeRange()}
 									onChange={(range) => updateDashboardField('timeRange', range)}
@@ -535,6 +549,7 @@ const Alerts = () => {
 									searchTerm={dashboardState.query}
 									onSearchTermChange={(term) => updateDashboardField('query', term)}
 									renderToolbar={false}
+									severityColors={severityColors}
 								/>
 							</div>
 						) : (
@@ -570,6 +585,7 @@ const Alerts = () => {
 									searchTerm={dashboardState.query}
 									onSearchTermChange={(term) => updateDashboardField('query', term)}
 									renderToolbar={false}
+									severityColors={severityColors}
 								/>
 							</div>
 						)}

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -4,6 +4,7 @@ import { extractTagKeyFromColumnId, getTagKeyColumnId, isTagKeyColumn, TagKeyInf
 import { Alert } from '@OpsiMate/shared';
 import { useMemo } from 'react';
 import { getOwnerDisplayName } from './utils/owner.utils';
+import { getAlertSeverity, SEVERITY_LABELS } from './utils/severity.utils';
 
 interface AlertsFilterPanelProps {
 	alerts: Alert[];
@@ -15,10 +16,11 @@ interface AlertsFilterPanelProps {
 	isArchived?: boolean;
 }
 
-const BASE_FILTER_FIELDS = ['status', 'type', 'alertName', 'owner'];
+const BASE_FILTER_FIELDS = ['status', 'severity', 'type', 'alertName', 'owner'];
 
 const BASE_FIELD_LABELS: Record<string, string> = {
 	status: 'Status',
+	severity: 'Severity',
 	type: 'Type',
 	alertName: 'Alert Name',
 	owner: 'Owner',
@@ -70,6 +72,8 @@ export const AlertsFilterPanel = ({
 						: alert.isSilenced
 							? 'Silenced'
 							: capitalizeFirst(alert.status);
+				case 'severity':
+					return SEVERITY_LABELS[getAlertSeverity(alert)];
 				case 'type':
 					return getAlertType(alert);
 				case 'alertName':

--- a/apps/client/src/components/Alerts/AlertsTVMode/AlertCard/AlertCard.tsx
+++ b/apps/client/src/components/Alerts/AlertsTVMode/AlertCard/AlertCard.tsx
@@ -1,8 +1,9 @@
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import { Alert } from '@OpsiMate/shared';
+import { Alert, AlertSeverity } from '@OpsiMate/shared';
 import { AlertCircle, BellOff, Clock, Server } from 'lucide-react';
 import { getAlertTagEntries, hasAlertTags } from '../../utils/alertTags.utils';
+import { getAlertSeverity } from '../../utils/severity.utils';
 import { getTagKeyColor } from '../../utils/tagColors.utils';
 import { CardSize } from '../AlertsTVMode.constants';
 
@@ -38,15 +39,11 @@ const getSeverityConfig = (alert: Alert) => {
 		};
 	}
 
-	// Check tags for severity, fall back to status-based determination
-	const severity = (
-		alert.tags?.severity ||
-		alert.tags?.priority ||
-		(alert.status === 'firing' ? 'warning' : 'info')
-	).toLowerCase();
+	// Shared severity taxonomy, so TV mode agrees with the alerts table.
+	const severity = getAlertSeverity(alert);
 
 	switch (severity) {
-		case 'critical':
+		case AlertSeverity.CRITICAL:
 			return {
 				bg: 'bg-gradient-to-br from-red-500/20 to-red-600/10',
 				border: 'border-red-500/50',
@@ -55,7 +52,7 @@ const getSeverityConfig = (alert: Alert) => {
 				iconColor: 'text-white',
 				pulse: true,
 			};
-		case 'warning':
+		case AlertSeverity.WARNING:
 			return {
 				bg: 'bg-gradient-to-br from-amber-500/20 to-orange-500/10',
 				border: 'border-amber-500/50',
@@ -64,7 +61,7 @@ const getSeverityConfig = (alert: Alert) => {
 				iconColor: 'text-white',
 				pulse: false,
 			};
-		case 'info':
+		default:
 			return {
 				bg: 'bg-gradient-to-br from-blue-500/20 to-blue-600/10',
 				border: 'border-blue-500/50',
@@ -72,15 +69,6 @@ const getSeverityConfig = (alert: Alert) => {
 				iconBg: 'bg-blue-500',
 				iconColor: 'text-white',
 				pulse: false,
-			};
-		default:
-			return {
-				bg: 'bg-gradient-to-br from-destructive/20 to-destructive/10',
-				border: 'border-destructive/50',
-				glow: 'shadow-[0_0_15px_rgba(239,68,68,0.2)]',
-				iconBg: 'bg-destructive',
-				iconColor: 'text-white',
-				pulse: true,
 			};
 	}
 };

--- a/apps/client/src/components/Alerts/AlertsTVMode/AlertsGroupedView/AlertsGroupedView.tsx
+++ b/apps/client/src/components/Alerts/AlertsTVMode/AlertsGroupedView/AlertsGroupedView.tsx
@@ -4,6 +4,7 @@ import { GroupByControls } from '@/components/Alerts/AlertsTable/GroupByControls
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { ChevronRight, Home, AlertTriangle, Flame, Clock } from 'lucide-react';
+import { getAlertSeverity, SEVERITY_RANK } from '../../utils/severity.utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -44,14 +45,10 @@ const countActiveAlerts = (node: GroupNode): number => {
 	return node.children.reduce((sum, child) => sum + countActiveAlerts(child), 0);
 };
 
-// Get severity level for sorting/coloring
+// Severity rank for sorting/coloring, on the shared taxonomy (critical=3, warning=2, info=1).
 const getSeverityLevel = (node: GroupNode): number => {
 	if (node.type === 'leaf') {
-		const severity = (node.alert.tags?.severity || node.alert.tags?.priority || '').toLowerCase();
-		if (severity === 'critical' || severity === 'p1') return 3;
-		if (severity === 'high' || severity === 'p2') return 2;
-		if (severity === 'warning' || severity === 'medium' || severity === 'p3') return 1;
-		return 0;
+		return SEVERITY_RANK[getAlertSeverity(node.alert)];
 	}
 	// For groups, return max severity of children
 	return Math.max(0, ...node.children.map(getSeverityLevel));
@@ -99,13 +96,10 @@ const getColor = (node: GroupNode, depth: number): { bg: string; glow: string; t
 
 	const severity = getSeverityLevel(node);
 
-	// Active alerts - vibrant colors based on severity
+	// Active alerts - vibrant colors on the shared scale: critical red, warning amber, info blue.
 	if (severity >= 3) return { bg: 'from-red-600 to-red-500', glow: 'shadow-red-400/60', text: 'text-white' };
-	if (severity >= 2) return { bg: 'from-orange-500 to-orange-400', glow: 'shadow-orange-400/60', text: 'text-white' };
-	if (severity >= 1) return { bg: 'from-amber-500 to-amber-400', glow: 'shadow-amber-400/60', text: 'text-white' };
-
-	// Default for active alerts
-	return { bg: 'from-red-500 to-red-400', glow: 'shadow-red-400/50', text: 'text-white' };
+	if (severity >= 2) return { bg: 'from-amber-500 to-amber-400', glow: 'shadow-amber-400/60', text: 'text-white' };
+	return { bg: 'from-sky-500 to-sky-400', glow: 'shadow-sky-400/50', text: 'text-white' };
 };
 
 // Squarified treemap algorithm for better aspect ratios

--- a/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
+++ b/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
@@ -4,6 +4,7 @@ import { getAlertValue } from '@/components/Alerts/AlertsTable/AlertsTable.utils
 import { DashboardHeader } from '@/components/Alerts/DashboardHeader';
 import { DashboardSettingsDrawer } from '@/components/Alerts/DashboardSettingsDrawer';
 import { useAlertTagKeys, useColumnManagement } from '@/components/Alerts/hooks';
+import { getAlertSeverity } from '@/components/Alerts/utils/severity.utils';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useDashboard } from '@/context/DashboardContext';
@@ -19,7 +20,7 @@ import { useServices } from '@/hooks/queries/services';
 import { useUsers } from '@/hooks/queries/users';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
-import { Alert } from '@OpsiMate/shared';
+import { Alert, AlertSeverity } from '@OpsiMate/shared';
 import { AlertTriangle, ArrowLeft, CheckCircle, Layers, LayoutGrid, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -282,7 +283,7 @@ const AlertsTVMode = () => {
 
 	const activeAlertsCount = filteredAlerts.filter((a) => !a.isDismissed).length;
 	const criticalCount = filteredAlerts.filter(
-		(a) => !a.isDismissed && (a.tags?.severity || a.tags?.priority || '').toLowerCase() === 'critical'
+		(a) => !a.isDismissed && getAlertSeverity(a) === AlertSeverity.CRITICAL
 	).length;
 
 	return (

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -5,9 +5,11 @@ import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { Alert } from '@OpsiMate/shared';
 import { ACTIONS_COLUMN, COLUMN_WIDTHS, SELECT_COLUMN_WIDTH } from '../AlertsTable.constants';
 import { CELL_PADDING } from './AlertRow.constants';
+import { getAlertSeverity, SEVERITY_ROW_CLASSES } from '../../utils/severity.utils';
 import { AlertActionsColumn } from './Columns/AlertActionsColumn';
 import { AlertNameColumn } from './Columns/AlertNameColumn';
 import { AlertOwnerColumn } from './Columns/AlertOwnerColumn';
+import { AlertSeverityColumn } from './Columns/AlertSeverityColumn';
 import { AlertStartsAtColumn } from './Columns/AlertStartsAtColumn';
 import { AlertStatusColumn } from './Columns/AlertStatusColumn';
 import { AlertSummaryColumn } from './Columns/AlertSummaryColumn';
@@ -28,6 +30,8 @@ export interface AlertRowProps {
 	onSelectAlerts?: (alerts: Alert[]) => void;
 	isArchived?: boolean;
 	isDragging?: boolean;
+	// Tint the whole row by alert severity (the table's "severity colors" toggle).
+	severityColors?: boolean;
 	onDragStart?: (alert: Alert, e: React.MouseEvent) => void;
 	onDragEnter?: (alert: Alert) => void;
 	onDragEnd?: () => void;
@@ -46,6 +50,7 @@ export const AlertRow = ({
 	onSelectAlerts,
 	isArchived = false,
 	isDragging = false,
+	severityColors = false,
 	onDragStart,
 	onDragEnter,
 	onDragEnd,
@@ -70,6 +75,8 @@ export const AlertRow = ({
 		<TableRow
 			className={cn(
 				'h-8 cursor-pointer hover:bg-muted/50',
+				// Severity tint sits under selection/active highlights so those still win.
+				severityColors && SEVERITY_ROW_CLASSES[getAlertSeverity(alert)],
 				isSelected && 'bg-muted/50',
 				// Unread alerts render bold until someone opens them.
 				alert.isRead === false && 'font-bold',
@@ -116,6 +123,8 @@ export const AlertRow = ({
 						return <AlertTypeColumn key={column} alert={alert} className={COLUMN_WIDTHS.type} />;
 					case 'alertName':
 						return <AlertNameColumn key={column} alert={alert} className={COLUMN_WIDTHS.alertName} />;
+					case 'severity':
+						return <AlertSeverityColumn key={column} alert={alert} className={COLUMN_WIDTHS.severity} />;
 					case 'status':
 						return <AlertStatusColumn key={column} alert={alert} className={COLUMN_WIDTHS.status} />;
 					case 'summary':

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -77,7 +77,9 @@ export const AlertRow = ({
 				'h-8 cursor-pointer hover:bg-muted/50',
 				// Severity tint sits under selection/active highlights so those still win.
 				severityColors && SEVERITY_ROW_CLASSES[getAlertSeverity(alert)],
-				isSelected && 'bg-muted/50',
+				// Selection carries its own hover class so the severity hover tint can't
+				// override the selection cue while the pointer is over the row.
+				isSelected && 'bg-muted/50 hover:bg-muted/50',
 				// Unread alerts render bold until someone opens them.
 				alert.isRead === false && 'font-bold',
 				// The alert currently open in the details panel: tinted row + accent edge,

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSeverityColumn/AlertSeverityColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSeverityColumn/AlertSeverityColumn.tsx
@@ -12,7 +12,7 @@ export interface AlertSeverityColumnProps {
 export const AlertSeverityColumn = ({ alert, className }: AlertSeverityColumnProps) => {
 	return (
 		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
-			<SeverityBadge severity={getAlertSeverity(alert)} showLabel />
+			<SeverityBadge severity={getAlertSeverity(alert)} />
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSeverityColumn/AlertSeverityColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSeverityColumn/AlertSeverityColumn.tsx
@@ -1,0 +1,18 @@
+import { TableCell } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+import { Alert } from '@OpsiMate/shared';
+import { SeverityBadge } from '../../../../SeverityBadge';
+import { getAlertSeverity } from '../../../../utils/severity.utils';
+
+export interface AlertSeverityColumnProps {
+	alert: Alert;
+	className?: string;
+}
+
+export const AlertSeverityColumn = ({ alert, className }: AlertSeverityColumnProps) => {
+	return (
+		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+			<SeverityBadge severity={getAlertSeverity(alert)} showLabel />
+		</TableCell>
+	);
+};

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSeverityColumn/index.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSeverityColumn/index.ts
@@ -1,0 +1,2 @@
+export { AlertSeverityColumn } from './AlertSeverityColumn';
+export type { AlertSeverityColumnProps } from './AlertSeverityColumn';

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertStatusColumn/AlertStatusColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertStatusColumn/AlertStatusColumn.tsx
@@ -1,46 +1,17 @@
-import { Badge } from '@/components/ui/badge';
 import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
-import { Alert, AlertStatus } from '@OpsiMate/shared';
+import { Alert } from '@OpsiMate/shared';
+import { StatusBadge } from '../../../../StatusBadge';
 
 export interface AlertStatusColumnProps {
 	alert: Alert;
 	className?: string;
 }
 
-const capitalizeFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
-
-const getStatusBadge = (alert: Alert) => {
-	if (alert.isDismissed) {
-		return (
-			<Badge variant="muted" className="text-xs px-1.5 py-0.5">
-				Dismissed
-			</Badge>
-		);
-	}
-
-	if (alert.isSilenced) {
-		return (
-			<Badge
-				variant="secondary"
-				className="text-xs px-1.5 py-0.5 bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30"
-				data-testid="alert-status-silenced"
-			>
-				Silenced
-			</Badge>
-		);
-	}
-
-	// Use AlertStatus enum to determine badge variant
-	const variant = alert.status === AlertStatus.FIRING ? 'destructive' : 'success';
-
-	return (
-		<Badge variant={variant} className="text-xs px-1.5 py-0.5">
-			{capitalizeFirst(alert.status)}
-		</Badge>
-	);
-};
-
 export const AlertStatusColumn = ({ alert, className }: AlertStatusColumnProps) => {
-	return <TableCell className={cn('py-1 px-2 overflow-hidden', className)}>{getStatusBadge(alert)}</TableCell>;
+	return (
+		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+			<StatusBadge alert={alert} />
+		</TableCell>
+	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/TypeAvatarStack/TypeAvatarStack.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/TypeAvatarStack/TypeAvatarStack.tsx
@@ -1,3 +1,4 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Alert } from '@OpsiMate/shared';
 import { getIntegrationLabel, IntegrationAvatar, resolveAlertIntegration } from '../../../IntegrationAvatar';
 
@@ -11,12 +12,17 @@ export const TypeAvatarStack = ({ alert }: TypeAvatarStackProps) => {
 	const integrationLabel = getIntegrationLabel(integration);
 
 	return (
-		<div
-			className="flex -space-x-1.5 flex-shrink-0"
-			aria-label={`${integrationLabel} alert type`}
-			title={integrationLabel}
-		>
-			<IntegrationAvatar integration={integration} size="sm" className="ring-2 ring-background shadow-sm" />
-		</div>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<div className="flex -space-x-1.5 flex-shrink-0" aria-label={`${integrationLabel} alert type`}>
+					<IntegrationAvatar
+						integration={integration}
+						size="sm"
+						className="ring-2 ring-background shadow-sm"
+					/>
+				</div>
+			</TooltipTrigger>
+			<TooltipContent>{integrationLabel}</TooltipContent>
+		</Tooltip>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/TypeAvatarStack/TypeAvatarStack.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/TypeAvatarStack/TypeAvatarStack.tsx
@@ -5,18 +5,18 @@ export interface TypeAvatarStackProps {
 	alert: Alert;
 }
 
+// Icon-only: the integration name lives in the tooltip to keep the column narrow.
 export const TypeAvatarStack = ({ alert }: TypeAvatarStackProps) => {
 	const integration = resolveAlertIntegration(alert);
 	const integrationLabel = getIntegrationLabel(integration);
 
 	return (
-		<div className="flex items-center gap-2 overflow-hidden">
-			<div className="flex -space-x-1.5 flex-shrink-0" aria-label={`${integrationLabel} alert type`}>
-				<IntegrationAvatar integration={integration} size="sm" className="ring-2 ring-background shadow-sm" />
-			</div>
-			<span className="text-xs font-medium text-foreground truncate" title={integrationLabel}>
-				{integrationLabel}
-			</span>
+		<div
+			className="flex -space-x-1.5 flex-shrink-0"
+			aria-label={`${integrationLabel} alert type`}
+			title={integrationLabel}
+		>
+			<IntegrationAvatar integration={integration} size="sm" className="ring-2 ring-background shadow-sm" />
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -20,10 +20,10 @@ export const COLUMN_LABELS: Record<string, string> = {
 
 export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
-	// Type and severity are icon-only cells; the width just fits the header label.
-	type: 'w-16 min-w-16 max-w-16',
-	alertName: 'w-[22%]',
-	severity: 'w-20 min-w-20 max-w-20',
+	// Type and severity are icon-only columns (icon-only headers too, names in tooltips).
+	type: 'w-12 min-w-12 max-w-12',
+	alertName: 'w-[24%]',
+	severity: 'w-12 min-w-12 max-w-12',
 	status: 'w-[10%]',
 	summary: 'w-auto',
 	owner: 'w-[12%]',

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -4,13 +4,14 @@ export const SELECT_COLUMN_WIDTH = '40px';
 export const ACTIONS_COLUMN_WIDTH = '80px';
 export const TABLE_HEAD_CLASSES = 'h-8 py-1 px-2';
 
-export const DEFAULT_VISIBLE_COLUMNS = ['type', 'alertName', 'status', 'summary', 'owner', 'startsAt'];
+export const DEFAULT_VISIBLE_COLUMNS = ['type', 'alertName', 'severity', 'status', 'summary', 'owner', 'startsAt'];
 
-export const DEFAULT_COLUMN_ORDER = ['type', 'alertName', 'status', 'summary', 'owner', 'startsAt'];
+export const DEFAULT_COLUMN_ORDER = ['type', 'alertName', 'severity', 'status', 'summary', 'owner', 'startsAt'];
 
 export const COLUMN_LABELS: Record<string, string> = {
 	type: 'Type',
 	alertName: 'Alert Name',
+	severity: 'Severity',
 	status: 'Status',
 	summary: 'Summary',
 	owner: 'Owner',
@@ -21,6 +22,7 @@ export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
 	type: 'w-[10%]',
 	alertName: 'w-[20%]',
+	severity: 'w-[9%]',
 	status: 'w-[10%]',
 	summary: 'w-auto',
 	owner: 'w-[12%]',

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -4,9 +4,9 @@ export const SELECT_COLUMN_WIDTH = '40px';
 export const ACTIONS_COLUMN_WIDTH = '80px';
 export const TABLE_HEAD_CLASSES = 'h-8 py-1 px-2';
 
-export const DEFAULT_VISIBLE_COLUMNS = ['type', 'alertName', 'severity', 'status', 'summary', 'owner', 'startsAt'];
+export const DEFAULT_VISIBLE_COLUMNS = ['type', 'severity', 'alertName', 'status', 'summary', 'owner', 'startsAt'];
 
-export const DEFAULT_COLUMN_ORDER = ['type', 'alertName', 'severity', 'status', 'summary', 'owner', 'startsAt'];
+export const DEFAULT_COLUMN_ORDER = ['type', 'severity', 'alertName', 'status', 'summary', 'owner', 'startsAt'];
 
 export const COLUMN_LABELS: Record<string, string> = {
 	type: 'Type',
@@ -20,9 +20,10 @@ export const COLUMN_LABELS: Record<string, string> = {
 
 export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
-	type: 'w-[10%]',
-	alertName: 'w-[20%]',
-	severity: 'w-[9%]',
+	// Type and severity are icon-only cells; the width just fits the header label.
+	type: 'w-16 min-w-16 max-w-16',
+	alertName: 'w-[22%]',
+	severity: 'w-20 min-w-20 max-w-20',
 	status: 'w-[10%]',
 	summary: 'w-auto',
 	owner: 'w-[12%]',

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -4,9 +4,9 @@ export const SELECT_COLUMN_WIDTH = '40px';
 export const ACTIONS_COLUMN_WIDTH = '80px';
 export const TABLE_HEAD_CLASSES = 'h-8 py-1 px-2';
 
-export const DEFAULT_VISIBLE_COLUMNS = ['type', 'severity', 'alertName', 'status', 'summary', 'owner', 'startsAt'];
+export const DEFAULT_VISIBLE_COLUMNS = ['type', 'severity', 'status', 'alertName', 'summary', 'owner', 'startsAt'];
 
-export const DEFAULT_COLUMN_ORDER = ['type', 'severity', 'alertName', 'status', 'summary', 'owner', 'startsAt'];
+export const DEFAULT_COLUMN_ORDER = ['type', 'severity', 'status', 'alertName', 'summary', 'owner', 'startsAt'];
 
 export const COLUMN_LABELS: Record<string, string> = {
 	type: 'Type',
@@ -20,11 +20,12 @@ export const COLUMN_LABELS: Record<string, string> = {
 
 export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
-	// Type and severity are icon-only columns (icon-only headers too, names in tooltips).
+	// Type, severity and status are icon-only columns (icon-only headers too, names in
+	// tooltips).
 	type: 'w-12 min-w-12 max-w-12',
-	alertName: 'w-[24%]',
+	alertName: 'w-[26%]',
 	severity: 'w-12 min-w-12 max-w-12',
-	status: 'w-[10%]',
+	status: 'w-12 min-w-12 max-w-12',
 	summary: 'w-auto',
 	owner: 'w-[12%]',
 	startsAt: 'w-[15%]',

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -3,7 +3,8 @@ import { Table, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useMemo, useRef, useState } from 'react';
+import { Plug, TriangleAlert } from 'lucide-react';
+import { ReactNode, useMemo, useRef } from 'react';
 import { AlertsEmptyState } from './AlertsEmptyState';
 import {
 	ACTIONS_COLUMN,
@@ -25,6 +26,13 @@ import { SortableHeader } from './SortableHeader';
 import { StickyGroupHeader } from './StickyGroupHeader';
 import { TimeFilter, createEmptyTimeRange, isTimeRangeEmpty } from './TimeFilter';
 import { VirtualizedAlertList } from './VirtualizedAlertList';
+
+// Icon-only headers for the narrow icon-only columns; the column name stays in the
+// header tooltip.
+const HEADER_ICONS: Record<string, ReactNode> = {
+	type: <Plug className="h-3.5 w-3.5" />,
+	severity: <TriangleAlert className="h-3.5 w-3.5" />,
+};
 
 export const AlertsTable = ({
 	alerts,
@@ -205,6 +213,7 @@ export const AlertsTable = ({
 													key={column}
 													column={column as AlertSortField}
 													label={allColumnLabels[column]}
+													labelIcon={HEADER_ICONS[column]}
 													sortField={sortField}
 													sortDirection={sortDirection}
 													onSort={handleSort}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -50,6 +50,7 @@ export const AlertsTable = ({
 	onTimeRangeChange,
 	isArchived = false,
 	renderToolbar = true,
+	severityColors = false,
 	heading,
 }: AlertsTableProps) => {
 	const parentRef = useRef<HTMLDivElement>(null);
@@ -189,9 +190,15 @@ export const AlertsTable = ({
 											);
 										}
 										if (
-											['alertName', 'status', 'startsAt', 'summary', 'type', 'owner'].includes(
-												column
-											)
+											[
+												'alertName',
+												'severity',
+												'status',
+												'startsAt',
+												'summary',
+												'type',
+												'owner',
+											].includes(column)
 										) {
 											return (
 												<SortableHeader
@@ -249,6 +256,7 @@ export const AlertsTable = ({
 									onSelectAlerts={onSelectAlerts}
 									columnLabels={allColumnLabels}
 									isArchived={isArchived}
+									severityColors={severityColors}
 									isDragging={isDragging}
 									onDragStart={handleDragStart}
 									onDragEnter={handleDragEnter}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -3,7 +3,7 @@ import { Table, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Plug, TriangleAlert } from 'lucide-react';
+import { Activity, Plug, TriangleAlert } from 'lucide-react';
 import { ReactNode, useMemo, useRef } from 'react';
 import { AlertsEmptyState } from './AlertsEmptyState';
 import {
@@ -32,6 +32,7 @@ import { VirtualizedAlertList } from './VirtualizedAlertList';
 const HEADER_ICONS: Record<string, ReactNode> = {
 	type: <Plug className="h-3.5 w-3.5" />,
 	severity: <TriangleAlert className="h-3.5 w-3.5" />,
+	status: <Activity className="h-3.5 w-3.5" />,
 };
 
 export const AlertsTable = ({

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -39,6 +39,8 @@ export interface AlertsTableProps {
 	searchTerm: string;
 	onSearchTermChange: (term: string) => void;
 	renderToolbar?: boolean;
+	// Tint rows by alert severity (the page-level "severity colors" toggle).
+	severityColors?: boolean;
 	// Optional caption rendered flush at the top of the table container (e.g. a section
 	// title + count), so callers don't need a separate header row above the table.
 	heading?: ReactNode;

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
@@ -5,6 +5,7 @@ import { getIntegrationLabel, resolveAlertIntegration } from '../IntegrationAvat
 import { createServiceNameLookup } from '../utils';
 import { getAlertTagsString } from '../utils/alertTags.utils';
 import { getOwnerDisplayName, getOwnerSortKey } from '../utils/owner.utils';
+import { getAlertSeverity, SEVERITY_LABELS, SEVERITY_RANK } from '../utils/severity.utils';
 import { AlertSortField, FlatGroupItem, GroupNode, GroupStatus, SortDirection } from './AlertsTable.types';
 
 export { createServiceNameLookup };
@@ -33,6 +34,34 @@ const getTagKeyValue = (alert: Alert, columnId: string): string => {
 	return alert.tags?.[tagKey] || '';
 };
 
+// Comparable value for one alert under a sort field; null means "field not sortable".
+const getSortValue = (alert: Alert, sortField: AlertSortField, users: UserInfo[]): string | number | null => {
+	if (isTagKeyColumn(sortField)) {
+		return getTagKeyValue(alert, sortField).toLowerCase();
+	}
+	switch (sortField) {
+		case 'alertName':
+			return alert.alertName.toLowerCase();
+		case 'status':
+			return alert.isDismissed ? 'dismissed' : alert.isSilenced ? 'silenced' : 'firing';
+		case 'severity':
+			// Rank-based so desc = critical first, info last.
+			return SEVERITY_RANK[getAlertSeverity(alert)];
+		case 'summary':
+			return (alert.summary || '').toLowerCase();
+		case 'startsAt': {
+			const date = new Date(alert.startsAt);
+			return isNaN(date.getTime()) ? 0 : date.getTime();
+		}
+		case 'type':
+			return getIntegrationLabel(resolveAlertIntegration(alert)).toLowerCase();
+		case 'owner':
+			return getOwnerSortKey(alert.ownerId, users);
+		default:
+			return null;
+	}
+};
+
 export const sortAlerts = (
 	alerts: Alert[],
 	sortField: AlertSortField,
@@ -40,45 +69,9 @@ export const sortAlerts = (
 	users: UserInfo[] = []
 ): Alert[] => {
 	return [...alerts].sort((a, b) => {
-		let aValue: string | number;
-		let bValue: string | number;
-
-		if (isTagKeyColumn(sortField)) {
-			aValue = getTagKeyValue(a, sortField).toLowerCase();
-			bValue = getTagKeyValue(b, sortField).toLowerCase();
-		} else {
-			switch (sortField) {
-				case 'alertName':
-					aValue = a.alertName.toLowerCase();
-					bValue = b.alertName.toLowerCase();
-					break;
-				case 'status':
-					aValue = a.isDismissed ? 'dismissed' : a.isSilenced ? 'silenced' : 'firing';
-					bValue = b.isDismissed ? 'dismissed' : b.isSilenced ? 'silenced' : 'firing';
-					break;
-				case 'summary':
-					aValue = (a.summary || '').toLowerCase();
-					bValue = (b.summary || '').toLowerCase();
-					break;
-				case 'startsAt': {
-					const aDate = new Date(a.startsAt);
-					const bDate = new Date(b.startsAt);
-					aValue = isNaN(aDate.getTime()) ? 0 : aDate.getTime();
-					bValue = isNaN(bDate.getTime()) ? 0 : bDate.getTime();
-					break;
-				}
-				case 'type':
-					aValue = getIntegrationLabel(resolveAlertIntegration(a)).toLowerCase();
-					bValue = getIntegrationLabel(resolveAlertIntegration(b)).toLowerCase();
-					break;
-				case 'owner':
-					aValue = getOwnerSortKey(a.ownerId, users);
-					bValue = getOwnerSortKey(b.ownerId, users);
-					break;
-				default:
-					return 0;
-			}
-		}
+		const aValue = getSortValue(a, sortField, users);
+		const bValue = getSortValue(b, sortField, users);
+		if (aValue === null || bValue === null) return 0;
 
 		if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
 		if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
@@ -101,6 +94,8 @@ export const getAlertValue = (alert: Alert, field: string, users: UserInfo[] = [
 			return alert.alertName;
 		case 'status':
 			return alert.isDismissed ? 'Dismissed' : alert.isSilenced ? 'Silenced' : 'Firing';
+		case 'severity':
+			return SEVERITY_LABELS[getAlertSeverity(alert)];
 		case 'summary':
 			return alert.summary || 'Unknown';
 		case 'startsAt': {

--- a/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.constants.ts
@@ -1,1 +1,1 @@
-export const BASE_SORT_FIELDS = ['alertName', 'status', 'startsAt', 'summary', 'type', 'owner'] as const;
+export const BASE_SORT_FIELDS = ['alertName', 'severity', 'status', 'startsAt', 'summary', 'type', 'owner'] as const;

--- a/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
@@ -3,6 +3,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { cn } from '@/lib/utils';
 import { isTagKeyColumn } from '@/types';
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { ReactNode } from 'react';
 import { AlertSortField, SortDirection } from '../AlertsTable.types';
 import { BASE_SORT_FIELDS } from './SortableHeader.constants';
 
@@ -13,13 +14,24 @@ const isValidSortField = (value: string): boolean => {
 export interface SortableHeaderProps {
 	column: AlertSortField;
 	label: string;
+	// Rendered instead of the text label for icon-only narrow columns; the label still
+	// shows in the tooltip and stays available to screen readers.
+	labelIcon?: ReactNode;
 	sortField: AlertSortField;
 	sortDirection: SortDirection;
 	onSort: (field: AlertSortField) => void;
 	className?: string;
 }
 
-export const SortableHeader = ({ column, label, sortField, sortDirection, onSort, className }: SortableHeaderProps) => {
+export const SortableHeader = ({
+	column,
+	label,
+	labelIcon,
+	sortField,
+	sortDirection,
+	onSort,
+	className,
+}: SortableHeaderProps) => {
 	const getSortIcon = () => {
 		if (sortField !== column) {
 			return <ArrowUpDown className="h-3 w-3 text-foreground" />;
@@ -45,8 +57,12 @@ export const SortableHeader = ({ column, label, sortField, sortDirection, onSort
 			<TooltipProvider>
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<div className="flex items-center gap-1 min-w-0">
-							<span className="truncate">{label}</span>
+						<div className="flex items-center gap-1 min-w-0" aria-label={label}>
+							{labelIcon ? (
+								<span className="flex-shrink-0 text-muted-foreground">{labelIcon}</span>
+							) : (
+								<span className="truncate">{label}</span>
+							)}
 							<span className="flex-shrink-0">{getSortIcon()}</span>
 						</div>
 					</TooltipTrigger>

--- a/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
@@ -53,11 +53,12 @@ export const SortableHeader = ({
 		<TableHead
 			className={cn('h-8 py-1 px-2 text-xs cursor-pointer hover:bg-muted/50 text-foreground', className)}
 			onClick={handleClick}
+			aria-label={label}
 		>
 			<TooltipProvider>
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<div className="flex items-center gap-1 min-w-0" aria-label={label}>
+						<div className="flex items-center gap-1 min-w-0">
 							{labelIcon ? (
 								<span className="flex-shrink-0 text-muted-foreground">{labelIcon}</span>
 							) : (

--- a/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
@@ -21,6 +21,8 @@ interface VirtualizedAlertListProps {
 	onSelectAlerts?: (alerts: Alert[]) => void;
 	columnLabels?: Record<string, string>;
 	isArchived?: boolean;
+	// Tint rows by alert severity (the "severity colors" toggle).
+	severityColors?: boolean;
 	isDragging?: boolean;
 	onDragStart?: (alert: Alert, e: React.MouseEvent) => void;
 	onDragEnter?: (alert: Alert) => void;
@@ -42,6 +44,7 @@ export const VirtualizedAlertList = ({
 	onSelectAlerts,
 	columnLabels,
 	isArchived = false,
+	severityColors = false,
 	isDragging = false,
 	onDragStart,
 	onDragEnter,
@@ -118,6 +121,7 @@ export const VirtualizedAlertList = ({
 									onDeleteAlert={onDeleteAlert}
 									onSelectAlerts={onSelectAlerts}
 									isArchived={isArchived}
+									severityColors={severityColors}
 									isDragging={isDragging}
 									onDragStart={onDragStart}
 									onDragEnter={onDragEnter}

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertSorting.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertSorting.ts
@@ -19,7 +19,8 @@ export const useAlertSorting = (filteredAlerts: Alert[]) => {
 			setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
 		} else {
 			setSortField(field);
-			setSortDirection(field === 'startsAt' ? 'desc' : 'asc');
+			// startsAt: newest first; severity: critical first (desc by rank).
+			setSortDirection(field === 'startsAt' || field === 'severity' ? 'desc' : 'asc');
 		}
 	};
 

--- a/apps/client/src/components/Alerts/SeverityBadge/SeverityBadge.tsx
+++ b/apps/client/src/components/Alerts/SeverityBadge/SeverityBadge.tsx
@@ -1,3 +1,4 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { AlertSeverity } from '@OpsiMate/shared';
 import { Info, OctagonAlert, TriangleAlert } from 'lucide-react';
@@ -11,24 +12,26 @@ const SEVERITY_ICONS: Record<AlertSeverity, typeof Info> = {
 
 interface SeverityBadgeProps {
 	severity: AlertSeverity;
-	// Icon-only (table cells) vs icon + label (details panel).
-	showLabel?: boolean;
 	className?: string;
 }
 
-// Colored severity indicator: an icon per level, with an optional text label. The icon
-// always carries a tooltip so the icon-only variant stays self-explanatory.
-export const SeverityBadge = ({ severity, showLabel = false, className }: SeverityBadgeProps) => {
+// Icon-only colored severity indicator; the label lives in a styled tooltip (same Radix
+// tooltip the table headers use) and in an aria-label for assistive tech.
+export const SeverityBadge = ({ severity, className }: SeverityBadgeProps) => {
 	const Icon = SEVERITY_ICONS[severity];
-	const label = SEVERITY_LABELS[severity];
+	const label = `Severity: ${SEVERITY_LABELS[severity]}`;
 
 	return (
-		<span
-			className={cn('inline-flex items-center gap-1 min-w-0', SEVERITY_TEXT_CLASSES[severity], className)}
-			title={`Severity: ${label}`}
-		>
-			<Icon className="h-3.5 w-3.5 flex-shrink-0" aria-label={label} />
-			{showLabel && <span className="text-xs font-medium truncate">{label}</span>}
-		</span>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span
+					className={cn('inline-flex items-center flex-shrink-0', SEVERITY_TEXT_CLASSES[severity], className)}
+					aria-label={label}
+				>
+					<Icon className="h-3.5 w-3.5" aria-hidden />
+				</span>
+			</TooltipTrigger>
+			<TooltipContent>{label}</TooltipContent>
+		</Tooltip>
 	);
 };

--- a/apps/client/src/components/Alerts/SeverityBadge/SeverityBadge.tsx
+++ b/apps/client/src/components/Alerts/SeverityBadge/SeverityBadge.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils';
+import { AlertSeverity } from '@OpsiMate/shared';
+import { Info, OctagonAlert, TriangleAlert } from 'lucide-react';
+import { SEVERITY_LABELS, SEVERITY_TEXT_CLASSES } from '../utils/severity.utils';
+
+const SEVERITY_ICONS: Record<AlertSeverity, typeof Info> = {
+	[AlertSeverity.CRITICAL]: OctagonAlert,
+	[AlertSeverity.WARNING]: TriangleAlert,
+	[AlertSeverity.INFO]: Info,
+};
+
+interface SeverityBadgeProps {
+	severity: AlertSeverity;
+	// Icon-only (table cells) vs icon + label (details panel).
+	showLabel?: boolean;
+	className?: string;
+}
+
+// Colored severity indicator: an icon per level, with an optional text label. The icon
+// always carries a tooltip so the icon-only variant stays self-explanatory.
+export const SeverityBadge = ({ severity, showLabel = false, className }: SeverityBadgeProps) => {
+	const Icon = SEVERITY_ICONS[severity];
+	const label = SEVERITY_LABELS[severity];
+
+	return (
+		<span
+			className={cn('inline-flex items-center gap-1 min-w-0', SEVERITY_TEXT_CLASSES[severity], className)}
+			title={`Severity: ${label}`}
+		>
+			<Icon className="h-3.5 w-3.5 flex-shrink-0" aria-label={label} />
+			{showLabel && <span className="text-xs font-medium truncate">{label}</span>}
+		</span>
+	);
+};

--- a/apps/client/src/components/Alerts/SeverityBadge/index.ts
+++ b/apps/client/src/components/Alerts/SeverityBadge/index.ts
@@ -1,0 +1,1 @@
+export { SeverityBadge } from './SeverityBadge';

--- a/apps/client/src/components/Alerts/StatusBadge/StatusBadge.tsx
+++ b/apps/client/src/components/Alerts/StatusBadge/StatusBadge.tsx
@@ -1,3 +1,4 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { Alert, AlertStatus } from '@OpsiMate/shared';
 import { BellOff, CircleCheck, Flame, VolumeX } from 'lucide-react';
@@ -24,18 +25,24 @@ interface StatusBadgeProps {
 	className?: string;
 }
 
-// Icon-only alert status (firing / resolved / silenced / dismissed) with the label in a
-// tooltip, matching SeverityBadge so the two can sit side by side in narrow columns.
+// Icon-only alert status (firing / resolved / silenced / dismissed); the label lives in a
+// styled tooltip (same Radix tooltip the table headers use) and in an aria-label.
 export const StatusBadge = ({ alert, className }: StatusBadgeProps) => {
 	const { Icon, label, className: colorClass, testId } = getStatusIndicator(alert);
+	const fullLabel = `Status: ${label}`;
 
 	return (
-		<span
-			className={cn('inline-flex items-center flex-shrink-0', colorClass, className)}
-			title={`Status: ${label}`}
-			data-testid={testId}
-		>
-			<Icon className="h-3.5 w-3.5" aria-label={label} />
-		</span>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span
+					className={cn('inline-flex items-center flex-shrink-0', colorClass, className)}
+					aria-label={fullLabel}
+					data-testid={testId}
+				>
+					<Icon className="h-3.5 w-3.5" aria-hidden />
+				</span>
+			</TooltipTrigger>
+			<TooltipContent>{fullLabel}</TooltipContent>
+		</Tooltip>
 	);
 };

--- a/apps/client/src/components/Alerts/StatusBadge/StatusBadge.tsx
+++ b/apps/client/src/components/Alerts/StatusBadge/StatusBadge.tsx
@@ -1,0 +1,41 @@
+import { cn } from '@/lib/utils';
+import { Alert, AlertStatus } from '@OpsiMate/shared';
+import { BellOff, CircleCheck, Flame, VolumeX } from 'lucide-react';
+
+interface StatusIndicator {
+	Icon: typeof Flame;
+	label: string;
+	className: string;
+	testId?: string;
+}
+
+// Precedence mirrors the old status badge: dismissed wins over silenced, which wins over
+// the firing/resolved lifecycle state.
+const getStatusIndicator = (alert: Alert): StatusIndicator => {
+	if (alert.isDismissed) return { Icon: BellOff, label: 'Dismissed', className: 'text-muted-foreground' };
+	if (alert.isSilenced)
+		return { Icon: VolumeX, label: 'Silenced', className: 'text-amber-500', testId: 'alert-status-silenced' };
+	if (alert.status === AlertStatus.FIRING) return { Icon: Flame, label: 'Firing', className: 'text-red-500' };
+	return { Icon: CircleCheck, label: 'Resolved', className: 'text-emerald-500' };
+};
+
+interface StatusBadgeProps {
+	alert: Alert;
+	className?: string;
+}
+
+// Icon-only alert status (firing / resolved / silenced / dismissed) with the label in a
+// tooltip, matching SeverityBadge so the two can sit side by side in narrow columns.
+export const StatusBadge = ({ alert, className }: StatusBadgeProps) => {
+	const { Icon, label, className: colorClass, testId } = getStatusIndicator(alert);
+
+	return (
+		<span
+			className={cn('inline-flex items-center flex-shrink-0', colorClass, className)}
+			title={`Status: ${label}`}
+			data-testid={testId}
+		>
+			<Icon className="h-3.5 w-3.5" aria-label={label} />
+		</span>
+	);
+};

--- a/apps/client/src/components/Alerts/StatusBadge/index.ts
+++ b/apps/client/src/components/Alerts/StatusBadge/index.ts
@@ -1,0 +1,1 @@
+export { StatusBadge } from './StatusBadge';

--- a/apps/client/src/components/Alerts/hooks/index.ts
+++ b/apps/client/src/components/Alerts/hooks/index.ts
@@ -4,3 +4,4 @@ export { useAlertsRefresh } from './useAlertsRefresh';
 export { useAlertTagKeys } from './useAlertTagKeys';
 export { useArchivedTabStatusFilterReset } from './useArchivedTabStatusFilterReset';
 export { useColumnManagement } from './useColumnManagement';
+export { useSeverityColors } from './useSeverityColors';

--- a/apps/client/src/components/Alerts/hooks/useAlertTagKeys.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertTagKeys.ts
@@ -1,6 +1,7 @@
 import { TagKeyInfo } from '@/types';
 import { Alert } from '@OpsiMate/shared';
 import { useMemo } from 'react';
+import { HIDDEN_TAG_KEYS } from '../utils/alertTags.utils';
 
 export { extractTagKeyFromColumnId, getTagKeyColumnId, isTagKeyColumn } from '@/types';
 export type { TagKeyInfo };
@@ -12,6 +13,9 @@ export const useAlertTagKeys = (alerts: Alert[]): TagKeyInfo[] => {
 		alerts.forEach((alert) => {
 			if (alert.tags && typeof alert.tags === 'object') {
 				Object.entries(alert.tags).forEach(([key, value]) => {
+					// The severity tag mirrors the first-class severity field; it never
+					// surfaces as a tag column, facet, or group-by option.
+					if (HIDDEN_TAG_KEYS.has(key)) return;
 					if (value) {
 						if (!tagKeyMap.has(key)) {
 							tagKeyMap.set(key, new Set());

--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -4,6 +4,7 @@ import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { Alert } from '@OpsiMate/shared';
 import { useMemo } from 'react';
 import { getOwnerDisplayName } from '../utils/owner.utils';
+import { getAlertSeverity, SEVERITY_LABELS } from '../utils/severity.utils';
 
 const getAlertType = (alert: Alert): string => {
 	return alert.type || 'Custom';
@@ -71,6 +72,9 @@ export const useAlertsFiltering = (
 							: alert.isSilenced
 								? 'Silenced'
 								: capitalizeFirst(alert.status);
+						break;
+					case 'severity':
+						fieldValue = SEVERITY_LABELS[getAlertSeverity(alert)];
 						break;
 					case 'type':
 						fieldValue = getAlertType(alert);

--- a/apps/client/src/components/Alerts/hooks/useColumnManagement.ts
+++ b/apps/client/src/components/Alerts/hooks/useColumnManagement.ts
@@ -9,6 +9,21 @@ export interface ColumnManagementOptions {
 	onVisibleColumnsChange?: (columns: string[]) => void;
 }
 
+// The severity column shipped after users may have persisted column lists, and those
+// lists replace the defaults wholesale — so severity would stay invisible for every
+// pre-existing dashboard. Inject it (after `type`, like the default) unless the user
+// has explicitly hidden it, which we remember per browser.
+const SEVERITY_HIDDEN_KEY = 'opsimate-severity-column-hidden';
+
+const withSeverity = (columns: string[]): string[] => {
+	if (columns.includes('severity')) return columns;
+	if (localStorage.getItem(SEVERITY_HIDDEN_KEY) === 'true') return columns;
+	const typeIndex = columns.indexOf('type');
+	const next = [...columns];
+	next.splice(typeIndex >= 0 ? typeIndex + 1 : 0, 0, 'severity');
+	return next;
+};
+
 export const useColumnManagement = (options: ColumnManagementOptions = {}) => {
 	const {
 		tagKeys = [],
@@ -17,13 +32,23 @@ export const useColumnManagement = (options: ColumnManagementOptions = {}) => {
 		onVisibleColumnsChange,
 	} = options;
 
-	const visibleColumns =
-		controlledVisibleColumns && controlledVisibleColumns.length > 0
-			? controlledVisibleColumns
-			: DEFAULT_VISIBLE_COLUMNS;
+	const visibleColumns = useMemo(
+		() =>
+			withSeverity(
+				controlledVisibleColumns && controlledVisibleColumns.length > 0
+					? controlledVisibleColumns
+					: DEFAULT_VISIBLE_COLUMNS
+			),
+		[controlledVisibleColumns]
+	);
 
-	const columnOrder =
-		controlledColumnOrder && controlledColumnOrder.length > 0 ? controlledColumnOrder : DEFAULT_COLUMN_ORDER;
+	const columnOrder = useMemo(
+		() =>
+			withSeverity(
+				controlledColumnOrder && controlledColumnOrder.length > 0 ? controlledColumnOrder : DEFAULT_COLUMN_ORDER
+			),
+		[controlledColumnOrder]
+	);
 
 	const allColumnLabels = useMemo(() => {
 		const labels: Record<string, string> = {};
@@ -45,9 +70,17 @@ export const useColumnManagement = (options: ColumnManagementOptions = {}) => {
 		(column: string) => {
 			if (!onVisibleColumnsChange) return;
 
-			const newColumns = visibleColumns.includes(column)
-				? visibleColumns.filter((col) => col !== column)
-				: [...visibleColumns, column];
+			const isVisible = visibleColumns.includes(column);
+			// Remember an explicit severity hide so the auto-injection above stops.
+			if (column === 'severity') {
+				if (isVisible) {
+					localStorage.setItem(SEVERITY_HIDDEN_KEY, 'true');
+				} else {
+					localStorage.removeItem(SEVERITY_HIDDEN_KEY);
+				}
+			}
+
+			const newColumns = isVisible ? visibleColumns.filter((col) => col !== column) : [...visibleColumns, column];
 
 			onVisibleColumnsChange(newColumns);
 		},

--- a/apps/client/src/components/Alerts/hooks/useSeverityColors.ts
+++ b/apps/client/src/components/Alerts/hooks/useSeverityColors.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+const STORAGE_KEY = 'opsimate-alerts-severity-colors';
+
+// Page-level preference for tinting alert rows by severity, remembered across sessions.
+export const useSeverityColors = () => {
+	const [severityColors, setSeverityColors] = useState(() => localStorage.getItem(STORAGE_KEY) === 'true');
+
+	const toggleSeverityColors = () =>
+		setSeverityColors((prev) => {
+			localStorage.setItem(STORAGE_KEY, String(!prev));
+			return !prev;
+		});
+
+	return { severityColors, toggleSeverityColors };
+};

--- a/apps/client/src/components/Alerts/utils/alertTags.utils.ts
+++ b/apps/client/src/components/Alerts/utils/alertTags.utils.ts
@@ -1,8 +1,15 @@
 import { Alert } from '@OpsiMate/shared';
 
+// Tags kept out of every tag UI (labels section, tag columns, facets, TV cards). The
+// severity tag is an internal mirror of the first-class severity field — users interact
+// with severity through the dedicated column/filter/badges, never the raw tag.
+export const HIDDEN_TAG_KEYS = new Set(['severity']);
+
 export const getAlertTagsArray = (alert: Alert): string[] => {
 	if (!alert.tags || typeof alert.tags !== 'object') return [];
-	return Object.values(alert.tags).filter(Boolean);
+	return Object.entries(alert.tags)
+		.filter(([key, value]) => !HIDDEN_TAG_KEYS.has(key) && Boolean(value))
+		.map(([, value]) => value);
 };
 
 export const getAlertTagsString = (alert: Alert): string => {
@@ -28,6 +35,6 @@ export const alertMatchesTagFilter = (alert: Alert, filterValues: string[]): boo
 export const getAlertTagEntries = (alert: Alert): Array<{ key: string; value: string }> => {
 	if (!alert.tags || typeof alert.tags !== 'object') return [];
 	return Object.entries(alert.tags)
-		.filter(([, value]) => Boolean(value))
+		.filter(([key, value]) => !HIDDEN_TAG_KEYS.has(key) && Boolean(value))
 		.map(([key, value]) => ({ key, value }));
 };

--- a/apps/client/src/components/Alerts/utils/severity.utils.ts
+++ b/apps/client/src/components/Alerts/utils/severity.utils.ts
@@ -1,0 +1,33 @@
+import { Alert, AlertSeverity, normalizeAlertSeverity } from '@OpsiMate/shared';
+
+// Sort rank: higher = more severe, so a descending sort shows critical first.
+export const SEVERITY_RANK: Record<AlertSeverity, number> = {
+	[AlertSeverity.CRITICAL]: 3,
+	[AlertSeverity.WARNING]: 2,
+	[AlertSeverity.INFO]: 1,
+};
+
+export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
+	[AlertSeverity.CRITICAL]: 'Critical',
+	[AlertSeverity.WARNING]: 'Warning',
+	[AlertSeverity.INFO]: 'Info',
+};
+
+// Subtle full-row tint used by the "severity colors" table toggle. Opacity-based so it
+// works in both light and dark themes.
+export const SEVERITY_ROW_CLASSES: Record<AlertSeverity, string> = {
+	[AlertSeverity.CRITICAL]: 'bg-red-500/10 hover:bg-red-500/20',
+	[AlertSeverity.WARNING]: 'bg-amber-500/10 hover:bg-amber-500/20',
+	[AlertSeverity.INFO]: 'bg-sky-500/10 hover:bg-sky-500/20',
+};
+
+export const SEVERITY_TEXT_CLASSES: Record<AlertSeverity, string> = {
+	[AlertSeverity.CRITICAL]: 'text-red-500',
+	[AlertSeverity.WARNING]: 'text-amber-500',
+	[AlertSeverity.INFO]: 'text-sky-500',
+};
+
+// The server always sets severity, but data from older deployments or playground fixtures
+// may miss it — fall back to a `severity` tag, then the default, like the server does.
+export const getAlertSeverity = (alert: Alert): AlertSeverity =>
+	normalizeAlertSeverity(alert.severity ?? alert.tags?.['severity']);

--- a/apps/client/src/components/Alerts/utils/severity.utils.ts
+++ b/apps/client/src/components/Alerts/utils/severity.utils.ts
@@ -28,6 +28,7 @@ export const SEVERITY_TEXT_CLASSES: Record<AlertSeverity, string> = {
 };
 
 // The server always sets severity, but data from older deployments or playground fixtures
-// may miss it — fall back to a `severity` tag, then the default, like the server does.
+// may miss it — fall back to a `severity` tag, then a `priority` tag (P1–P5, the signal
+// TV mode has historically used), then the default, like the server does.
 export const getAlertSeverity = (alert: Alert): AlertSeverity =>
-	normalizeAlertSeverity(alert.severity ?? alert.tags?.['severity']);
+	normalizeAlertSeverity(alert.severity ?? alert.tags?.['severity'] ?? alert.tags?.['priority']);

--- a/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
+++ b/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { API_HOST } from '@/lib/api';
 import { Archive, Check, Copy, ExternalLink, Send, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface CustomAlertsSetupModalProps {
 	open: boolean;
@@ -425,6 +426,14 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 							file.
 						</p>
 					</div>
+
+					<SeveritySetupNote>
+						<p>
+							Include a <code>severity</code> field in the JSON payload (e.g.{' '}
+							<code>{'"severity": "critical"'}</code>), or a <code>severity</code> key inside{' '}
+							<code>tags</code>. The explicit field wins when both are present.
+						</p>
+					</SeveritySetupNote>
 
 					<div className="flex justify-between">
 						<Button

--- a/apps/client/src/components/Integrations/DatadogSetupModal/DatadogSetupModal.tsx
+++ b/apps/client/src/components/Integrations/DatadogSetupModal/DatadogSetupModal.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { API_BASE_URL } from '@/lib/api';
 import { Check, Copy, ExternalLink, Info } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface DatadogSetupModalProps {
 	open: boolean;
@@ -252,6 +253,15 @@ export const DatadogSetupModal = ({ open, onOpenChange }: DatadogSetupModalProps
 							</div>
 						</div>
 					</div>
+
+					<SeveritySetupNote>
+						<p>
+							Add a <code>severity:critical</code> tag to the monitor (
+							<strong>Edit monitor &rarr; Tags</strong>). If no severity tag is present, the
+							monitor&apos;s <strong>priority</strong> (P1&ndash;P5) is used instead: P1 &rarr; critical,
+							P2/P3 &rarr; warning, P4/P5 &rarr; info.
+						</p>
+					</SeveritySetupNote>
 
 					<div className="pt-4 flex justify-end">
 						<Button onClick={() => onOpenChange(false)}>Done</Button>

--- a/apps/client/src/components/Integrations/GCPSetupModal/GCPSetupModal.tsx
+++ b/apps/client/src/components/Integrations/GCPSetupModal/GCPSetupModal.tsx
@@ -5,6 +5,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { API_HOST } from '@/lib/api';
 import { Check, Copy, ExternalLink } from 'lucide-react';
 import { useState } from 'react';
+import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface GCPSetupModalProps {
 	open: boolean;
@@ -199,6 +200,13 @@ export const GCPSetupModal = ({ open, onOpenChange }: GCPSetupModalProps) => {
 							</p>
 						</div>
 					</div>
+
+					<SeveritySetupNote>
+						<p>
+							Add a user label named <code>severity</code> to your alerting policy (
+							<strong>Policy &rarr; User labels</strong>), e.g. <code>severity: critical</code>.
+						</p>
+					</SeveritySetupNote>
 
 					<div className="pt-4 flex justify-between">
 						<Button

--- a/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
+++ b/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
@@ -5,6 +5,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { API_BASE_URL } from '@/lib/api';
 import { Check, Copy, ExternalLink, Info } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface GrafanaSetupModalProps {
 	open: boolean;
@@ -165,6 +166,14 @@ export const GrafanaSetupModal = ({ open, onOpenChange }: GrafanaSetupModalProps
 							</div>
 						</div>
 					</div>
+
+					<SeveritySetupNote>
+						<p>
+							Add a <code>severity</code> label to your Grafana alert rule (edit the rule &rarr;{' '}
+							<strong>Labels</strong>), e.g. <code>severity=critical</code>. The label is delivered with
+							the alert and sets its severity in OpsiMate.
+						</p>
+					</SeveritySetupNote>
 
 					<div className="pt-4 flex justify-end">
 						<Button onClick={() => onOpenChange(false)}>Done</Button>

--- a/apps/client/src/components/Integrations/SeveritySetupNote/SeveritySetupNote.tsx
+++ b/apps/client/src/components/Integrations/SeveritySetupNote/SeveritySetupNote.tsx
@@ -1,0 +1,25 @@
+import { TriangleAlert } from 'lucide-react';
+import { ReactNode } from 'react';
+
+interface SeveritySetupNoteProps {
+	// Integration-specific instructions for where to put the severity value.
+	children: ReactNode;
+}
+
+// Shared "how to set alert severity" box for the integration setup modals. The
+// integration-specific part comes in as children; the allowed values and default
+// behavior are the same everywhere.
+export const SeveritySetupNote = ({ children }: SeveritySetupNoteProps) => (
+	<div className="bg-muted/40 border rounded-lg p-4 space-y-2">
+		<h4 className="font-semibold text-sm flex items-center gap-2 text-foreground">
+			<TriangleAlert className="h-4 w-4 text-amber-500" />
+			Setting alert severity
+		</h4>
+		<div className="text-sm text-muted-foreground space-y-1">{children}</div>
+		<p className="text-xs text-muted-foreground">
+			Allowed values: <code>critical</code>, <code>warning</code>, <code>info</code>. Common synonyms (
+			<code>P1</code>, <code>error</code>, <code>high</code>, <code>disaster</code>, <code>low</code>, …) are
+			mapped automatically. Alerts without a recognized severity default to <code>warning</code>.
+		</p>
+	</div>
+);

--- a/apps/client/src/components/Integrations/SeveritySetupNote/index.ts
+++ b/apps/client/src/components/Integrations/SeveritySetupNote/index.ts
@@ -1,0 +1,1 @@
+export { SeveritySetupNote } from './SeveritySetupNote';

--- a/apps/client/src/components/Integrations/UptimeKumaSetupModal/UptimeKumaSetupModal.tsx
+++ b/apps/client/src/components/Integrations/UptimeKumaSetupModal/UptimeKumaSetupModal.tsx
@@ -5,6 +5,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { API_HOST } from '@/lib/api';
 import { Check, Copy, ExternalLink } from 'lucide-react';
 import { useState } from 'react';
+import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface UptimeKumaSetupModalProps {
 	open: boolean;
@@ -154,6 +155,14 @@ export const UptimeKumaSetupModal = ({ open, onOpenChange }: UptimeKumaSetupModa
 							</p>
 						</div>
 					</div>
+
+					<SeveritySetupNote>
+						<p>
+							Add a tag named <code>severity</code> to the monitor (
+							<strong>Edit monitor &rarr; Tags</strong>) with the value <code>critical</code>,{' '}
+							<code>warning</code> or <code>info</code>.
+						</p>
+					</SeveritySetupNote>
 
 					<div className="pt-4 flex justify-between">
 						<Button

--- a/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
+++ b/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { API_HOST } from '@/lib/api';
 import { Check, Copy, ExternalLink } from 'lucide-react';
 import { useState } from 'react';
+import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface ZabbixSetupModalProps {
 	open: boolean;
@@ -504,6 +505,14 @@ fi`;
 						</div>
 					</TabsContent>
 				</Tabs>
+
+				<SeveritySetupNote>
+					<p>
+						Nothing extra to configure &mdash; the trigger&apos;s severity (
+						<code>{'{TRIGGER.SEVERITY}'}</code>) is sent automatically: Disaster/High &rarr; critical,
+						Average/Warning &rarr; warning, Information &rarr; info.
+					</p>
+				</SeveritySetupNote>
 
 				<div className="pt-4 flex justify-between border-t mt-4">
 					<Button

--- a/apps/client/src/mocks/state.ts
+++ b/apps/client/src/mocks/state.ts
@@ -14,6 +14,7 @@ import {
 	AuditLog,
 	AuditResourceType,
 	Dashboard,
+	normalizeAlertSeverity,
 	Integration,
 	IntegrationType,
 	Provider,
@@ -396,6 +397,8 @@ const seedAlerts = () => {
 	const alerts = generateDiverseMockAlerts(500);
 	return alerts.map((alert, idx) => ({
 		...alert,
+		// First-class severity mirrors production ingestion (derived from the severity tag).
+		severity: normalizeAlertSeverity(TAG_SEVERITY[idx % TAG_SEVERITY.length]),
 		tags: {
 			severity: TAG_SEVERITY[idx % TAG_SEVERITY.length],
 			service: TAG_SERVICE[idx % TAG_SERVICE.length],

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -324,6 +324,9 @@ export class AlertController {
 				id: alertId,
 				type: 'Datadog',
 				status: AlertStatus.FIRING,
+				// Datadog monitor priority (P1–P5); the ingestion funnel normalizes it
+				// (P1 → critical, …) unless an explicit severity tag is present.
+				severity: tags['severity'] ?? payload.priority,
 				tags,
 				startsAt: new Date(Number(startsAtSource)).toISOString(),
 				updatedAt: new Date(Number(updatedAtSource)).toISOString(),

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -440,6 +440,7 @@ export class AlertController {
 				id: alert.id,
 				type: 'Custom',
 				status: AlertStatus.FIRING,
+				severity: alert.severity,
 				tags: alert.tags,
 				startsAt: alert.startsAt || new Date().toISOString(),
 				updatedAt: alert.updatedAt || new Date().toISOString(),

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -40,6 +40,9 @@ export const HttpAlertWebhookSchema = z.object({
 	summary: z.string().optional(),
 	runbookUrl: z.string().url().optional(),
 	createdAt: isoDateString.optional(),
+	// Free-form; normalized onto the fixed critical/warning/info scale at ingestion
+	// (unknown or missing values default to warning).
+	severity: z.string().optional(),
 });
 
 /**

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -41,7 +41,7 @@ export const HttpAlertWebhookSchema = z.object({
 	runbookUrl: z.string().url().optional(),
 	createdAt: isoDateString.optional(),
 	// Free-form; normalized onto the fixed critical/warning/info scale at ingestion
-	// (unknown or missing values default to info).
+	// (unknown or missing values default to warning).
 	severity: z.string().optional(),
 });
 

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -41,7 +41,7 @@ export const HttpAlertWebhookSchema = z.object({
 	runbookUrl: z.string().url().optional(),
 	createdAt: isoDateString.optional(),
 	// Free-form; normalized onto the fixed critical/warning/info scale at ingestion
-	// (unknown or missing values default to warning).
+	// (unknown or missing values default to info).
 	severity: z.string().optional(),
 });
 

--- a/apps/server/src/bl/actions/actionExecutor.ts
+++ b/apps/server/src/bl/actions/actionExecutor.ts
@@ -27,6 +27,7 @@ export interface AlertContextInput {
 	alertName?: string;
 	status?: string;
 	type?: string;
+	severity?: string;
 	summary?: string | null;
 	startsAt?: string;
 	updatedAt?: string;
@@ -59,7 +60,8 @@ export const buildAlertContext = (alert: AlertContextInput): Record<string, stri
 		'alert.createdAt': alert.createdAt ?? '',
 		'alert.url': alert.alertUrl ?? '',
 		'alert.runbookUrl': alert.runbookUrl ?? '',
-		'alert.severity': alert.tags?.severity ?? '',
+		// First-class severity wins; the tag is kept as a fallback for older callers.
+		'alert.severity': alert.severity ?? alert.tags?.severity ?? '',
 		'alert.service': alert.tags?.service ?? '',
 	};
 	for (const [key, value] of Object.entries(alert.tags ?? {})) {

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -9,6 +9,7 @@ import {
 	AlertStatus,
 	AlertType,
 	Logger,
+	normalizeAlertSeverity,
 } from '@OpsiMate/shared';
 import { AlertCommentsRepository } from '../../dal/alertCommentsRepository.ts';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
@@ -74,10 +75,16 @@ export class AlertBL {
 	}
 
 	// region active
-	async insertOrUpdateAlert(alert: Omit<Alert, 'createdAt' | 'isDismissed'>): Promise<{ changes: number }> {
+	// Severity is resolved here — the single funnel for every ingestion endpoint: an explicit
+	// severity field wins, then a `severity` tag (Zabbix/Grafana/Datadog labels), then the
+	// default. Free-form values are normalized onto the fixed critical/warning/info scale.
+	async insertOrUpdateAlert(
+		alert: Omit<Alert, 'createdAt' | 'isDismissed' | 'severity'> & { severity?: string }
+	): Promise<{ changes: number }> {
 		try {
 			logger.info(`Inserting alert: ${alert.id}`);
-			return await this.alertRepo.insertOrUpdateAlert(alert);
+			const severity = normalizeAlertSeverity(alert.severity ?? alert.tags?.['severity']);
+			return await this.alertRepo.insertOrUpdateAlert({ ...alert, severity });
 		} catch (error) {
 			logger.error('Error inserting alert', error);
 			throw error;

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -77,7 +77,10 @@ export class AlertBL {
 	// region active
 	// Severity is resolved here — the single funnel for every ingestion endpoint: an explicit
 	// severity field wins, then a `severity` tag (Zabbix/Grafana/Datadog labels), then the
-	// default. Free-form values are normalized onto the fixed critical/warning/info scale.
+	// default. Free-form values are normalized onto the fixed critical/warning/info scale,
+	// and the severity tag is rewritten to the normalized value so label matchers (silences,
+	// enrichments) always see the same three values the severity field uses. The tag is
+	// hidden from the UI — users only interact with the first-class severity.
 	async insertOrUpdateAlert(
 		alert: Omit<Alert, 'createdAt' | 'isDismissed' | 'severity'> & { severity?: string }
 	): Promise<{ changes: number }> {
@@ -85,7 +88,8 @@ export class AlertBL {
 			logger.info(`Inserting alert: ${alert.id}`);
 			// || (not ??) so a blank explicit severity falls through to the tag.
 			const severity = normalizeAlertSeverity(alert.severity?.trim() || alert.tags?.['severity']);
-			return await this.alertRepo.insertOrUpdateAlert({ ...alert, severity });
+			const tags = { ...(alert.tags ?? {}), severity };
+			return await this.alertRepo.insertOrUpdateAlert({ ...alert, tags, severity });
 		} catch (error) {
 			logger.error('Error inserting alert', error);
 			throw error;

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -83,7 +83,8 @@ export class AlertBL {
 	): Promise<{ changes: number }> {
 		try {
 			logger.info(`Inserting alert: ${alert.id}`);
-			const severity = normalizeAlertSeverity(alert.severity ?? alert.tags?.['severity']);
+			// || (not ??) so a blank explicit severity falls through to the tag.
+			const severity = normalizeAlertSeverity(alert.severity?.trim() || alert.tags?.['severity']);
 			return await this.alertRepo.insertOrUpdateAlert({ ...alert, severity });
 		} catch (error) {
 			logger.error('Error inserting alert', error);

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -1,4 +1,4 @@
-import { Alert, AlertEnrichment, AppliedEnrichment, Logger } from '@OpsiMate/shared';
+import { Alert, AlertEnrichment, AppliedEnrichment, Logger, normalizeAlertSeverity } from '@OpsiMate/shared';
 import { CreateEnrichmentInput, EnrichmentRepository, UpdateEnrichmentInput } from '../../dal/enrichmentRepository';
 
 const logger = new Logger('bl/enrichment.bl');
@@ -76,17 +76,23 @@ export class EnrichmentBL {
 	// alert's original tags).
 	private static applyToAlert(enrichment: AlertEnrichment, alert: Alert, claimedKeys: Set<string>): Alert {
 		const tags = { ...alert.tags };
+		// First-class severity was resolved at ingestion; a rule that sets a severity
+		// field overrides it, so enrichment stays able to reclassify alerts.
+		let severity = alert.severity;
 		for (const field of enrichment.addFields ?? []) {
 			if (claimedKeys.has(field.key)) continue;
 			// Field values are templated too, so a field can copy a label, e.g. owner={{label.team}}.
 			tags[field.key] = EnrichmentBL.resolveTemplate(field.value, alert);
 			claimedKeys.add(field.key);
+			if (field.key === 'severity') {
+				severity = normalizeAlertSeverity(tags[field.key]);
+			}
 		}
 		const summary =
 			enrichment.summaryTemplate && enrichment.summaryTemplate.trim().length > 0
 				? EnrichmentBL.resolveTemplate(enrichment.summaryTemplate, alert)
 				: alert.summary;
-		return { ...alert, tags, summary };
+		return { ...alert, tags, summary, severity };
 	}
 
 	// Decorate alerts with all matching enrichment rules. Applied at fetch time only —

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -152,7 +152,9 @@ export class EnrichmentBL {
 			tags[field.key] = EnrichmentBL.resolveTemplate(field.value, alert);
 			claimedKeys.add(field.key);
 			if (field.key === 'severity') {
+				// The severity tag always mirrors the normalized first-class value.
 				severity = normalizeAlertSeverity(tags[field.key]);
+				tags[field.key] = severity;
 			}
 		}
 		const summary =

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -1,4 +1,4 @@
-import { AlertStatus, AlertType, Alert as SharedAlert } from '@OpsiMate/shared';
+import { AlertStatus, AlertType, normalizeAlertSeverity, Alert as SharedAlert } from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
 import { AlertRow, TableInfoRow } from './models';
@@ -13,11 +13,12 @@ export class AlertRepository {
 	async insertOrUpdateAlert(alert: Omit<SharedAlert, 'createdAt' | 'isDismissed'>): Promise<{ changes: number }> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
-				INSERT INTO alerts (id, status, type, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				INSERT INTO alerts (id, status, type, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				ON CONFLICT(id) DO UPDATE SET
 											  status=excluded.status,
 											  type=excluded.type,
+											  severity=excluded.severity,
 											  tags=excluded.tags,
 											  starts_at=excluded.starts_at,
 											  updated_at=excluded.updated_at,
@@ -31,6 +32,7 @@ export class AlertRepository {
 				alert.id,
 				alert.status,
 				alert.type,
+				alert.severity,
 				JSON.stringify(alert.tags ?? {}),
 				alert.startsAt,
 				alert.updatedAt,
@@ -49,6 +51,7 @@ export class AlertRepository {
 				CREATE TABLE IF NOT EXISTS alerts (
 					id TEXT PRIMARY KEY,
 					status TEXT,
+					severity TEXT,
 					tags TEXT,
 					type TEXT,
 					starts_at TEXT,
@@ -86,6 +89,12 @@ export class AlertRepository {
 			if (!hasOwnerId) {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN owner_id INTEGER REFERENCES users(id)`).run();
 			}
+
+			// Backward compatibility: ensure severity column exists
+			const hasSeverity = columns.some((col: TableInfoRow) => col.name === 'severity');
+			if (!hasSeverity) {
+				this.db.prepare(`ALTER TABLE alerts ADD COLUMN severity TEXT`).run();
+			}
 		});
 	}
 
@@ -96,6 +105,8 @@ export class AlertRepository {
 			id: row.id,
 			status,
 			type: row.type,
+			// Legacy rows (pre-severity) fall back to the default via normalization.
+			severity: normalizeAlertSeverity(row.severity),
 			tags: row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {},
 			startsAt: row.starts_at,
 			updatedAt: row.updated_at,

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -100,14 +100,15 @@ export class AlertRepository {
 
 	private toSharedAlert = (row: AlertRow): SharedAlert => {
 		const status = row.status === 'firing' ? AlertStatus.FIRING : AlertStatus.RESOLVED;
+		const tags = row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {};
 
 		return {
 			id: row.id,
 			status,
 			type: row.type,
-			// Legacy rows (pre-severity) fall back to the default via normalization.
-			severity: normalizeAlertSeverity(row.severity),
-			tags: row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {},
+			// Legacy rows (pre-severity column) fall back to their severity tag, then the default.
+			severity: normalizeAlertSeverity(row.severity ?? tags['severity']),
+			tags,
 			startsAt: row.starts_at,
 			updatedAt: row.updated_at,
 			alertUrl: row.alert_url,

--- a/apps/server/src/dal/archivedAlertRepository.ts
+++ b/apps/server/src/dal/archivedAlertRepository.ts
@@ -123,12 +123,13 @@ export class ArchivedAlertRepository {
 	}
 
 	private toSharedAlert = (row: ArchivedAlertRow): SharedAlert => {
+		const tags = row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {};
 		return {
 			id: row.id,
 			status: row.status == 'firing' ? AlertStatus.FIRING : AlertStatus.RESOLVED,
-			// Legacy rows (pre-severity) fall back to the default via normalization.
-			severity: normalizeAlertSeverity(row.severity),
-			tags: row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {},
+			// Legacy rows (pre-severity column) fall back to their severity tag, then the default.
+			severity: normalizeAlertSeverity(row.severity ?? tags['severity']),
+			tags,
 			type: row.type,
 			startsAt: row.starts_at,
 			updatedAt: row.updated_at,

--- a/apps/server/src/dal/archivedAlertRepository.ts
+++ b/apps/server/src/dal/archivedAlertRepository.ts
@@ -1,4 +1,4 @@
-import { AlertStatus, Alert as SharedAlert, AlertHistory } from '@OpsiMate/shared';
+import { AlertStatus, Alert as SharedAlert, AlertHistory, normalizeAlertSeverity } from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
 import { ArchivedAlertRow, TableInfoRow } from './models';
@@ -17,6 +17,7 @@ export class ArchivedAlertRepository {
 						CREATE TABLE IF NOT EXISTS alerts_archived (
 																	   id TEXT PRIMARY KEY,
 																	   status TEXT NOT NULL,
+																	   severity TEXT,
 																	   tags TEXT,
 																	   type TEXT,
 																	   starts_at TEXT,
@@ -68,6 +69,12 @@ export class ArchivedAlertRepository {
 			if (!hasOwnerId) {
 				this.db.prepare(`ALTER TABLE alerts_archived ADD COLUMN owner_id INTEGER REFERENCES users(id)`).run();
 			}
+
+			// Backward compatibility: ensure severity column exists
+			const hasSeverity = columns.some((col: TableInfoRow) => col.name === 'severity');
+			if (!hasSeverity) {
+				this.db.prepare(`ALTER TABLE alerts_archived ADD COLUMN severity TEXT`).run();
+			}
 		});
 	}
 
@@ -75,10 +82,11 @@ export class ArchivedAlertRepository {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
                 INSERT INTO alerts_archived
-                    (id, status, tags, type, starts_at, updated_at, alert_url, alert_name, is_dismissed, summary, runbook_url, created_at, owner_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (id, status, severity, tags, type, starts_at, updated_at, alert_url, alert_name, is_dismissed, summary, runbook_url, created_at, owner_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     status = excluded.status,
+                    severity = excluded.severity,
                     tags = excluded.tags,
                     type = excluded.type,
                     starts_at = excluded.starts_at,
@@ -96,6 +104,7 @@ export class ArchivedAlertRepository {
 			const result = stmt.run(
 				alert.id,
 				AlertStatus.RESOLVED,
+				alert.severity,
 				JSON.stringify(alert.tags),
 				alert.type,
 				alert.startsAt,
@@ -117,6 +126,8 @@ export class ArchivedAlertRepository {
 		return {
 			id: row.id,
 			status: row.status == 'firing' ? AlertStatus.FIRING : AlertStatus.RESOLVED,
+			// Legacy rows (pre-severity) fall back to the default via normalization.
+			severity: normalizeAlertSeverity(row.severity),
 			tags: row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {},
 			type: row.type,
 			startsAt: row.starts_at,

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -55,6 +55,7 @@ export type AlertRow = {
 	id: string;
 	type: AlertType;
 	status: string;
+	severity?: string | null;
 	tags: string;
 	starts_at: string;
 	updated_at: string;
@@ -72,6 +73,7 @@ export type ArchivedAlertRow = {
 	id: string;
 	type: AlertType;
 	status: string;
+	severity?: string | null;
 	tags: string;
 	starts_at: string;
 	updated_at: string;

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -492,6 +492,53 @@ describe('Alerts API', () => {
 			expect(row.severity).toBe('warning');
 		});
 
+		test('should default severity for prototype-key payloads instead of crashing', async () => {
+			// 'constructor' / '__proto__' survive lowercasing and would resolve to inherited
+			// object members without the hasOwn guard in normalizeAlertSeverity.
+			for (const [id, evil] of [
+				['severity-proto-1', 'constructor'],
+				['severity-proto-2', '__proto__'],
+			]) {
+				const response = await app
+					.post('/api/v1/alerts/custom')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send({ id, tags: {}, alertName: 'Prototype Key Test', severity: evil });
+
+				expect(response.status).toBe(200);
+				const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow;
+				expect(row.severity).toBe('warning');
+			}
+		});
+
+		test('should fall back to the severity tag when the explicit field is blank', async () => {
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					id: 'severity-blank-explicit',
+					tags: { severity: 'critical' },
+					alertName: 'Blank Severity Test',
+					severity: '',
+				});
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get('severity-blank-explicit') as AlertRow;
+			expect(row.severity).toBe('critical');
+		});
+
+		test('should serve legacy rows (NULL severity column) from their severity tag', async () => {
+			// Simulates a row written before the severity column existed.
+			db.prepare(
+				`INSERT INTO alerts (id, status, type, tags, starts_at, updated_at, alert_url, alert_name)
+				 VALUES ('severity-legacy', 'firing', 'Zabbix', ?, ?, ?, '', 'Legacy Severity Test')`
+			).run(JSON.stringify({ severity: 'Disaster' }), new Date().toISOString(), new Date().toISOString());
+
+			const response = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+			expect(response.status).toBe(200);
+			const legacy = (response.body.data.alerts as Alert[]).find((a) => a.id === 'severity-legacy');
+			expect(legacy?.severity).toBe('critical');
+		});
+
 		test('should derive severity from a severity tag, mapping synonyms', async () => {
 			const payload = {
 				id: 'severity-from-tag',

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -475,7 +475,7 @@ describe('Alerts API', () => {
 			expect(row.severity).toBe('critical');
 		});
 
-		test('should default severity to warning when omitted', async () => {
+		test('should default severity to info when omitted, and mirror it into the tag', async () => {
 			const payload = {
 				id: 'severity-default',
 				tags: {},
@@ -489,7 +489,8 @@ describe('Alerts API', () => {
 
 			expect(response.status).toBe(200);
 			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id) as AlertRow;
-			expect(row.severity).toBe('warning');
+			expect(row.severity).toBe('info');
+			expect(JSON.parse(row.tags as string).severity).toBe('info');
 		});
 
 		test('should default severity for prototype-key payloads instead of crashing', async () => {
@@ -506,7 +507,7 @@ describe('Alerts API', () => {
 
 				expect(response.status).toBe(200);
 				const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow;
-				expect(row.severity).toBe('warning');
+				expect(row.severity).toBe('info');
 			}
 		});
 
@@ -539,7 +540,7 @@ describe('Alerts API', () => {
 			expect(legacy?.severity).toBe('critical');
 		});
 
-		test('should derive severity from a severity tag, mapping synonyms', async () => {
+		test('should derive severity from a severity tag, mapping synonyms and normalizing the tag', async () => {
 			const payload = {
 				id: 'severity-from-tag',
 				tags: { severity: 'Disaster' },
@@ -554,6 +555,9 @@ describe('Alerts API', () => {
 			expect(response.status).toBe(200);
 			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id) as AlertRow;
 			expect(row.severity).toBe('critical');
+			// The stored tag is rewritten to the normalized value so label matchers
+			// (silences/enrichments) see the same scale as the severity field.
+			expect(JSON.parse(row.tags as string).severity).toBe('critical');
 		});
 
 		test('should expose severity on the alerts list API', async () => {
@@ -661,9 +665,10 @@ describe('Alerts API', () => {
 			expect(row.alert_name).toBe(payload.title);
 			expect(row.status).toBe('firing');
 
-			// Validate tags mapping – primary tag should be derived from alert_scope / tags
+			// Validate tags mapping – primary tag should be derived from alert_scope / tags.
+			// The ingestion funnel also mirrors the resolved severity into the tags.
 			const parsedTags = row.tags ? JSON.parse(row.tags as string) : {};
-			expect(parsedTags).toEqual({ service: 'web', env: 'prod' });
+			expect(parsedTags).toEqual({ service: 'web', env: 'prod', severity: 'info' });
 		});
 
 		test('should archive an existing Datadog alert when alert_transition is recovered', async () => {

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -457,6 +457,70 @@ describe('Alerts API', () => {
 			expect(row.alert_name).toBe(payload.alertName);
 		});
 
+		test('should store a normalized explicit severity', async () => {
+			const payload = {
+				id: 'severity-explicit',
+				tags: {},
+				alertName: 'Severity Test',
+				severity: 'CRITICAL',
+			};
+
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send(payload);
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id) as AlertRow;
+			expect(row.severity).toBe('critical');
+		});
+
+		test('should default severity to warning when omitted', async () => {
+			const payload = {
+				id: 'severity-default',
+				tags: {},
+				alertName: 'Severity Default Test',
+			};
+
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send(payload);
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id) as AlertRow;
+			expect(row.severity).toBe('warning');
+		});
+
+		test('should derive severity from a severity tag, mapping synonyms', async () => {
+			const payload = {
+				id: 'severity-from-tag',
+				tags: { severity: 'Disaster' },
+				alertName: 'Severity Tag Test',
+			};
+
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send(payload);
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id) as AlertRow;
+			expect(row.severity).toBe('critical');
+		});
+
+		test('should expose severity on the alerts list API', async () => {
+			const response = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+
+			expect(response.status).toBe(200);
+			const alerts = response.body.data.alerts as Alert[];
+			expect(alerts.length).toBeGreaterThan(0);
+			// Every alert carries a normalized severity, including legacy seeded rows without one.
+			for (const alert of alerts) {
+				expect(['critical', 'warning', 'info']).toContain(alert.severity);
+			}
+		});
+
 		test('should return 400 for invalid payload (missing required fields)', async () => {
 			const payload = {
 				// Missing id, startsAt, etc.

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -475,7 +475,7 @@ describe('Alerts API', () => {
 			expect(row.severity).toBe('critical');
 		});
 
-		test('should default severity to info when omitted, and mirror it into the tag', async () => {
+		test('should default severity to warning when omitted, and mirror it into the tag', async () => {
 			const payload = {
 				id: 'severity-default',
 				tags: {},
@@ -489,8 +489,8 @@ describe('Alerts API', () => {
 
 			expect(response.status).toBe(200);
 			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id) as AlertRow;
-			expect(row.severity).toBe('info');
-			expect(JSON.parse(row.tags as string).severity).toBe('info');
+			expect(row.severity).toBe('warning');
+			expect(JSON.parse(row.tags as string).severity).toBe('warning');
 		});
 
 		test('should default severity for prototype-key payloads instead of crashing', async () => {
@@ -507,7 +507,7 @@ describe('Alerts API', () => {
 
 				expect(response.status).toBe(200);
 				const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow;
-				expect(row.severity).toBe('info');
+				expect(row.severity).toBe('warning');
 			}
 		});
 
@@ -668,7 +668,7 @@ describe('Alerts API', () => {
 			// Validate tags mapping – primary tag should be derived from alert_scope / tags.
 			// The ingestion funnel also mirrors the resolved severity into the tags.
 			const parsedTags = row.tags ? JSON.parse(row.tags as string) : {};
-			expect(parsedTags).toEqual({ service: 'web', env: 'prod', severity: 'info' });
+			expect(parsedTags).toEqual({ service: 'web', env: 'prod', severity: 'warning' });
 		});
 
 		test('should archive an existing Datadog alert when alert_transition is recovered', async () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -121,10 +121,56 @@ export enum AlertStatus {
 	RESOLVED = 'resolved',
 }
 
+// Fixed severity scale. Integrations send free-form values (Zabbix "Disaster", Datadog
+// "error", …) which are normalized onto this scale at ingestion time.
+export enum AlertSeverity {
+	CRITICAL = 'critical',
+	WARNING = 'warning',
+	INFO = 'info',
+}
+
+export const DEFAULT_ALERT_SEVERITY = AlertSeverity.WARNING;
+
+// Synonyms seen across integrations, mapped case-insensitively onto the fixed scale.
+const SEVERITY_SYNONYMS: Record<string, AlertSeverity> = {
+	critical: AlertSeverity.CRITICAL,
+	crit: AlertSeverity.CRITICAL,
+	disaster: AlertSeverity.CRITICAL,
+	emergency: AlertSeverity.CRITICAL,
+	fatal: AlertSeverity.CRITICAL,
+	error: AlertSeverity.CRITICAL,
+	high: AlertSeverity.CRITICAL,
+	p1: AlertSeverity.CRITICAL,
+	warning: AlertSeverity.WARNING,
+	warn: AlertSeverity.WARNING,
+	average: AlertSeverity.WARNING,
+	moderate: AlertSeverity.WARNING,
+	medium: AlertSeverity.WARNING,
+	p2: AlertSeverity.WARNING,
+	p3: AlertSeverity.WARNING,
+	info: AlertSeverity.INFO,
+	information: AlertSeverity.INFO,
+	informational: AlertSeverity.INFO,
+	notice: AlertSeverity.INFO,
+	low: AlertSeverity.INFO,
+	ok: AlertSeverity.INFO,
+	p4: AlertSeverity.INFO,
+	p5: AlertSeverity.INFO,
+};
+
+// Maps any free-form severity string onto the fixed scale; unknown or missing values
+// fall back to the default (warning) so every alert always has a severity.
+export function normalizeAlertSeverity(value?: string | null): AlertSeverity {
+	if (!value) return DEFAULT_ALERT_SEVERITY;
+	return SEVERITY_SYNONYMS[value.trim().toLowerCase()] ?? DEFAULT_ALERT_SEVERITY;
+}
+
 export interface Alert {
 	id: string;
 	type: AlertType;
 	status: AlertStatus;
+	// Always present on API responses; alerts sent without one default to warning.
+	severity: AlertSeverity;
 	tags: Record<string, string>;
 	startsAt: string;
 	updatedAt: string;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -129,7 +129,7 @@ export enum AlertSeverity {
 	INFO = 'info',
 }
 
-export const DEFAULT_ALERT_SEVERITY = AlertSeverity.INFO;
+export const DEFAULT_ALERT_SEVERITY = AlertSeverity.WARNING;
 
 // Synonyms seen across integrations, mapped case-insensitively onto the fixed scale.
 const SEVERITY_SYNONYMS: Record<string, AlertSeverity> = {
@@ -159,7 +159,7 @@ const SEVERITY_SYNONYMS: Record<string, AlertSeverity> = {
 };
 
 // Maps any free-form severity string onto the fixed scale; unknown or missing values
-// fall back to the default (info) so every alert always has a severity. The hasOwn
+// fall back to the default (warning) so every alert always has a severity. The hasOwn
 // guard keeps prototype keys in user-controlled input ('constructor', '__proto__', …)
 // from resolving to inherited object members instead of the default.
 export function normalizeAlertSeverity(value?: string | null): AlertSeverity {
@@ -172,7 +172,7 @@ export interface Alert {
 	id: string;
 	type: AlertType;
 	status: AlertStatus;
-	// Always present on API responses; alerts sent without one default to info.
+	// Always present on API responses; alerts sent without one default to warning.
 	severity: AlertSeverity;
 	tags: Record<string, string>;
 	startsAt: string;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -159,10 +159,13 @@ const SEVERITY_SYNONYMS: Record<string, AlertSeverity> = {
 };
 
 // Maps any free-form severity string onto the fixed scale; unknown or missing values
-// fall back to the default (warning) so every alert always has a severity.
+// fall back to the default (warning) so every alert always has a severity. The hasOwn
+// guard keeps prototype keys in user-controlled input ('constructor', '__proto__', …)
+// from resolving to inherited object members instead of the default.
 export function normalizeAlertSeverity(value?: string | null): AlertSeverity {
 	if (!value) return DEFAULT_ALERT_SEVERITY;
-	return SEVERITY_SYNONYMS[value.trim().toLowerCase()] ?? DEFAULT_ALERT_SEVERITY;
+	const key = value.trim().toLowerCase();
+	return Object.hasOwn(SEVERITY_SYNONYMS, key) ? SEVERITY_SYNONYMS[key] : DEFAULT_ALERT_SEVERITY;
 }
 
 export interface Alert {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -129,7 +129,7 @@ export enum AlertSeverity {
 	INFO = 'info',
 }
 
-export const DEFAULT_ALERT_SEVERITY = AlertSeverity.WARNING;
+export const DEFAULT_ALERT_SEVERITY = AlertSeverity.INFO;
 
 // Synonyms seen across integrations, mapped case-insensitively onto the fixed scale.
 const SEVERITY_SYNONYMS: Record<string, AlertSeverity> = {
@@ -159,7 +159,7 @@ const SEVERITY_SYNONYMS: Record<string, AlertSeverity> = {
 };
 
 // Maps any free-form severity string onto the fixed scale; unknown or missing values
-// fall back to the default (warning) so every alert always has a severity. The hasOwn
+// fall back to the default (info) so every alert always has a severity. The hasOwn
 // guard keeps prototype keys in user-controlled input ('constructor', '__proto__', …)
 // from resolving to inherited object members instead of the default.
 export function normalizeAlertSeverity(value?: string | null): AlertSeverity {
@@ -172,7 +172,7 @@ export interface Alert {
 	id: string;
 	type: AlertType;
 	status: AlertStatus;
-	// Always present on API responses; alerts sent without one default to warning.
+	// Always present on API responses; alerts sent without one default to info.
 	severity: AlertSeverity;
 	tags: Record<string, string>;
 	startsAt: string;


### PR DESCRIPTION
## Issue Reference

<!-- Link to the related issue or ticket, e.g. Closes #123 -->

---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->

---

## Screenshots

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Severity** column to the Alerts table (icon header + **sorting**) and a **Severity colors** toggle to tint rows (saved preference).
  * Updated alert visuals with severity/status **icon indicators** and improved severity display in TV/grouped views.
  * Enabled **Severity** filtering in the filter panel.
* **Bug Fixes**
  * Severity is now consistently **normalized, stored, validated, and returned** for both active and archived alerts, including legacy records.
* **Documentation**
  * Added severity guidance to multiple integration setup modals.
* **Tests**
  * Expanded coverage for normalization, legacy handling, and custom/webhook ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->