### PR TITLE
chore: drop the silences backward-compat shims

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -22,7 +22,7 @@ import {
 import { isPlaygroundMode } from '@/lib/playground';
 import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import ForgotPassword from './pages/ForgotPassword';
 import ResetPasswordByEmail from './pages/ResetPasswordByEmail';
 
@@ -38,13 +38,6 @@ const UnsavedChangesDialogWrapper = () => {
 };
 
 const queryClient = new QueryClient();
-
-// Old bookmarks: the page used to live at /silences. Preserves the query string
-// (e.g. ?playground) across the redirect.
-const SilencesRedirect: React.FC = () => {
-	const location = useLocation();
-	return <Navigate to={{ pathname: '/mute-policies', search: location.search }} replace />;
-};
 
 const App: React.FC = () => {
 	// The playground/demo defaults to light mode for a consistent first impression.
@@ -79,7 +72,6 @@ const App: React.FC = () => {
 										<Route path="/register" element={<Register />} />
 										<Route path="/alerts" element={<Alerts />} />
 										<Route path="/mute-policies" element={<MutePolicies />} />
-										<Route path="/silences" element={<SilencesRedirect />} />
 										<Route path="/actions" element={<Actions />} />
 										<Route path="/enrichments" element={<Enrichments />} />
 										<Route path="/alerts/tv-mode" element={<AlertsTVMode />} />

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -86,11 +86,7 @@ export const AlertsFilterPanel = ({
 		const passesOtherFilters = (alert: Alert, exceptField: string): boolean => {
 			for (const [field, values] of Object.entries(filters)) {
 				if (!values || values.length === 0 || field === exceptField) continue;
-				const fieldValue = getFieldValue(alert, field);
-				// Saved dashboards from before the rename may still filter on 'Silenced';
-				// keep facet counts consistent with useAlertsFiltering's main list.
-				if (field === 'status' && values.includes('Silenced') && fieldValue === 'Muted') continue;
-				if (!values.includes(fieldValue)) return false;
+				if (!values.includes(getFieldValue(alert, field))) return false;
 			}
 			return true;
 		};

--- a/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.utils.ts
@@ -60,10 +60,6 @@ export const filterAlertsByFilters = (
 			switch (field) {
 				case 'status':
 					fieldValue = alert.isDismissed ? 'Dismissed' : alert.isMuted ? 'Muted' : alert.status;
-					// Saved dashboards from before the rename may still filter on 'Silenced'.
-					if (values.includes('Silenced') && fieldValue === 'Muted') {
-						continue;
-					}
 					break;
 				case 'type':
 					fieldValue = alert.type || 'Custom';

--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -66,18 +66,13 @@ export const useAlertsFiltering = (
 
 				let fieldValue: string;
 				switch (field) {
-					case 'status': {
+					case 'status':
 						fieldValue = alert.isDismissed
 							? 'Dismissed'
 							: alert.isMuted
 								? 'Muted'
 								: capitalizeFirst(alert.status);
-						// Saved dashboards from before the rename may still filter on 'Silenced'.
-						if (values.includes('Silenced') && fieldValue === 'Muted') {
-							continue;
-						}
 						break;
-					}
 					case 'severity':
 						fieldValue = SEVERITY_LABELS[getAlertSeverity(alert)];
 						break;

--- a/apps/server/src/api/v1/v1.ts
+++ b/apps/server/src/api/v1/v1.ts
@@ -77,9 +77,6 @@ export default function createV1Router(
 	router.use('/custom-fields', createCustomFieldsRouter(customFieldsController));
 	router.use('/custom-actions', createCustomActionsRouter(customActionsController));
 	router.use('/mute-policies', createMutePolicyRouter(mutePolicyController));
-	// Deprecated alias: the feature used to be called "silences"; kept for a release so
-	// existing API consumers don't break.
-	router.use('/silences', createMutePolicyRouter(mutePolicyController));
 	router.use('/enrichments', createEnrichmentRouter(enrichmentController));
 	router.use('/actions', createActionRouter(actionController));
 	// All other /users endpoints (except /register and /login) are protected


### PR DESCRIPTION
Follow-up to #666 (Silences → Mute Policies rename). Removes the transitional `silence` compatibility that was kept for one release:

- **`/silences` client redirect** and the `SilencesRedirect` component (+ now-unused router imports).
- **`/silences` API alias** route.
- **Legacy `'Silenced'` status-filter shims** in the alerts list (`useAlertsFiltering`), the filter-panel facet counts (`AlertsFilterPanel`), and TV mode (`AlertsTVMode.utils`).

## Behavior after this

- Old `/silences` links and API calls now 404 (the feature lives at `/mute-policies` and `/api/v1/mute-policies`).
- Dashboards saved with a `status: Silenced` filter no longer match muted alerts — re-save the dashboard to pick up `Muted`.

## Intentionally kept

- The one-time **DB migration** `alert_silences → alert_mute_policies` (in `mutePolicyRepository`) stays, so existing deployments don't lose their policies on upgrade — this is the only remaining reference to the old name, and it's unavoidable since it has to find the old table.
- `grafana-client`'s `silencedBy` is **Grafana's own webhook field**, not our feature — unchanged.

Client + server typecheck clean; server tests 112 / client tests 37 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert status filters now match values more consistently, improving filter results and facet counts.
  * Removed legacy handling for older “Silenced” selections, so alert filtering behavior is now more predictable.
  * The old `/silences` path is no longer available; navigation now uses the current mute-policies route directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->