### PR TITLE
fix(alerts): alert details & grouping UI polish

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertActionsSection/AlertActionsSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertActionsSection/AlertActionsSection.tsx
@@ -1,75 +1,18 @@
-import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Check, RotateCcw, Trash2 } from 'lucide-react';
 import { AlertActions } from './AlertActions';
 
 interface AlertActionsSectionProps {
 	alert: Alert;
-	isActive: boolean;
-	onDismiss?: (alertId: string) => void;
-	onUndismiss?: (alertId: string) => void;
-	onDelete?: (alertId: string) => void;
 }
 
-export const AlertActionsSection = ({
-	alert,
-	isActive,
-	onDismiss,
-	onUndismiss,
-	onDelete,
-}: AlertActionsSectionProps) => {
+// The custom-actions section of the details body. The alert's primary buttons
+// (dismiss/archive/delete) live in AlertFooterActions, pinned at the panel's bottom.
+export const AlertActionsSection = ({ alert }: AlertActionsSectionProps) => {
 	return (
 		<>
 			<Separator />
 			<AlertActions alert={alert} />
-			<Separator />
-			{isActive ? (
-				<div className="space-y-2">
-					{alert.isDismissed ? (
-						<Button
-							variant="outline"
-							size="sm"
-							className="w-full justify-start gap-2"
-							onClick={() => onUndismiss?.(alert.id)}
-						>
-							<RotateCcw className="h-3 w-3" />
-							Undismiss Alert
-						</Button>
-					) : (
-						<Button
-							variant="outline"
-							size="sm"
-							className="w-full justify-start gap-2"
-							onClick={() => onDismiss?.(alert.id)}
-						>
-							<Check className="h-3 w-3" />
-							Dismiss Alert
-						</Button>
-					)}
-					<Button
-						variant="outline"
-						size="sm"
-						className="w-full justify-start gap-2"
-						onClick={() => onDelete?.(alert.id)}
-					>
-						<Archive className="h-3 w-3" />
-						Archive Alert
-					</Button>
-				</div>
-			) : (
-				<div className="space-y-2">
-					<Button
-						variant="destructive"
-						size="sm"
-						className="w-full justify-start gap-2"
-						onClick={() => onDelete?.(alert.id)}
-					>
-						<Trash2 className="h-3 w-3" />
-						Delete Alert
-					</Button>
-				</div>
-			)}
 		</>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetails.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetails.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { AlertDetailsBody } from './AlertDetailsBody';
 import { AlertDetailsHeader } from './AlertDetailsHeader';
+import { AlertFooterActions } from './AlertFooterActions';
 import { SectionsExpandContext, SectionsExpandControls, useSectionsExpandBroadcast } from './CollapsibleSection';
 import { useAlertHistory } from './hooks';
 
@@ -36,16 +37,20 @@ export const AlertDetails = ({
 
 			<ScrollArea className="flex-1">
 				<SectionsExpandContext.Provider value={signal}>
-					<AlertDetailsBody
-						alert={alert}
-						isActive={isActive}
-						historyData={historyData}
-						onDismiss={onDismiss}
-						onUndismiss={onUndismiss}
-						onDelete={onDelete}
-					/>
+					<AlertDetailsBody alert={alert} historyData={historyData} />
 				</SectionsExpandContext.Provider>
 			</ScrollArea>
+
+			{/* Primary actions pinned at the bottom, outside the scroll area. */}
+			<div className="border-t p-3 flex-shrink-0">
+				<AlertFooterActions
+					alert={alert}
+					isActive={isActive}
+					onDismiss={onDismiss}
+					onUndismiss={onUndismiss}
+					onDelete={onDelete}
+				/>
+			</div>
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
@@ -14,30 +14,18 @@ import { CollapsibleSection } from '../CollapsibleSection';
 
 interface AlertDetailsBodyProps {
 	alert: SharedAlert;
-	isActive: boolean;
 	historyData: AlertHistory | null;
 	// Active time-range filter, passed through to the History section.
 	timeRange?: TimeRange | null;
-	onDismiss?: (alertId: string) => void;
-	onUndismiss?: (alertId: string) => void;
-	onDelete?: (alertId: string) => void;
 	// Switches to the Comments tab (containers with tabs only).
 	onViewAllComments?: () => void;
 }
 
 // The Details-tab body, shared by all alert-detail containers. Identity stays pinned at the
 // top; everything else lives in collapsible sections (summary, latest comment, history,
-// labels, links) followed by the actions section.
-export const AlertDetailsBody = ({
-	alert,
-	isActive,
-	historyData,
-	timeRange,
-	onDismiss,
-	onUndismiss,
-	onDelete,
-	onViewAllComments,
-}: AlertDetailsBodyProps) => {
+// labels, links) followed by the custom-actions section. The dismiss/archive buttons are
+// NOT part of the body — containers pin them at the bottom via AlertFooterActions.
+export const AlertDetailsBody = ({ alert, historyData, timeRange, onViewAllComments }: AlertDetailsBodyProps) => {
 	return (
 		<div className="p-4 space-y-2">
 			<AlertInfoSection alert={alert} />
@@ -70,13 +58,7 @@ export const AlertDetailsBody = ({
 				</CollapsibleSection>
 			)}
 
-			<AlertActionsSection
-				alert={alert}
-				isActive={isActive}
-				onDismiss={onDismiss}
-				onUndismiss={onUndismiss}
-				onDelete={onDelete}
-			/>
+			<AlertActionsSection alert={alert} />
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsDrawer/AlertDetailsDrawer.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsDrawer/AlertDetailsDrawer.tsx
@@ -6,6 +6,7 @@ import { Alert } from '@OpsiMate/shared';
 import { Info, MessageSquare, X } from 'lucide-react';
 import { useEffect, useState, useCallback } from 'react';
 import { AlertActionsSection } from '../AlertActionsSection';
+import { AlertFooterActions } from '../AlertFooterActions';
 import { AlertHistorySection } from '../AlertHistorySection';
 import { AlertInfoSection } from '../AlertInfoSection';
 import { AlertLinksSection } from '../AlertLinksSection';
@@ -122,15 +123,7 @@ export const AlertDetailsDrawer = ({
 
 							{renderedAlert && <AlertLinksSection alert={renderedAlert} />}
 
-							{renderedAlert && (
-								<AlertActionsSection
-									alert={renderedAlert}
-									isActive={isActive}
-									onDismiss={onDismiss}
-									onUndismiss={onUndismiss}
-									onDelete={onDelete}
-								/>
-							)}
+							{renderedAlert && <AlertActionsSection alert={renderedAlert} />}
 						</div>
 					</ScrollArea>
 				</TabsContent>
@@ -139,6 +132,19 @@ export const AlertDetailsDrawer = ({
 					{renderedAlert && <CommentsWall alertId={renderedAlert.id} />}
 				</TabsContent>
 			</Tabs>
+
+			{/* Primary actions pinned at the drawer's bottom, outside the scroll area. */}
+			{renderedAlert && (
+				<div className="border-t p-3 flex-shrink-0">
+					<AlertFooterActions
+						alert={renderedAlert}
+						isActive={isActive}
+						onDismiss={onDismiss}
+						onUndismiss={onUndismiss}
+						onDelete={onDelete}
+					/>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { TimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.types';
 import { AlertDetailsBody } from '../AlertDetailsBody';
 import { AlertDetailsHeader } from '../AlertDetailsHeader';
+import { AlertFooterActions } from '../AlertFooterActions';
 import { SectionsExpandContext, SectionsExpandControls, useSectionsExpandBroadcast } from '../CollapsibleSection';
 import { CommentsWall } from '../CommentsWall';
 import { useAlertHistory } from '../hooks';
@@ -59,12 +60,8 @@ export const AlertDetailsPanel = ({
 						<SectionsExpandContext.Provider value={signal}>
 							<AlertDetailsBody
 								alert={alert}
-								isActive={isActive}
 								historyData={historyData}
 								timeRange={timeRange}
-								onDismiss={onDismiss}
-								onUndismiss={onUndismiss}
-								onDelete={onDelete}
 								onViewAllComments={() => setTab('comments')}
 							/>
 						</SectionsExpandContext.Provider>
@@ -75,6 +72,17 @@ export const AlertDetailsPanel = ({
 					<CommentsWall alertId={alert.id} />
 				</TabsContent>
 			</Tabs>
+
+			{/* Primary actions pinned at the panel's bottom, outside the scroll area. */}
+			<div className="border-t p-3 flex-shrink-0">
+				<AlertFooterActions
+					alert={alert}
+					isActive={isActive}
+					onDismiss={onDismiss}
+					onUndismiss={onUndismiss}
+					onDelete={onDelete}
+				/>
+			</div>
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/AlertFooterActions.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/AlertFooterActions.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@/components/ui/button';
+import { Alert } from '@OpsiMate/shared';
+import { Archive, Check, RotateCcw, Trash2 } from 'lucide-react';
+
+interface AlertFooterActionsProps {
+	alert: Alert;
+	isActive: boolean;
+	onDismiss?: (alertId: string) => void;
+	onUndismiss?: (alertId: string) => void;
+	onDelete?: (alertId: string) => void;
+}
+
+// The alert's primary actions, pinned as a one-row footer at the bottom of the details
+// panel (outside the scroll area) so they're always reachable.
+export const AlertFooterActions = ({ alert, isActive, onDismiss, onUndismiss, onDelete }: AlertFooterActionsProps) => {
+	if (!isActive) {
+		return (
+			<Button variant="destructive" size="sm" className="w-full gap-2" onClick={() => onDelete?.(alert.id)}>
+				<Trash2 className="h-3 w-3" />
+				Delete Alert
+			</Button>
+		);
+	}
+
+	return (
+		<div className="grid grid-cols-2 gap-2">
+			{alert.isDismissed ? (
+				<Button variant="outline" size="sm" className="gap-2" onClick={() => onUndismiss?.(alert.id)}>
+					<RotateCcw className="h-3 w-3" />
+					Undismiss
+				</Button>
+			) : (
+				<Button variant="outline" size="sm" className="gap-2" onClick={() => onDismiss?.(alert.id)}>
+					<Check className="h-3 w-3" />
+					Dismiss
+				</Button>
+			)}
+			<Button variant="outline" size="sm" className="gap-2" onClick={() => onDelete?.(alert.id)}>
+				<Archive className="h-3 w-3" />
+				Archive
+			</Button>
+		</div>
+	);
+};

--- a/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/index.ts
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/index.ts
@@ -1,0 +1,1 @@
+export { AlertFooterActions } from './AlertFooterActions';

--- a/apps/client/src/components/Alerts/AlertDetails/AlertSummarySection/AlertSummarySection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertSummarySection/AlertSummarySection.tsx
@@ -4,6 +4,13 @@ interface AlertSummarySectionProps {
 	summary: string;
 }
 
+// Long summaries scroll inside the section instead of pushing the rest of the details
+// panel down: the block is capped at ~30% of the viewport (the panel is full-height, so
+// this is ~30% of the sidebar) and overflows vertically.
 export const AlertSummarySection = ({ summary }: AlertSummarySectionProps) => {
-	return <FormattedText text={summary} className="text-sm text-foreground leading-relaxed" />;
+	return (
+		<div className="max-h-[30vh] overflow-y-auto pr-1">
+			<FormattedText text={summary} className="text-sm text-foreground leading-relaxed" />
+		</div>
+	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/GroupHeader/GroupHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/GroupHeader/GroupHeader.tsx
@@ -44,11 +44,16 @@ export const GroupHeader = ({ item, onToggle, columnLabels = {} }: GroupHeaderPr
 			>
 				{item.isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
 			</Button>
-			<span className="font-semibold text-sm mr-2 text-foreground">{fieldLabel}:</span>
-			<span className="text-sm mr-2 text-foreground/80">{item.value}</span>
-			<Badge variant={badgeVariant} className={`h-5 px-1.5 text-xs rounded-sm ${silencedBadgeClass}`}>
+			{/* Fixed-width count right after the chevron so the numbers align vertically
+			    across groups regardless of how long each group's label is. */}
+			<Badge
+				variant={badgeVariant}
+				className={`h-5 min-w-10 justify-center px-1.5 mr-2 text-xs rounded-sm ${silencedBadgeClass}`}
+			>
 				{item.count}
 			</Badge>
+			<span className="font-semibold text-sm mr-2 text-foreground">{fieldLabel}:</span>
+			<span className="text-sm text-foreground/80">{item.value}</span>
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/StickyGroupHeader/StickyGroupHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/StickyGroupHeader/StickyGroupHeader.tsx
@@ -47,11 +47,16 @@ export const StickyGroupHeader = ({ item, onToggle, columnLabels = {} }: StickyG
 			>
 				{item.isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
 			</Button>
-			<span className="font-semibold text-sm mr-2 text-foreground">{fieldLabel}:</span>
-			<span className="text-sm mr-2 text-foreground/80">{item.value}</span>
-			<Badge variant={badgeVariant} className={`h-5 px-1.5 text-xs rounded-sm ${silencedBadgeClass}`}>
+			{/* Fixed-width count right after the chevron so the numbers align vertically
+			    across groups regardless of how long each group's label is. */}
+			<Badge
+				variant={badgeVariant}
+				className={`h-5 min-w-10 justify-center px-1.5 mr-2 text-xs rounded-sm ${silencedBadgeClass}`}
+			>
 				{item.count}
 			</Badge>
+			<span className="font-semibold text-sm mr-2 text-foreground">{fieldLabel}:</span>
+			<span className="text-sm text-foreground/80">{item.value}</span>
 		</div>
 	);
 };

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -16,7 +16,7 @@ import { useCreateEnrichment, useUpdateEnrichment } from '@/hooks/queries/enrich
 import { EnrichmentPayload } from '@/lib/api';
 import { AlertEnrichment } from '@OpsiMate/shared';
 import { Plus, Sparkles, Tag, Trash2, Wand2 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 type KeyValue = { key: string; value: string };
 
@@ -115,6 +115,24 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 		alerts.forEach((a) => Object.keys(a.tags ?? {}).forEach((k) => keys.add(k)));
 		return Array.from(keys).sort();
 	}, [alerts]);
+
+	const summaryRef = useRef<HTMLTextAreaElement>(null);
+
+	// Insert a placeholder into the summary template at the cursor (replacing any selection),
+	// then restore focus with the caret placed after the inserted text.
+	const insertIntoSummary = (placeholder: string) => {
+		const el = summaryRef.current;
+		const start = el?.selectionStart ?? summaryTemplate.length;
+		const end = el?.selectionEnd ?? summaryTemplate.length;
+		const next = summaryTemplate.slice(0, start) + placeholder + summaryTemplate.slice(end);
+		setSummaryTemplate(next);
+		requestAnimationFrame(() => {
+			if (!el) return;
+			el.focus();
+			const caret = start + placeholder.length;
+			el.setSelectionRange(caret, caret);
+		});
+	};
 
 	useEffect(() => {
 		if (!open) return;
@@ -283,6 +301,7 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 								Summary template (optional)
 							</Label>
 							<Textarea
+								ref={summaryRef}
 								id="enrichment-summary"
 								placeholder="e.g. {{summary}} — contact the help desk, the disk is full"
 								value={summaryTemplate}
@@ -299,7 +318,7 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 						{labelKeys.length > 0 && (
 							<div className="space-y-1.5">
 								<p className="text-xs text-muted-foreground">
-									Available labels (click to copy a placeholder):
+									Available labels (click to insert a placeholder):
 								</p>
 								<div className="flex flex-wrap gap-1.5">
 									{labelKeys.map((key) => {
@@ -308,12 +327,9 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 											<button
 												key={key}
 												type="button"
-												onClick={() => {
-													void navigator.clipboard?.writeText(placeholder);
-													toast({ title: 'Copied', description: placeholder });
-												}}
+												onClick={() => insertIntoSummary(placeholder)}
 												className="px-2 py-0.5 rounded-full border bg-background hover:bg-muted text-[11px] font-mono"
-												title={`Copy ${placeholder}`}
+												title={`Insert ${placeholder}`}
 											>
 												{placeholder}
 											</button>

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -119,11 +119,13 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 	const summaryRef = useRef<HTMLTextAreaElement>(null);
 
 	// Insert a placeholder into the summary template at the cursor (replacing any selection),
-	// then restore focus with the caret placed after the inserted text.
+	// then restore focus with the caret placed after the inserted text. When the textarea
+	// isn't focused its selection is 0, so append at the end instead of the start.
 	const insertIntoSummary = (placeholder: string) => {
 		const el = summaryRef.current;
-		const start = el?.selectionStart ?? summaryTemplate.length;
-		const end = el?.selectionEnd ?? summaryTemplate.length;
+		const isFocused = el != null && document.activeElement === el;
+		const start = isFocused ? el.selectionStart : summaryTemplate.length;
+		const end = isFocused ? el.selectionEnd : summaryTemplate.length;
 		const next = summaryTemplate.slice(0, start) + placeholder + summaryTemplate.slice(end);
 		setSummaryTemplate(next);
 		requestAnimationFrame(() => {
@@ -327,6 +329,9 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 											<button
 												key={key}
 												type="button"
+												// Keep focus in the textarea so the caret position is preserved
+												// and the placeholder inserts where the user was typing.
+												onMouseDown={(e) => e.preventDefault()}
 												onClick={() => insertIntoSummary(placeholder)}
 												className="px-2 py-0.5 rounded-full border bg-background hover:bg-muted text-[11px] font-mono"
 												title={`Insert ${placeholder}`}

--- a/apps/client/src/components/shared/FormattedText.tsx
+++ b/apps/client/src/components/shared/FormattedText.tsx
@@ -59,13 +59,15 @@ interface FormattedTextProps {
 // subset of HTML (bold, links, lists, ...) is rendered after sanitization.
 export const FormattedText = ({ text, className }: FormattedTextProps) => {
 	if (!containsHtml(text)) {
-		return <div className={cn('whitespace-pre-line break-words', className)}>{text}</div>;
+		// overflow-wrap:anywhere (not just break-words) so a single very long token with no
+		// spaces — e.g. an asset id — wraps instead of overflowing the panel width.
+		return <div className={cn('whitespace-pre-line [overflow-wrap:anywhere]', className)}>{text}</div>;
 	}
 	const safe = DOMPurify.sanitize(text, SANITIZE_CONFIG);
 	return (
 		<div
 			className={cn(
-				'whitespace-pre-line break-words',
+				'whitespace-pre-line [overflow-wrap:anywhere]',
 				'[&_a]:text-primary [&_a]:underline [&_ul]:list-disc [&_ol]:list-decimal [&_ul]:pl-5 [&_ol]:pl-5',
 				'[&_code]:bg-muted [&_code]:px-1 [&_code]:rounded [&_code]:font-mono [&_code]:text-xs',
 				'[&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_h4]:text-sm [&_h4]:font-semibold',


### PR DESCRIPTION
## Summary

A set of small UI fixes for the alerts table and the alert details sidebar.

### 1. Pinned Dismiss/Archive footer
The primary alert actions (Dismiss/Undismiss + Archive, or Delete for archived alerts) move out of the scrollable body into a **fixed one-row footer** at the bottom of the details panel, so they're always reachable without scrolling. Applied to the alerts-page panel, the TV-mode/modal container, and the drawer. The custom "Actions" section stays in the body.

### 2. Capped, scrollable summary
A long summary used to push every section below it (comments, history, labels, actions) out of view. The summary block is now capped at **30% of the sidebar height** and scrolls internally.

### 3. Wrap long unbroken tokens
A summary containing a very long space-less string (e.g. an asset id like `asset_id-1231232_1335142-...`) overflowed the panel width, because `overflow-wrap: break-word` doesn't reduce an element's min-content size. Switched `FormattedText` to `overflow-wrap: anywhere`, which forces the token to wrap. Fixes summaries, comments, and enrichment output alike.

### 4. Enrichment: insert placeholder on click
In the enrichment form, clicking an "Available labels" chip now **inserts** the `{{label.key}}` placeholder into the summary template at the caret (replacing any selection) instead of copying it to the clipboard. Helper text updated accordingly.

### 5. Align group-header counts
When grouping the alerts table, the per-group count badge trailed the label, so its position drifted with label length (`Info` vs `Critical`). The count now sits in a **fixed-width slot right after the chevron**, so the numbers line up vertically. Applied to both the regular and sticky group headers.

## Verification

Each change verified in a headless browser against the playground build: footer buttons on one row pinned to the bottom; summary capped at 285px/30vh and scrollable; long `_`/`-` token wrapping within the panel; enrichment chips inserting at the caret; group counts aligned at a single x-position. Typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent footer for alert actions, keeping controls visible while viewing alert details.
  * Enrichment summaries now support inserting label placeholders directly at your cursor position.

* **UI Improvements**
  * Alert details actions are now separated from the main scroll area in drawers/panels for clearer navigation.
  * Alert summary text and long values wrap more reliably to prevent layout overflow.
  * Alert table group headers now present the count badge in a more consistently aligned position.

* **Bug Fixes**
  * Improved readability for very long, space-less text strings within panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->