### PR TITLE
refactor: rename the archived-alert store to resolved

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertActionsSection/AlertActionsSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertActionsSection/AlertActionsSection.tsx
@@ -7,7 +7,7 @@ interface AlertActionsSectionProps {
 }
 
 // The custom-actions section of the details body. The alert's primary buttons
-// (dismiss/archive/delete) live in AlertFooterActions, pinned at the panel's bottom.
+// (dismiss/resolve/delete) live in AlertFooterActions, pinned at the panel's bottom.
 export const AlertActionsSection = ({ alert }: AlertActionsSectionProps) => {
 	return (
 		<>

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
@@ -23,7 +23,7 @@ interface AlertDetailsBodyProps {
 
 // The Details-tab body, shared by all alert-detail containers. Identity stays pinned at the
 // top; everything else lives in collapsible sections (summary, latest comment, history,
-// labels, links) followed by the custom-actions section. The dismiss/archive buttons are
+// labels, links) followed by the custom-actions section. The dismiss/resolve buttons are
 // NOT part of the body — containers pin them at the bottom via AlertFooterActions.
 export const AlertDetailsBody = ({ alert, historyData, timeRange, onViewAllComments }: AlertDetailsBodyProps) => {
 	return (

--- a/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/AlertFooterActions.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/AlertFooterActions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Check, RotateCcw, Trash2 } from 'lucide-react';
+import { Check, CheckCircle2, RotateCcw, Trash2 } from 'lucide-react';
 
 interface AlertFooterActionsProps {
 	alert: Alert;
@@ -36,8 +36,8 @@ export const AlertFooterActions = ({ alert, isActive, onDismiss, onUndismiss, on
 				</Button>
 			)}
 			<Button variant="outline" size="sm" className="gap-2" onClick={() => onDelete?.(alert.id)}>
-				<Archive className="h-3 w-3" />
-				Archive
+				<CheckCircle2 className="h-3 w-3" />
+				Resolve
 			</Button>
 		</div>
 	);

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -227,7 +227,16 @@ const Alerts = () => {
 	};
 
 	const handleDeleteResolvedAlert = async (alertId: string) => {
-		await deleteResolvedAlertMutation.mutateAsync(alertId);
+		try {
+			await deleteResolvedAlertMutation.mutateAsync(alertId);
+			toast({ title: 'Alert deleted', description: 'The alert was permanently removed.' });
+		} catch (err) {
+			toast({
+				title: 'Failed to delete alert',
+				description: err instanceof Error ? err.message : 'Unknown error',
+				variant: 'destructive',
+			});
+		}
 	};
 
 	// In the combined "All" view, route delete to the right mutation based on the alert's list.

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -3,7 +3,7 @@ import { FilterSidebar } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useDashboard } from '@/context/DashboardContext';
-import { useAlerts, useArchivedAlerts, useDeleteArchivedAlert, useMarkAlertRead } from '@/hooks/queries/alerts';
+import { useAlerts, useResolvedAlerts, useDeleteResolvedAlert, useMarkAlertRead } from '@/hooks/queries/alerts';
 import {
 	useCreateDashboard,
 	useDeleteDashboard,
@@ -15,7 +15,7 @@ import { useServices } from '@/hooks/queries/services';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Bell, Columns2, LayoutList, Palette } from 'lucide-react';
+import { Bell, CheckCircle2, Columns2, LayoutList, Palette } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertsFilterPanel } from '.';
@@ -35,7 +35,7 @@ import {
 	useAlertsFiltering,
 	useAlertsRefresh,
 	useAlertTagKeys,
-	useArchivedTabStatusFilterReset,
+	useResolvedTabStatusFilterReset,
 	useColumnManagement,
 	useSeverityColors,
 } from './hooks';
@@ -44,7 +44,7 @@ const Alerts = () => {
 	const navigate = useNavigate();
 	const { toast } = useToast();
 	const { data: alerts = [], isLoading, refetch } = useAlerts();
-	const { data: archivedAlerts = [], isLoading: isLoadingArchived, refetch: refetchArchived } = useArchivedAlerts();
+	const { data: resolvedAlerts = [], isLoading: isLoadingResolved, refetch: refetchResolved } = useResolvedAlerts();
 	const { data: services = [] } = useServices();
 	const { data: dashboards = [] } = useGetDashboards();
 	const createDashboardMutation = useCreateDashboard();
@@ -71,11 +71,11 @@ const Alerts = () => {
 	const [splitByAssignment, setSplitByAssignment] = useState(false);
 	const { severityColors, toggleSeverityColors } = useSeverityColors();
 
-	const allAlerts = useMemo(() => [...alerts, ...archivedAlerts], [alerts, archivedAlerts]);
+	const allAlerts = useMemo(() => [...alerts, ...resolvedAlerts], [alerts, resolvedAlerts]);
 	const tagKeys = useAlertTagKeys(allAlerts);
 
 	const currentAlertData =
-		activeTab === AlertTab.Active ? alerts : activeTab === AlertTab.Archived ? archivedAlerts : allAlerts;
+		activeTab === AlertTab.Active ? alerts : activeTab === AlertTab.Resolved ? resolvedAlerts : allAlerts;
 	const syncedSelectedAlert = useMemo(() => {
 		if (!selectedAlert) return null;
 		const updatedAlert = currentAlertData.find((alert) => alert.id === selectedAlert.id);
@@ -93,28 +93,28 @@ const Alerts = () => {
 	});
 
 	const {
-		lastRefresh: lastRefreshArchived,
-		isRefreshing: isRefreshingArchived,
-		handleManualRefresh: handleManualRefreshArchived,
-	} = useAlertsRefresh(refetchArchived, {
-		shouldPause: shouldPauseRefresh || (activeTab !== AlertTab.Archived && activeTab !== AlertTab.All),
+		lastRefresh: lastRefreshResolved,
+		isRefreshing: isRefreshingResolved,
+		handleManualRefresh: handleManualRefreshResolved,
+	} = useAlertsRefresh(refetchResolved, {
+		shouldPause: shouldPauseRefresh || (activeTab !== AlertTab.Resolved && activeTab !== AlertTab.All),
 	});
 
-	const lastRefresh = activeTab === AlertTab.Archived ? lastRefreshArchived : lastRefreshActive;
+	const lastRefresh = activeTab === AlertTab.Resolved ? lastRefreshResolved : lastRefreshActive;
 	const isRefreshing =
 		activeTab === AlertTab.Active
 			? isRefreshingActive
-			: activeTab === AlertTab.Archived
-				? isRefreshingArchived
-				: isRefreshingActive || isRefreshingArchived;
+			: activeTab === AlertTab.Resolved
+				? isRefreshingResolved
+				: isRefreshingActive || isRefreshingResolved;
 	const handleManualRefresh =
 		activeTab === AlertTab.Active
 			? handleManualRefreshActive
-			: activeTab === AlertTab.Archived
-				? handleManualRefreshArchived
+			: activeTab === AlertTab.Resolved
+				? handleManualRefreshResolved
 				: () => {
 						handleManualRefreshActive();
-						handleManualRefreshArchived();
+						handleManualRefreshResolved();
 					};
 
 	const { visibleColumns, columnOrder, handleColumnToggle, allColumnLabels, enabledTagKeys } = useColumnManagement({
@@ -169,7 +169,7 @@ const Alerts = () => {
 		updateDashboardField('filters', newFilters);
 	};
 
-	useArchivedTabStatusFilterReset({
+	useResolvedTabStatusFilterReset({
 		activeTab,
 		filters: dashboardState.filters,
 		onFilterChange: handleFilterChange,
@@ -179,7 +179,7 @@ const Alerts = () => {
 		filters: dashboardState.filters,
 		timeRange: dashboardState.timeRange,
 	});
-	const filteredArchivedAlerts = useAlertsFiltering(archivedAlerts, {
+	const filteredResolvedAlerts = useAlertsFiltering(resolvedAlerts, {
 		filters: dashboardState.filters,
 		timeRange: dashboardState.timeRange,
 	});
@@ -188,12 +188,12 @@ const Alerts = () => {
 	const unassignedAlerts = useMemo(() => filteredAlerts.filter((a) => !a.ownerId), [filteredAlerts]);
 	const assignedAlerts = useMemo(() => filteredAlerts.filter((a) => !!a.ownerId), [filteredAlerts]);
 
-	// Combined "All" view: active alerts followed by archived ones tagged so each row can route
-	// its own actions. archivedIds lets shared callbacks tell which list an alert belongs to.
-	const archivedIds = useMemo(() => new Set(archivedAlerts.map((a) => a.id)), [archivedAlerts]);
+	// Combined "All" view: active alerts followed by resolved ones tagged so each row can route
+	// its own actions. resolvedIds lets shared callbacks tell which list an alert belongs to.
+	const resolvedIds = useMemo(() => new Set(resolvedAlerts.map((a) => a.id)), [resolvedAlerts]);
 	const filteredAllAlerts = useMemo(
-		() => [...filteredAlerts, ...filteredArchivedAlerts.map((a) => ({ ...a, isArchived: true }))],
-		[filteredAlerts, filteredArchivedAlerts]
+		() => [...filteredAlerts, ...filteredResolvedAlerts.map((a) => ({ ...a, isResolved: true }))],
+		[filteredAlerts, filteredResolvedAlerts]
 	);
 
 	const {
@@ -202,10 +202,10 @@ const Alerts = () => {
 		handleDeleteAlert,
 		handleDismissAll,
 		handleAssignOwnerAll,
-		handleArchiveAll,
+		handleResolveAll,
 		handleDeleteForeverAll,
 	} = useAlertActions();
-	const deleteArchivedAlertMutation = useDeleteArchivedAlert();
+	const deleteResolvedAlertMutation = useDeleteResolvedAlert();
 	const markAlertReadMutation = useMarkAlertRead();
 
 	const handleDismissAllSelected = async () => {
@@ -216,9 +216,9 @@ const Alerts = () => {
 		await handleAssignOwnerAll(selectedAlerts, ownerId, () => setSelectedAlerts([]));
 	};
 
-	const handleArchiveAllSelected = async () => {
+	const handleResolveAllSelected = async () => {
 		setSelectedAlert(null);
-		await handleArchiveAll(selectedAlerts, () => setSelectedAlerts([]));
+		await handleResolveAll(selectedAlerts, () => setSelectedAlerts([]));
 	};
 
 	const handleDeleteAllSelected = async () => {
@@ -226,14 +226,14 @@ const Alerts = () => {
 		await handleDeleteForeverAll(selectedAlerts, () => setSelectedAlerts([]));
 	};
 
-	const handleDeleteArchivedAlert = async (alertId: string) => {
-		await deleteArchivedAlertMutation.mutateAsync(alertId);
+	const handleDeleteResolvedAlert = async (alertId: string) => {
+		await deleteResolvedAlertMutation.mutateAsync(alertId);
 	};
 
 	// In the combined "All" view, route delete to the right mutation based on the alert's list.
 	const handleDeleteAnyAlert = (alertId: string) => {
-		if (archivedIds.has(alertId)) {
-			void handleDeleteArchivedAlert(alertId);
+		if (resolvedIds.has(alertId)) {
+			void handleDeleteResolvedAlert(alertId);
 		} else {
 			void handleDeleteAlert(alertId);
 		}
@@ -325,9 +325,9 @@ const Alerts = () => {
 
 	const handleAlertClick = (alert: Alert) => {
 		// Opening an unread (active) alert marks it as read, un-bolding its row. The transient
-		// isArchived flag (set on archived rows in the All view) is the guard here — an id-based
-		// check would wrongly skip active alerts that were archived once and re-fired.
-		if (alert.isRead === false && !alert.isArchived) {
+		// isResolved flag (set on resolved rows in the All view) is the guard here — an id-based
+		// check would wrongly skip active alerts that were resolved once and re-fired.
+		if (alert.isRead === false && !alert.isResolved) {
 			markAlertReadMutation.mutate(alert.id);
 		}
 		setSelectedAlert((prev) => (prev?.id === alert.id ? null : alert));
@@ -346,7 +346,7 @@ const Alerts = () => {
 						onFilterChange={handleFilterChange}
 						collapsed={filterPanelCollapsed}
 						tagKeys={tagKeys}
-						isArchived={activeTab === AlertTab.Archived}
+						isResolved={activeTab === AlertTab.Resolved}
 					/>
 				</FilterSidebar>
 
@@ -398,13 +398,13 @@ const Alerts = () => {
 										<span>Active</span>
 									</ToggleGroupItem>
 									<ToggleGroupItem
-										value={AlertTab.Archived}
-										aria-label="Archived alerts"
+										value={AlertTab.Resolved}
+										aria-label="Resolved alerts"
 										size="sm"
 										className="gap-1.5 bg-transparent text-foreground hover:bg-muted hover:text-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground [&_svg]:text-current data-[state=on]:[&_svg]:text-primary-foreground"
 									>
-										<Archive className="h-4 w-4" />
-										<span>Archived</span>
+										<CheckCircle2 className="h-4 w-4" />
+										<span>Resolved</span>
 									</ToggleGroupItem>
 									<ToggleGroupItem
 										value={AlertTab.All}
@@ -421,8 +421,8 @@ const Alerts = () => {
 										const count =
 											activeTab === AlertTab.Active
 												? filteredAlerts.length
-												: activeTab === AlertTab.Archived
-													? filteredArchivedAlerts.length
+												: activeTab === AlertTab.Resolved
+													? filteredResolvedAlerts.length
 													: filteredAllAlerts.length;
 										return `${count} Alert${count !== 1 ? 's' : ''}`;
 									})()}
@@ -511,30 +511,30 @@ const Alerts = () => {
 										onClearSelection={() => setSelectedAlerts([])}
 										onDismissAll={handleDismissAllSelected}
 										onAssignOwnerAll={handleAssignOwnerAllSelected}
-										onArchiveAll={handleArchiveAllSelected}
+										onResolveAll={handleResolveAllSelected}
 										onDeleteAll={handleDeleteAllSelected}
 									/>
 								</div>
 							</>
-						) : activeTab === AlertTab.Archived ? (
+						) : activeTab === AlertTab.Resolved ? (
 							<div
 								className={cn(
 									'flex-1 min-h-0',
-									archivedAlerts.length === 0 &&
-										!isLoadingArchived &&
+									resolvedAlerts.length === 0 &&
+										!isLoadingResolved &&
 										'flex items-center justify-center'
 								)}
 							>
 								<AlertsTable
-									alerts={filteredArchivedAlerts}
+									alerts={filteredResolvedAlerts}
 									services={services}
 									onDismissAlert={undefined}
 									onUndismissAlert={undefined}
-									onDeleteAlert={handleDeleteArchivedAlert}
+									onDeleteAlert={handleDeleteResolvedAlert}
 									onSelectAlerts={undefined}
 									selectedAlerts={[]}
-									isLoading={isLoadingArchived}
-									isArchived={true}
+									isLoading={isLoadingResolved}
+									isResolved={true}
 									visibleColumns={visibleColumns}
 									columnOrder={columnOrder}
 									onAlertClick={handleAlertClick}
@@ -558,7 +558,7 @@ const Alerts = () => {
 									'flex-1 min-h-0',
 									filteredAllAlerts.length === 0 &&
 										!isLoading &&
-										!isLoadingArchived &&
+										!isLoadingResolved &&
 										'flex items-center justify-center'
 								)}
 							>
@@ -570,7 +570,7 @@ const Alerts = () => {
 									onDeleteAlert={handleDeleteAnyAlert}
 									onSelectAlerts={undefined}
 									selectedAlerts={[]}
-									isLoading={isLoading || isLoadingArchived}
+									isLoading={isLoading || isLoadingResolved}
 									visibleColumns={visibleColumns}
 									columnOrder={columnOrder}
 									onAlertClick={handleAlertClick}
@@ -593,18 +593,18 @@ const Alerts = () => {
 
 					{syncedSelectedAlert &&
 						(() => {
-							const selectedIsArchived =
-								activeTab === AlertTab.Archived ||
-								(activeTab === AlertTab.All && archivedIds.has(syncedSelectedAlert.id));
+							const selectedIsResolved =
+								activeTab === AlertTab.Resolved ||
+								(activeTab === AlertTab.All && resolvedIds.has(syncedSelectedAlert.id));
 							return (
 								<AlertDetailsPanel
 									alert={syncedSelectedAlert}
-									isActive={!selectedIsArchived}
+									isActive={!selectedIsResolved}
 									timeRange={dashboardState.timeRange}
 									onClose={() => setSelectedAlert(null)}
 									onDismiss={handleDismissAlert}
 									onUndismiss={handleUndismissAlert}
-									onDelete={selectedIsArchived ? handleDeleteArchivedAlert : handleDeleteAlert}
+									onDelete={selectedIsResolved ? handleDeleteResolvedAlert : handleDeleteAlert}
 								/>
 							);
 						})()}

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -13,7 +13,7 @@ interface AlertsFilterPanelProps {
 	collapsed?: boolean;
 	className?: string;
 	tagKeys?: TagKeyInfo[];
-	isArchived?: boolean;
+	isResolved?: boolean;
 }
 
 const BASE_FILTER_FIELDS = ['status', 'severity', 'type', 'alertName', 'owner'];
@@ -33,7 +33,7 @@ export const AlertsFilterPanel = ({
 	collapsed = false,
 	className,
 	tagKeys = [],
-	isArchived = false,
+	isResolved = false,
 }: AlertsFilterPanelProps) => {
 	const { data: users = [] } = useUsers();
 
@@ -50,13 +50,13 @@ export const AlertsFilterPanel = ({
 			tagKeyLabels[getTagKeyColumnId(tk.key)] = tk.label;
 		});
 
-		const baseFields = isArchived ? BASE_FILTER_FIELDS.filter((f) => f !== 'status') : BASE_FILTER_FIELDS;
+		const baseFields = isResolved ? BASE_FILTER_FIELDS.filter((f) => f !== 'status') : BASE_FILTER_FIELDS;
 
 		return {
 			fields: [...baseFields, ...tagKeyFields],
 			fieldLabels: { ...BASE_FIELD_LABELS, ...tagKeyLabels },
 		};
-	}, [tagKeys, isArchived]);
+	}, [tagKeys, isResolved]);
 
 	const facets: FilterFacets = useMemo(() => {
 		// The value an alert presents for a given filter field, matching useAlertsFiltering's logic.

--- a/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { useUsers } from '@/hooks/queries/users';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Trash2 } from 'lucide-react';
+import { CheckCircle2, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 export interface AlertsSelectionBarProps {
@@ -20,7 +20,7 @@ export interface AlertsSelectionBarProps {
 	onClearSelection: () => void;
 	onDismissAll: () => void;
 	onAssignOwnerAll?: (ownerId: string | null) => void;
-	onArchiveAll?: () => void;
+	onResolveAll?: () => void;
 	onDeleteAll?: () => void;
 }
 
@@ -29,7 +29,7 @@ export const AlertsSelectionBar = ({
 	onClearSelection,
 	onDismissAll,
 	onAssignOwnerAll,
-	onArchiveAll,
+	onResolveAll,
 	onDeleteAll,
 }: AlertsSelectionBarProps) => {
 	const { data: users = [] } = useUsers();
@@ -67,10 +67,10 @@ export const AlertsSelectionBar = ({
 						Dismiss all
 					</Button>
 				)}
-				{onArchiveAll && (
-					<Button variant="outline" size="sm" onClick={onArchiveAll} className="gap-1.5">
-						<Archive className="h-3.5 w-3.5" />
-						Archive
+				{onResolveAll && (
+					<Button variant="outline" size="sm" onClick={onResolveAll} className="gap-1.5">
+						<CheckCircle2 className="h-3.5 w-3.5" />
+						Resolve
 					</Button>
 				)}
 				{onDeleteAll && (
@@ -97,7 +97,7 @@ export const AlertsSelectionBar = ({
 						</AlertDialogTitle>
 						<AlertDialogDescription>
 							This permanently deletes the selected alert{selectedAlerts.length !== 1 ? 's' : ''} — they
-							will not appear in the archive. This cannot be undone.
+							will move to the resolved list. This cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
@@ -97,7 +97,7 @@ export const AlertsSelectionBar = ({
 						</AlertDialogTitle>
 						<AlertDialogDescription>
 							This permanently deletes the selected alert{selectedAlerts.length !== 1 ? 's' : ''} — they
-							will move to the resolved list. This cannot be undone.
+							will not appear in the resolved list. This cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -28,7 +28,7 @@ export interface AlertRowProps {
 	onUndismissAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
 	onSelectAlerts?: (alerts: Alert[]) => void;
-	isArchived?: boolean;
+	isResolved?: boolean;
 	isDragging?: boolean;
 	// Tint the whole row by alert severity (the table's "severity colors" toggle).
 	severityColors?: boolean;
@@ -48,7 +48,7 @@ export const AlertRow = ({
 	onUndismissAlert,
 	onDeleteAlert,
 	onSelectAlerts,
-	isArchived = false,
+	isResolved = false,
 	isDragging = false,
 	severityColors = false,
 	onDragStart,
@@ -137,7 +137,7 @@ export const AlertRow = ({
 								key={column}
 								alert={alert}
 								className={COLUMN_WIDTHS.owner}
-								isArchived={isArchived}
+								isResolved={isResolved}
 							/>
 						);
 					case 'startsAt':

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertOwnerColumn/AlertOwnerColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertOwnerColumn/AlertOwnerColumn.tsx
@@ -1,6 +1,6 @@
 import { PersonPicker } from '@/components/PersonPicker';
 import { TableCell } from '@/components/ui/table';
-import { useSetAlertOwner, useSetArchivedAlertOwner } from '@/hooks/queries/alerts';
+import { useSetAlertOwner, useSetResolvedAlertOwner } from '@/hooks/queries/alerts';
 import { useUsers } from '@/hooks/queries/users';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
@@ -8,17 +8,17 @@ import { Alert } from '@OpsiMate/shared';
 export interface AlertOwnerColumnProps {
 	alert: Alert;
 	className?: string;
-	isArchived?: boolean;
+	isResolved?: boolean;
 }
 
-export const AlertOwnerColumn = ({ alert, className, isArchived = false }: AlertOwnerColumnProps) => {
+export const AlertOwnerColumn = ({ alert, className, isResolved = false }: AlertOwnerColumnProps) => {
 	const { data: users = [] } = useUsers();
 	const setOwnerMutation = useSetAlertOwner();
-	const setArchivedOwnerMutation = useSetArchivedAlertOwner();
+	const setResolvedOwnerMutation = useSetResolvedAlertOwner();
 
 	// Prefer the per-row transient flag (set in the combined "All" view) over the table-level prop.
-	const rowIsArchived = isArchived || Boolean(alert.isArchived);
-	const mutation = rowIsArchived ? setArchivedOwnerMutation : setOwnerMutation;
+	const rowIsResolved = isResolved || Boolean(alert.isResolved);
+	const mutation = rowIsResolved ? setResolvedOwnerMutation : setOwnerMutation;
 
 	const handleOwnerChange = (userId: string | null) => {
 		mutation.mutate({ alertId: alert.id, ownerId: userId });

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
@@ -7,7 +7,7 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Alert } from '@OpsiMate/shared';
-import { Archive, Book, Check, ExternalLink, MoreVertical, RotateCcw, Trash2, X } from 'lucide-react';
+import { Book, Check, CheckCircle2, ExternalLink, MoreVertical, RotateCcw, Trash2, X } from 'lucide-react';
 
 export interface RowActionsProps {
 	alert: Alert;
@@ -18,13 +18,13 @@ export interface RowActionsProps {
 
 export const RowActions = ({ alert, onDismissAlert, onUndismissAlert, onDeleteAlert }: RowActionsProps) => {
 	const { alertUrl, runbookUrl, isDismissed } = alert;
-	// In the combined "All" view a row carries a transient isArchived flag so it can present
-	// archived behaviour (permanent delete, no dismiss/archive) even though the table-level
-	// callbacks are shared across active and archived rows.
-	const isArchivedAlert = Boolean(alert.isArchived);
-	const isActive = !isArchivedAlert && Boolean(onDismissAlert);
+	// In the combined "All" view a row carries a transient isResolved flag so it can present
+	// resolved behaviour (permanent delete, no dismiss/resolve) even though the table-level
+	// callbacks are shared across active and resolved rows.
+	const isResolvedAlert = Boolean(alert.isResolved);
+	const isActive = !isResolvedAlert && Boolean(onDismissAlert);
 	const canToggle =
-		!isArchivedAlert && ((!isDismissed && Boolean(onDismissAlert)) || (isDismissed && Boolean(onUndismissAlert)));
+		!isResolvedAlert && ((!isDismissed && Boolean(onDismissAlert)) || (isDismissed && Boolean(onUndismissAlert)));
 	const hasActions = Boolean(alertUrl || runbookUrl || onDeleteAlert);
 
 	const handleToggle = (event: React.MouseEvent) => {
@@ -91,8 +91,8 @@ export const RowActions = ({ alert, onDismissAlert, onUndismissAlert, onDeleteAl
 							>
 								{isActive ? (
 									<>
-										<Archive className="mr-2 h-3 w-3" />
-										Archive
+										<CheckCircle2 className="mr-2 h-3 w-3" />
+										Resolve
 									</>
 								) : (
 									<>

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -57,7 +57,7 @@ export const AlertsTable = ({
 	onSearchTermChange,
 	timeRange,
 	onTimeRangeChange,
-	isArchived = false,
+	isResolved = false,
 	renderToolbar = true,
 	severityColors = false,
 	heading,
@@ -265,7 +265,7 @@ export const AlertsTable = ({
 									onDeleteAlert={onDeleteAlert}
 									onSelectAlerts={onSelectAlerts}
 									columnLabels={allColumnLabels}
-									isArchived={isArchived}
+									isResolved={isResolved}
 									severityColors={severityColors}
 									isDragging={isDragging}
 									onDragStart={handleDragStart}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -5,7 +5,7 @@ import { ReactNode } from 'react';
 
 export enum AlertTab {
 	Active = 'active',
-	Archived = 'archived',
+	Resolved = 'resolved',
 	All = 'all',
 }
 
@@ -22,7 +22,7 @@ export interface AlertsTableProps {
 	onSelectAlerts?: (alerts: Alert[]) => void;
 	selectedAlerts?: Alert[];
 	isLoading?: boolean;
-	isArchived?: boolean;
+	isResolved?: boolean;
 	className?: string;
 	visibleColumns?: string[];
 	columnOrder?: string[];

--- a/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
@@ -20,7 +20,7 @@ interface VirtualizedAlertListProps {
 	onDeleteAlert?: (alertId: string) => void;
 	onSelectAlerts?: (alerts: Alert[]) => void;
 	columnLabels?: Record<string, string>;
-	isArchived?: boolean;
+	isResolved?: boolean;
 	// Tint rows by alert severity (the "severity colors" toggle).
 	severityColors?: boolean;
 	isDragging?: boolean;
@@ -43,7 +43,7 @@ export const VirtualizedAlertList = ({
 	onDeleteAlert,
 	onSelectAlerts,
 	columnLabels,
-	isArchived = false,
+	isResolved = false,
 	severityColors = false,
 	isDragging = false,
 	onDragStart,
@@ -120,7 +120,7 @@ export const VirtualizedAlertList = ({
 									onUndismissAlert={onUndismissAlert}
 									onDeleteAlert={onDeleteAlert}
 									onSelectAlerts={onSelectAlerts}
-									isArchived={isArchived}
+									isResolved={isResolved}
 									severityColors={severityColors}
 									isDragging={isDragging}
 									onDragStart={onDragStart}

--- a/apps/client/src/components/Alerts/hooks/index.ts
+++ b/apps/client/src/components/Alerts/hooks/index.ts
@@ -2,6 +2,6 @@ export { useAlertActions } from './useAlertActions';
 export { useAlertsFiltering } from './useAlertsFiltering';
 export { useAlertsRefresh } from './useAlertsRefresh';
 export { useAlertTagKeys } from './useAlertTagKeys';
-export { useArchivedTabStatusFilterReset } from './useArchivedTabStatusFilterReset';
+export { useResolvedTabStatusFilterReset } from './useResolvedTabStatusFilterReset';
 export { useColumnManagement } from './useColumnManagement';
 export { useSeverityColors } from './useSeverityColors';

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -113,7 +113,7 @@ export const useAlertActions = () => {
 					}
 				: {
 						title: 'Alerts resolved',
-						description: `Moved ${successCount} alert${successCount !== 1 ? 's' : ''} to resolve`,
+						description: `Moved ${successCount} alert${successCount !== 1 ? 's' : ''} to Resolved`,
 					}
 		);
 		onComplete();

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -1,6 +1,6 @@
 import {
 	useDeleteAlert,
-	useDeleteArchivedAlert,
+	useDeleteResolvedAlert,
 	useDismissAlert,
 	useSetAlertOwner,
 	useUndismissAlert,
@@ -13,7 +13,7 @@ export const useAlertActions = () => {
 	const undismissAlertMutation = useUndismissAlert();
 	const deleteAlertMutation = useDeleteAlert();
 	const setAlertOwnerMutation = useSetAlertOwner();
-	const deleteArchivedAlertMutation = useDeleteArchivedAlert();
+	const deleteResolvedAlertMutation = useDeleteResolvedAlert();
 	const { toast } = useToast();
 
 	const handleDismissAlert = async (alertId: string) => {
@@ -97,8 +97,8 @@ export const useAlertActions = () => {
 		onComplete();
 	};
 
-	// Bulk-archive the selected active alerts (active "delete" == archive).
-	const handleArchiveAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
+	// Bulk-resolve the selected active alerts (active "delete" == resolve).
+	const handleResolveAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
 		const results = await Promise.allSettled(
 			selectedAlerts.map((alert) => deleteAlertMutation.mutateAsync(alert.id))
 		);
@@ -107,25 +107,25 @@ export const useAlertActions = () => {
 		toast(
 			failCount > 0
 				? {
-						title: 'Partial archive',
-						description: `Archived ${successCount} alerts, ${failCount} failed`,
+						title: 'Partial resolve',
+						description: `Resolved ${successCount} alerts, ${failCount} failed`,
 						variant: 'destructive',
 					}
 				: {
-						title: 'Alerts archived',
-						description: `Moved ${successCount} alert${successCount !== 1 ? 's' : ''} to archive`,
+						title: 'Alerts resolved',
+						description: `Moved ${successCount} alert${successCount !== 1 ? 's' : ''} to resolve`,
 					}
 		);
 		onComplete();
 	};
 
-	// Permanently delete the selected active alerts: archive each one, then remove it from
-	// the archive (permanent delete only exists for archived alerts).
+	// Permanently delete the selected active alerts: resolve each one, then remove it from
+	// the resolve (permanent delete only exists for resolved alerts).
 	const handleDeleteForeverAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
 		const results = await Promise.allSettled(
 			selectedAlerts.map(async (alert) => {
 				await deleteAlertMutation.mutateAsync(alert.id);
-				await deleteArchivedAlertMutation.mutateAsync(alert.id);
+				await deleteResolvedAlertMutation.mutateAsync(alert.id);
 			})
 		);
 		const successCount = results.filter((r) => r.status === 'fulfilled').length;
@@ -151,7 +151,7 @@ export const useAlertActions = () => {
 		handleDeleteAlert,
 		handleDismissAll,
 		handleAssignOwnerAll,
-		handleArchiveAll,
+		handleResolveAll,
 		handleDeleteForeverAll,
 	};
 };

--- a/apps/client/src/components/Alerts/hooks/useResolvedTabStatusFilterReset.ts
+++ b/apps/client/src/components/Alerts/hooks/useResolvedTabStatusFilterReset.ts
@@ -1,19 +1,19 @@
 import { useEffect } from 'react';
 import { AlertTab } from '../AlertsTable/AlertsTable.types';
 
-interface UseArchivedTabStatusFilterResetOptions {
+interface UseResolvedTabStatusFilterResetOptions {
 	activeTab: AlertTab;
 	filters: Record<string, string[]>;
 	onFilterChange: (filters: Record<string, string[]>) => void;
 }
 
-export const useArchivedTabStatusFilterReset = ({
+export const useResolvedTabStatusFilterReset = ({
 	activeTab,
 	filters,
 	onFilterChange,
-}: UseArchivedTabStatusFilterResetOptions) => {
+}: UseResolvedTabStatusFilterResetOptions) => {
 	useEffect(() => {
-		if (activeTab === AlertTab.Archived) {
+		if (activeTab === AlertTab.Resolved) {
 			if (filters.status && filters.status.length > 0) {
 				const updatedFilters = { ...filters };
 				delete updatedFilters.status;

--- a/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
+++ b/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from '@/components/ui/use-toast';
 import { API_HOST } from '@/lib/api';
-import { Archive, Check, Copy, ExternalLink, Send, Trash2 } from 'lucide-react';
+import { Check, CheckCircle2, Copy, ExternalLink, Send, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { SeveritySetupNote } from '../SeveritySetupNote';
 
@@ -16,13 +16,13 @@ export interface CustomAlertsSetupModalProps {
 export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetupModalProps) => {
 	const [copiedUrl, setCopiedUrl] = useState(false);
 	const [copiedPayload, setCopiedPayload] = useState(false);
-	const [copiedArchive, setCopiedArchive] = useState(false);
+	const [copiedResolve, setCopiedResolve] = useState(false);
 	const [copiedDelete, setCopiedDelete] = useState(false);
 	const { toast } = useToast();
 
 	const webhookUrl = `${API_HOST}/api/v1/alerts/custom?api_token={your_api_token}`;
-	const archiveUrl = `${API_HOST}/api/v1/alerts/{alertId}?api_token={your_api_token}`;
-	const deleteUrl = `${API_HOST}/api/v1/alerts/archived/{alertId}?api_token={your_api_token}`;
+	const resolveUrl = `${API_HOST}/api/v1/alerts/{alertId}?api_token={your_api_token}`;
+	const deleteUrl = `${API_HOST}/api/v1/alerts/resolved/{alertId}?api_token={your_api_token}`;
 
 	const examplePayload = `{
   "id": "unique-alert-id",
@@ -34,7 +34,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
   "runbookUrl": "https://docs.example.com/runbooks/cpu-alert"
 }`;
 
-	const handleCopy = async (text: string, type: 'url' | 'payload' | 'archive' | 'delete') => {
+	const handleCopy = async (text: string, type: 'url' | 'payload' | 'resolve' | 'delete') => {
 		try {
 			await navigator.clipboard.writeText(text);
 			if (type === 'url') {
@@ -43,9 +43,9 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 			} else if (type === 'payload') {
 				setCopiedPayload(true);
 				setTimeout(() => setCopiedPayload(false), 2000);
-			} else if (type === 'archive') {
-				setCopiedArchive(true);
-				setTimeout(() => setCopiedArchive(false), 2000);
+			} else if (type === 'resolve') {
+				setCopiedResolve(true);
+				setTimeout(() => setCopiedResolve(false), 2000);
 			} else {
 				setCopiedDelete(true);
 				setTimeout(() => setCopiedDelete(false), 2000);
@@ -79,9 +79,9 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 							<Send className="h-4 w-4" />
 							Create
 						</TabsTrigger>
-						<TabsTrigger value="archive" className="flex items-center gap-2">
-							<Archive className="h-4 w-4" />
-							Archive
+						<TabsTrigger value="resolve" className="flex items-center gap-2">
+							<CheckCircle2 className="h-4 w-4" />
+							Resolve
 						</TabsTrigger>
 						<TabsTrigger value="delete" className="flex items-center gap-2">
 							<Trash2 className="h-4 w-4" />
@@ -263,24 +263,24 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 						</div>
 					</TabsContent>
 
-					<TabsContent value="archive" className="space-y-6">
-						{/* Archive Alert Endpoint */}
+					<TabsContent value="resolve" className="space-y-6">
+						{/* Resolve Alert Endpoint */}
 						<div className="space-y-3">
 							<div>
-								<h3 className="text-lg font-semibold mb-2 text-foreground">1. Archive Endpoint</h3>
+								<h3 className="text-lg font-semibold mb-2 text-foreground">1. Resolve Endpoint</h3>
 								<p className="text-sm text-muted-foreground mb-3">
-									Send a DELETE request to archive an active alert. The alert will be moved to the
-									archived alerts table.
+									Send a DELETE request to resolve an active alert. The alert will be moved to the
+									resolved alerts table.
 								</p>
 							</div>
 							<div className="flex gap-2">
-								<Input value={archiveUrl} readOnly className="font-mono text-sm" />
+								<Input value={resolveUrl} readOnly className="font-mono text-sm" />
 								<Button
-									onClick={() => handleCopy(archiveUrl, 'archive')}
+									onClick={() => handleCopy(resolveUrl, 'resolve')}
 									variant="outline"
 									className="gap-2"
 								>
-									{copiedArchive ? (
+									{copiedResolve ? (
 										<>
 											<Check className="h-4 w-4" />
 											Copied
@@ -308,15 +308,15 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 							</div>
 						</div>
 
-						{/* What happens when archived */}
+						{/* What happens when resolved */}
 						<div className="space-y-3">
-							<h3 className="text-lg font-semibold text-foreground">2. What Happens When Archived</h3>
+							<h3 className="text-lg font-semibold text-foreground">2. What Happens When Resolved</h3>
 							<div className="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
 								<ul className="text-sm text-blue-900 dark:text-blue-100 space-y-2 list-disc list-inside">
 									<li>Alert is removed from the active alerts list</li>
-									<li>Alert is moved to the archived alerts table</li>
-									<li>Alert data is preserved and can be viewed in archives</li>
-									<li>Archived alerts can be permanently deleted later</li>
+									<li>Alert is moved to the resolved alerts table</li>
+									<li>Alert data is preserved and can be viewed in the Resolved tab</li>
+									<li>Resolved alerts can be permanently deleted later</li>
 								</ul>
 							</div>
 						</div>
@@ -338,7 +338,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 									1. Permanent Delete Endpoint
 								</h3>
 								<p className="text-sm text-muted-foreground mb-3">
-									Send a DELETE request to permanently remove an archived alert from the system.
+									Send a DELETE request to permanently remove a resolved alert from the system.
 								</p>
 							</div>
 							<div className="flex gap-2">
@@ -367,7 +367,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 									<code className="bg-amber-100 dark:bg-amber-900 px-1 py-0.5 rounded">
 										{'{alertId}'}
 									</code>{' '}
-									with the archived alert ID and{' '}
+									with the resolved alert ID and{' '}
 									<code className="bg-amber-100 dark:bg-amber-900 px-1 py-0.5 rounded">
 										{'{your_api_token}'}
 									</code>{' '}
@@ -383,7 +383,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 								Warning: Permanent Action
 							</h4>
 							<p className="text-sm text-red-900 dark:text-red-100">
-								Permanently deleting an archived alert <strong>cannot be undone</strong>. The alert will
+								Permanently deleting a resolved alert <strong>cannot be undone</strong>. The alert will
 								be completely removed from the system with no way to recover it.
 							</p>
 						</div>
@@ -393,9 +393,9 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 							<h3 className="text-lg font-semibold text-foreground">2. Prerequisites</h3>
 							<div className="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
 								<ul className="text-sm text-blue-900 dark:text-blue-100 space-y-2 list-disc list-inside">
-									<li>The alert must first be archived before it can be permanently deleted</li>
-									<li>Use the Archive endpoint to move active alerts to the archive first</li>
-									<li>Only archived alerts can be permanently deleted</li>
+									<li>The alert must first be resolved before it can be permanently deleted</li>
+									<li>Use the Resolve endpoint to move active alerts to the resolved list first</li>
+									<li>Only resolved alerts can be permanently deleted</li>
 								</ul>
 							</div>
 						</div>
@@ -404,7 +404,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 						<div className="space-y-3">
 							<h3 className="text-lg font-semibold text-foreground">3. Example cURL Request</h3>
 							<pre className="bg-muted p-4 rounded-lg text-xs font-mono overflow-x-auto border">
-								{`curl -X DELETE "${API_HOST}/api/v1/alerts/archived/alert-123?api_token=YOUR_TOKEN"`}
+								{`curl -X DELETE "${API_HOST}/api/v1/alerts/resolved/alert-123?api_token=YOUR_TOKEN"`}
 							</pre>
 						</div>
 					</TabsContent>

--- a/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
+++ b/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
@@ -130,7 +130,7 @@ export const GrafanaSetupModal = ({ open, onOpenChange }: GrafanaSetupModalProps
 								</li>
 								<li>
 									Make sure your alert rules send <strong>resolved</strong> notifications too —
-									OpsiMate uses them to automatically archive alerts when they clear.
+									OpsiMate uses them to automatically resolve alerts when they clear.
 								</li>
 							</ol>
 						</div>
@@ -141,7 +141,7 @@ export const GrafanaSetupModal = ({ open, onOpenChange }: GrafanaSetupModalProps
 								OpsiMate reads each alert&apos;s <code>fingerprint</code> as the identifier,{' '}
 								<code>alertname</code> as the name, the <code>summary</code> annotation as the summary,
 								and the alert labels as tags. A <code>firing</code> status creates/updates the alert; a{' '}
-								<code>resolved</code> status archives it.
+								<code>resolved</code> status resolves it.
 							</p>
 						</div>
 

--- a/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
+++ b/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
@@ -422,8 +422,8 @@ fi`;
 							<h4 className="font-semibold text-sm mb-2 text-foreground">✨ Features</h4>
 							<ul className="text-sm text-muted-foreground space-y-1 list-disc ml-4">
 								<li>
-									<strong>Auto-resolve:</strong> Alerts are automatically archived when resolved in
-									Zabbix
+									<strong>Auto-resolve:</strong> Alerts are automatically resolved in OpsiMate when
+									resolved in Zabbix
 								</li>
 								<li>
 									<strong>Deep links:</strong> Click alerts in OpsiMate to jump directly to Zabbix
@@ -498,7 +498,7 @@ fi`;
 										<li>Trigger a test problem in Zabbix</li>
 										<li>Check OpsiMate Alerts page for the new alert</li>
 										<li>Resolve the problem in Zabbix</li>
-										<li>Verify the alert is archived in OpsiMate</li>
+										<li>Verify the alert is resolved in OpsiMate</li>
 									</ol>
 								</div>
 							</div>

--- a/apps/client/src/components/Settings/RetentionSettings.tsx
+++ b/apps/client/src/components/Settings/RetentionSettings.tsx
@@ -31,9 +31,9 @@ const RESOURCE_META: Record<RetentionResource, { title: string; description: str
 		title: 'Active alerts',
 		description: 'Open alerts not updated for this long (clears stale alerts that never resolved).',
 	},
-	[RetentionResource.ArchivedAlerts]: {
-		title: 'Archived alerts',
-		description: 'Resolved/archived alerts kept for historical reference.',
+	[RetentionResource.ResolvedAlerts]: {
+		title: 'Resolved alerts',
+		description: 'Resolved/resolved alerts kept for historical reference.',
 	},
 	[RetentionResource.AlertComments]: {
 		title: 'Alert comments',
@@ -43,7 +43,7 @@ const RESOURCE_META: Record<RetentionResource, { title: string; description: str
 
 const RESOURCE_ORDER: RetentionResource[] = [
 	RetentionResource.ActiveAlerts,
-	RetentionResource.ArchivedAlerts,
+	RetentionResource.ResolvedAlerts,
 	RetentionResource.AlertStatusHistory,
 	RetentionResource.AlertHistoryEvents,
 	RetentionResource.AlertComments,

--- a/apps/client/src/components/Settings/RetentionSettings.tsx
+++ b/apps/client/src/components/Settings/RetentionSettings.tsx
@@ -33,7 +33,7 @@ const RESOURCE_META: Record<RetentionResource, { title: string; description: str
 	},
 	[RetentionResource.ResolvedAlerts]: {
 		title: 'Resolved alerts',
-		description: 'Resolved/resolved alerts kept for historical reference.',
+		description: 'Resolved alerts kept for historical reference.',
 	},
 	[RetentionResource.AlertComments]: {
 		title: 'Alert comments',

--- a/apps/client/src/hooks/queries/alerts/index.ts
+++ b/apps/client/src/hooks/queries/alerts/index.ts
@@ -1,9 +1,9 @@
 export { useAlerts } from './useAlerts';
-export { useArchivedAlerts } from './useArchivedAlerts';
+export { useResolvedAlerts } from './useResolvedAlerts';
 export { useDeleteAlert } from './useDeleteAlert';
-export { useDeleteArchivedAlert } from './useDeleteArchivedAlert';
+export { useDeleteResolvedAlert } from './useDeleteResolvedAlert';
 export { useDismissAlert } from './useDismissAlert';
 export { useMarkAlertRead } from './useMarkAlertRead';
 export { useUndismissAlert } from './useUndismissAlert';
 export { useSetAlertOwner } from './useSetAlertOwner';
-export { useSetArchivedAlertOwner } from './useSetArchivedAlertOwner';
+export { useSetResolvedAlertOwner } from './useSetResolvedAlertOwner';

--- a/apps/client/src/hooks/queries/alerts/useDeleteAlert.ts
+++ b/apps/client/src/hooks/queries/alerts/useDeleteAlert.ts
@@ -39,7 +39,7 @@ export const useDeleteAlert = () => {
 		onSettled: () => {
 			// Always refetch after error or success to ensure server state
 			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
-			queryClient.invalidateQueries({ queryKey: queryKeys.archivedAlerts });
+			queryClient.invalidateQueries({ queryKey: queryKeys.resolvedAlerts });
 		},
 	});
 };

--- a/apps/client/src/hooks/queries/alerts/useDeleteResolvedAlert.ts
+++ b/apps/client/src/hooks/queries/alerts/useDeleteResolvedAlert.ts
@@ -3,26 +3,26 @@ import { Alert } from '@OpsiMate/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../queryKeys';
 
-export const useDeleteArchivedAlert = () => {
+export const useDeleteResolvedAlert = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
 		mutationFn: async (alertId: string) => {
-			const response = await alertsApi.deleteArchivedAlert(alertId);
+			const response = await alertsApi.deleteResolvedAlert(alertId);
 			if (!response.success) {
-				throw new Error(response.error || 'Failed to delete archived alert');
+				throw new Error(response.error || 'Failed to delete resolved alert');
 			}
 			return response.data;
 		},
 		onMutate: async (alertId: string) => {
 			// Cancel any outgoing refetches to avoid overwriting our optimistic update
-			await queryClient.cancelQueries({ queryKey: queryKeys.archivedAlerts });
+			await queryClient.cancelQueries({ queryKey: queryKeys.resolvedAlerts });
 
 			// Snapshot the previous value
-			const previousAlerts = queryClient.getQueryData<Alert[]>(queryKeys.archivedAlerts);
+			const previousAlerts = queryClient.getQueryData<Alert[]>(queryKeys.resolvedAlerts);
 
 			// Optimistically update by removing the alert
-			queryClient.setQueryData<Alert[]>(queryKeys.archivedAlerts, (old) => {
+			queryClient.setQueryData<Alert[]>(queryKeys.resolvedAlerts, (old) => {
 				if (!old) return [];
 				return old.filter((alert) => alert.id !== alertId);
 			});
@@ -33,12 +33,12 @@ export const useDeleteArchivedAlert = () => {
 		onError: (err, alertId, context) => {
 			// If the mutation fails, use the context returned from onMutate to roll back
 			if (context?.previousAlerts) {
-				queryClient.setQueryData(queryKeys.archivedAlerts, context.previousAlerts);
+				queryClient.setQueryData(queryKeys.resolvedAlerts, context.previousAlerts);
 			}
 		},
 		onSettled: () => {
 			// Always refetch after error or success to ensure server state
-			queryClient.invalidateQueries({ queryKey: queryKeys.archivedAlerts });
+			queryClient.invalidateQueries({ queryKey: queryKeys.resolvedAlerts });
 		},
 	});
 };

--- a/apps/client/src/hooks/queries/alerts/useResolvedAlerts.ts
+++ b/apps/client/src/hooks/queries/alerts/useResolvedAlerts.ts
@@ -2,13 +2,13 @@ import { alertsApi } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '../queryKeys';
 
-export const useArchivedAlerts = () => {
+export const useResolvedAlerts = () => {
 	return useQuery({
-		queryKey: queryKeys.archivedAlerts,
+		queryKey: queryKeys.resolvedAlerts,
 		queryFn: async () => {
-			const response = await alertsApi.getAllArchivedAlerts();
+			const response = await alertsApi.getAllResolvedAlerts();
 			if (!response.success) {
-				throw new Error(response.error || 'Failed to fetch archived alerts');
+				throw new Error(response.error || 'Failed to fetch resolved alerts');
 			}
 			return response.data?.alerts || [];
 		},

--- a/apps/client/src/hooks/queries/alerts/useSetResolvedAlertOwner.ts
+++ b/apps/client/src/hooks/queries/alerts/useSetResolvedAlertOwner.ts
@@ -3,31 +3,31 @@ import { Alert } from '@OpsiMate/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../queryKeys';
 
-interface SetArchivedAlertOwnerParams {
+interface SetResolvedAlertOwnerParams {
 	alertId: string;
 	ownerId: string | null;
 }
 
-export const useSetArchivedAlertOwner = () => {
+export const useSetResolvedAlertOwner = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: async ({ alertId, ownerId }: SetArchivedAlertOwnerParams) => {
-			const response = await alertsApi.setArchivedAlertOwner(alertId, ownerId);
+		mutationFn: async ({ alertId, ownerId }: SetResolvedAlertOwnerParams) => {
+			const response = await alertsApi.setResolvedAlertOwner(alertId, ownerId);
 			if (!response.success) {
-				throw new Error(response.error || 'Failed to set archived alert owner');
+				throw new Error(response.error || 'Failed to set resolved alert owner');
 			}
 			return response.data?.alert;
 		},
-		onMutate: async ({ alertId, ownerId }: SetArchivedAlertOwnerParams) => {
+		onMutate: async ({ alertId, ownerId }: SetResolvedAlertOwnerParams) => {
 			// Cancel any outgoing refetches to avoid overwriting our optimistic update
-			await queryClient.cancelQueries({ queryKey: queryKeys.archivedAlerts });
+			await queryClient.cancelQueries({ queryKey: queryKeys.resolvedAlerts });
 
 			// Snapshot the previous value
-			const previousAlerts = queryClient.getQueryData<Alert[]>(queryKeys.archivedAlerts);
+			const previousAlerts = queryClient.getQueryData<Alert[]>(queryKeys.resolvedAlerts);
 
 			// Optimistically update the alert owner
-			queryClient.setQueryData<Alert[]>(queryKeys.archivedAlerts, (old) => {
+			queryClient.setQueryData<Alert[]>(queryKeys.resolvedAlerts, (old) => {
 				if (!old) return [];
 				return old.map((alert) => (alert.id === alertId ? { ...alert, ownerId } : alert));
 			});
@@ -38,12 +38,12 @@ export const useSetArchivedAlertOwner = () => {
 		onError: (_err, _variables, context) => {
 			// If the mutation fails, use the context returned from onMutate to roll back
 			if (context?.previousAlerts) {
-				queryClient.setQueryData(queryKeys.archivedAlerts, context.previousAlerts);
+				queryClient.setQueryData(queryKeys.resolvedAlerts, context.previousAlerts);
 			}
 		},
 		onSettled: () => {
 			// Always refetch after error or success to ensure server state
-			queryClient.invalidateQueries({ queryKey: queryKeys.archivedAlerts });
+			queryClient.invalidateQueries({ queryKey: queryKeys.resolvedAlerts });
 			queryClient.invalidateQueries({ queryKey: ['alertHistory'] });
 		},
 	});

--- a/apps/client/src/hooks/queries/queryKeys.ts
+++ b/apps/client/src/hooks/queries/queryKeys.ts
@@ -2,7 +2,7 @@
 export const queryKeys = {
 	services: ['services'] as const,
 	alerts: ['alerts'] as const,
-	archivedAlerts: ['archivedAlerts'] as const,
+	resolvedAlerts: ['resolvedAlerts'] as const,
 	alertComments: ['alertComments'] as const,
 	alertHistory: (alertId: string) => ['alertHistory', alertId] as const,
 	providers: ['providers'] as const,

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -600,14 +600,14 @@ export const alertsApi = {
 		return response;
 	},
 
-	// Get all archived alerts
-	async getAllArchivedAlerts(): Promise<ApiResponse<{ alerts: SharedAlert[] }>> {
-		return await apiRequest<{ alerts: SharedAlert[] }>('/alerts/archived');
+	// Get all resolved alerts
+	async getAllResolvedAlerts(): Promise<ApiResponse<{ alerts: SharedAlert[] }>> {
+		return await apiRequest<{ alerts: SharedAlert[] }>('/alerts/resolved');
 	},
 
-	// Delete an archived alert permanently
-	async deleteArchivedAlert(alertId: string): Promise<ApiResponse<void>> {
-		return await apiRequest<void>(`/alerts/archived/${alertId}`, 'DELETE');
+	// Delete an resolved alert permanently
+	async deleteResolvedAlert(alertId: string): Promise<ApiResponse<void>> {
+		return await apiRequest<void>(`/alerts/resolved/${alertId}`, 'DELETE');
 	},
 
 	// Set alert owner
@@ -615,9 +615,9 @@ export const alertsApi = {
 		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/owner`, 'PATCH', { ownerId });
 	},
 
-	// Set archived alert owner
-	async setArchivedAlertOwner(alertId: string, ownerId: string | null): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/archived/${alertId}/owner`, 'PATCH', { ownerId });
+	// Set resolved alert owner
+	async setResolvedAlertOwner(alertId: string, ownerId: string | null): Promise<ApiResponse<{ alert: SharedAlert }>> {
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/resolved/${alertId}/owner`, 'PATCH', { ownerId });
 	},
 };
 

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -118,10 +118,10 @@ export const handlers = [
 		});
 	}),
 
-	http.get(`${API_BASE}/alerts/archived`, () => {
+	http.get(`${API_BASE}/alerts/resolved`, () => {
 		return HttpResponse.json({
 			success: true,
-			data: { alerts: playgroundState.archivedAlerts },
+			data: { alerts: playgroundState.resolvedAlerts },
 		});
 	}),
 
@@ -191,10 +191,10 @@ export const handlers = [
 		return HttpResponse.json({ success: true, data: { alert } });
 	}),
 
-	http.patch(`${API_BASE}/alerts/archived/:alertId/owner`, async ({ params, request }) => {
+	http.patch(`${API_BASE}/alerts/resolved/:alertId/owner`, async ({ params, request }) => {
 		const alertId = params.alertId as string;
 		const body = (await request.json()) as { ownerId: string | null };
-		const alert = playgroundState.archivedAlerts.find((a) => a.id === alertId);
+		const alert = playgroundState.resolvedAlerts.find((a) => a.id === alertId);
 
 		if (!alert) {
 			return HttpResponse.json({ success: false, error: 'Alert not found' }, { status: 404 });
@@ -212,22 +212,22 @@ export const handlers = [
 		const alertIndex = playgroundState.alerts.findIndex((a) => a.id === alertId);
 
 		if (alertIndex === -1) {
-			return HttpResponse.json({ success: true, message: 'Alert not found, nothing to archive' });
+			return HttpResponse.json({ success: true, message: 'Alert not found, nothing to resolve' });
 		}
 
 		const alert = { ...playgroundState.alerts[alertIndex] };
 		alert.updatedAt = nowIso();
 
 		playgroundState.alerts.splice(alertIndex, 1);
-		playgroundState.archivedAlerts.unshift(alert);
+		playgroundState.resolvedAlerts.unshift(alert);
 
 		return HttpResponse.json({ success: true, message: 'Alert deleted successfully' });
 	}),
 
-	http.delete(`${API_BASE}/alerts/archived/:alertId`, ({ params }) => {
+	http.delete(`${API_BASE}/alerts/resolved/:alertId`, ({ params }) => {
 		const alertId = params.alertId as string;
-		playgroundState.archivedAlerts = playgroundState.archivedAlerts.filter((a) => a.id !== alertId);
-		return HttpResponse.json({ success: true, message: 'Archived alert deleted permanently' });
+		playgroundState.resolvedAlerts = playgroundState.resolvedAlerts.filter((a) => a.id !== alertId);
+		return HttpResponse.json({ success: true, message: 'Resolved alert deleted permanently' });
 	}),
 
 	http.get(`${API_BASE}/alerts/:alertId/history`, ({ params }) => {

--- a/apps/client/src/mocks/state.ts
+++ b/apps/client/src/mocks/state.ts
@@ -31,7 +31,7 @@ export { getPlaygroundUser };
 
 export interface PlaygroundState {
 	alerts: Alert[];
-	archivedAlerts: Alert[];
+	resolvedAlerts: Alert[];
 	alertComments: AlertComment[];
 	providers: Provider[];
 	services: ServiceWithProvider[];
@@ -409,10 +409,10 @@ const seedAlerts = () => {
 	}));
 };
 
-const createArchivedAlerts = (alerts: Alert[]) =>
+const createResolvedAlerts = (alerts: Alert[]) =>
 	alerts.slice(0, 20).map((alert, index) => ({
 		...alert,
-		id: `archived-${alert.id}-${index}`,
+		id: `resolved-${alert.id}-${index}`,
 		isDismissed: true,
 		status: AlertStatus.RESOLVED,
 		updatedAt: new Date(Date.now() - 1000 * 60 * 60 * (index + 1)).toISOString(),
@@ -425,7 +425,7 @@ const initialAlerts = seedAlerts();
 
 export const playgroundState: PlaygroundState = {
 	alerts: initialAlerts,
-	archivedAlerts: createArchivedAlerts(initialAlerts),
+	resolvedAlerts: createResolvedAlerts(initialAlerts),
 	alertComments: [
 		{
 			id: 'c-1',

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -93,11 +93,11 @@ export class AlertController {
 			logger.info(`Received Uptime Kuma alert: ${JSON.stringify(payload)}`);
 
 			if (kumaStatus === 1) {
-				await this.alertBL.archiveAlert(monitorId);
+				await this.alertBL.resolveAlert(monitorId);
 
 				return res.status(200).json({
 					success: true,
-					data: { alertId: monitorId, archived: true },
+					data: { alertId: monitorId, resolved: true },
 				});
 			}
 
@@ -178,10 +178,10 @@ export class AlertController {
 				(hasValidRecoveryDate && hasValidRecoveryTime);
 
 			if (isResolved) {
-				await this.alertBL.archiveAlert(alertId);
+				await this.alertBL.resolveAlert(alertId);
 				return res.status(200).json({
 					success: true,
-					data: { alertId, archived: true },
+					data: { alertId, resolved: true },
 				});
 			}
 
@@ -269,7 +269,7 @@ export class AlertController {
 			logger.info(`got gcp alert: ${JSON.stringify(payload)}`);
 
 			if (incident.state.toLowerCase() === 'closed') {
-				await this.alertBL.archiveAlert(incident.incident_id);
+				await this.alertBL.resolveAlert(incident.incident_id);
 			} else {
 				await this.alertBL.insertOrUpdateAlert({
 					id: incident.incident_id,
@@ -304,7 +304,7 @@ export class AlertController {
 			logger.info(`got datadog alert: ${JSON.stringify(payload)}`);
 
 			if (isRecovered) {
-				await this.alertBL.archiveAlert(alertId);
+				await this.alertBL.resolveAlert(alertId);
 				return res.status(200).json({ success: true, data: { alertId } });
 			}
 
@@ -379,7 +379,7 @@ export class AlertController {
 
 	// Receives alerts pushed by a Grafana "Webhook" contact point. Replaces the old polling job:
 	// Grafana now POSTs firing/resolved transitions here. Each alert in the batch is upserted
-	// (firing) or archived (resolved), keyed by Grafana's per-alert fingerprint.
+	// (firing) or resolved (resolved), keyed by Grafana's per-alert fingerprint.
 	async createCustomGrafanaAlert(req: Request, res: Response) {
 		try {
 			const payload = GrafanaWebhookSchema.parse(req.body);
@@ -401,7 +401,7 @@ export class AlertController {
 				}
 
 				if (alert.status?.toLowerCase() === 'resolved') {
-					await this.alertBL.archiveAlert(alertId);
+					await this.alertBL.resolveAlert(alertId);
 					processedIds.push(alertId);
 					continue;
 				}
@@ -486,7 +486,7 @@ export class AlertController {
 			if (alertId.length < 1) {
 				return res.status(400).json({ success: false, error: 'Invalid alert ID' });
 			}
-			await this.alertBL.archiveAlert(alertId);
+			await this.alertBL.resolveAlert(alertId);
 			return res.json({ success: true, message: 'Alert deleted successfully' });
 		} catch (error) {
 			logger.error('Error deleting alert:', error);
@@ -494,26 +494,26 @@ export class AlertController {
 		}
 	}
 
-	async getArchivedAlerts(req: Request, res: Response) {
+	async getResolvedAlerts(req: Request, res: Response) {
 		try {
-			const alerts = await this.alertBL.getAllArchivedAlerts();
+			const alerts = await this.alertBL.getAllResolvedAlerts();
 			return res.json({ success: true, data: { alerts } });
 		} catch (error) {
-			logger.error('Error getting archived alerts:', error);
+			logger.error('Error getting resolved alerts:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
 	}
 
-	async deleteArchivedAlert(req: Request, res: Response) {
+	async deleteResolvedAlert(req: Request, res: Response) {
 		try {
 			const alertId = req.params.alertId;
 			if (alertId.length < 1) {
 				return res.status(400).json({ success: false, error: 'Invalid alert ID' });
 			}
-			await this.alertBL.deleteArchivedAlert(alertId);
-			return res.json({ success: true, message: 'Archived alert deleted permanently' });
+			await this.alertBL.deleteResolvedAlert(alertId);
+			return res.json({ success: true, message: 'Resolved alert deleted permanently' });
 		} catch (error) {
-			logger.error('Error deleting archived alert:', error);
+			logger.error('Error deleting resolved alert:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
 	}
@@ -527,7 +527,7 @@ export class AlertController {
 			const alertHistory: AlertHistory = await this.alertBL.getAlertHistory(alertId);
 			return res.json({ success: true, data: { ...alertHistory } });
 		} catch (error) {
-			logger.error('Error deleting archived alert:', error);
+			logger.error('Error deleting resolved alert:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
 	}
@@ -536,18 +536,18 @@ export class AlertController {
 		return this.setAlertOwnerWrapper(req, res, false);
 	}
 
-	async setArchivedAlertOwner(req: AuthenticatedRequest, res: Response) {
+	async setResolvedAlertOwner(req: AuthenticatedRequest, res: Response) {
 		return this.setAlertOwnerWrapper(req, res, true);
 	}
 
-	async setAlertOwnerWrapper(req: AuthenticatedRequest, res: Response, isArchived: boolean) {
+	async setAlertOwnerWrapper(req: AuthenticatedRequest, res: Response, isResolved: boolean) {
 		try {
 			const { id } = req.params;
 			if (!id) {
 				return res.status(400).json({ success: false, error: 'Alert id is required' });
 			}
 			const { ownerId } = SetAlertOwnerSchema.parse(req.body);
-			const alert = await this.alertBL.setAlertOwner(id, ownerId, isArchived, req.user?.fullName);
+			const alert = await this.alertBL.setAlertOwner(id, ownerId, isResolved, req.user?.fullName);
 			if (!alert) {
 				return res.status(404).json({ success: false, error: 'Alert not found' });
 			}

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -527,7 +527,7 @@ export class AlertController {
 			const alertHistory: AlertHistory = await this.alertBL.getAlertHistory(alertId);
 			return res.json({ success: true, data: { ...alertHistory } });
 		} catch (error) {
-			logger.error('Error deleting resolved alert:', error);
+			logger.error('Error getting alert history:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
 	}

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -8,10 +8,10 @@ export default function createAlertRouter(controller: AlertController) {
 	// CRUD
 	router.get('/', controller.getAlerts.bind(controller));
 
-	// Archived alerts (must be before /:alertId to avoid route conflicts)
-	router.get('/archived', controller.getArchivedAlerts.bind(controller));
-	router.delete('/archived/:alertId', controller.deleteArchivedAlert.bind(controller));
-	router.patch('/archived/:id/owner', controller.setArchivedAlertOwner.bind(controller));
+	// Resolved alerts (must be before /:alertId to avoid route conflicts)
+	router.get('/resolved', controller.getResolvedAlerts.bind(controller));
+	router.delete('/resolved/:alertId', controller.deleteResolvedAlert.bind(controller));
+	router.patch('/resolved/:id/owner', controller.setResolvedAlertOwner.bind(controller));
 
 	// Delete alert (parameterized route must come after specific routes)
 	router.delete('/:alertId', controller.deleteAlert.bind(controller));

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -37,7 +37,7 @@ import { ActionRepository } from './dal/actionRepository';
 import { AlertCommentsRepository } from './dal/alertCommentsRepository.ts';
 import { AlertHistoryRepository } from './dal/alertHistoryRepository';
 import { AlertRepository } from './dal/alertRepository';
-import { ArchivedAlertRepository } from './dal/archivedAlertRepository';
+import { ResolvedAlertRepository } from './dal/resolvedAlertRepository';
 import { RetentionRepository } from './dal/retentionRepository';
 import { AuditLogRepository } from './dal/auditLogRepository';
 import { CustomActionRepository } from './dal/customActionRepository';
@@ -74,7 +74,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const alertCommentsRepo = new AlertCommentsRepository(db);
 	const auditLogRepo = new AuditLogRepository(db);
 	const secretsMetadataRepo = new SecretsMetadataRepository(db);
-	const archivedAlertRepo = new ArchivedAlertRepository(db);
+	const resolvedAlertRepo = new ResolvedAlertRepository(db);
 	const alertHistoryRepo = new AlertHistoryRepository(db);
 	const retentionRepo = new RetentionRepository(db);
 	// Needed by AlertBL (to resolve owner names for history); constructed here so it is also
@@ -86,7 +86,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 		providerRepo.initProvidersTable(),
 		serviceRepo.initServicesTable(),
 		integrationRepo.initIntegrationsTable(),
-		archivedAlertRepo.initArchivedAlertsTable(), // this should be prior to alertRepo.initAlertsTable
+		resolvedAlertRepo.initResolvedAlertsTable(), // this should be prior to alertRepo.initAlertsTable
 		alertRepo.initAlertsTable(),
 		alertCommentsRepo.initAlertCommentsTable(),
 		alertHistoryRepo.initAlertHistoryEventsTable(),
@@ -98,7 +98,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	// BL (needed by both)
 	const auditBL = new AuditBL(auditLogRepo);
 	const providerBL = new ProviderBL(providerRepo, serviceRepo, secretsMetadataRepo, auditBL);
-	const alertBL = new AlertBL(alertRepo, archivedAlertRepo, alertCommentsRepo, alertHistoryRepo, userRepo);
+	const alertBL = new AlertBL(alertRepo, resolvedAlertRepo, alertCommentsRepo, alertHistoryRepo, userRepo);
 	const integrationBL = new IntegrationBL(integrationRepo, alertBL);
 	const retentionBL = new RetentionBL(retentionRepo);
 

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -1,5 +1,5 @@
 import { AlertRepository } from '../../dal/alertRepository';
-import { ArchivedAlertRepository } from '../../dal/archivedAlertRepository';
+import { ResolvedAlertRepository } from '../../dal/resolvedAlertRepository';
 import {
 	Alert,
 	AlertComment,
@@ -34,7 +34,7 @@ export class AlertBL {
 
 	constructor(
 		private alertRepo: AlertRepository,
-		private archivedAlertRepo: ArchivedAlertRepository,
+		private resolvedAlertRepo: ResolvedAlertRepository,
 		private alertCommentsRepo: AlertCommentsRepository,
 		private alertHistoryRepo: AlertHistoryRepository,
 		private userRepo: UserRepository
@@ -153,68 +153,68 @@ export class AlertBL {
 	}
 	// endregion
 
-	// region archived
-	async getAllArchivedAlerts(): Promise<Alert[]> {
+	// region resolved
+	async getAllResolvedAlerts(): Promise<Alert[]> {
 		try {
-			logger.info('Fetching all archived alerts');
-			return await this.archivedAlertRepo.getAllArchivedAlerts();
+			logger.info('Fetching all resolved alerts');
+			return await this.resolvedAlertRepo.getAllResolvedAlerts();
 		} catch (error) {
-			logger.error('Error fetching archived alerts', error);
+			logger.error('Error fetching resolved alerts', error);
 			throw error;
 		}
 	}
 
-	async archiveAlert(activeAlertId: string): Promise<void> {
+	async resolveAlert(activeAlertId: string): Promise<void> {
 		try {
 			logger.info(`Archiving alert with id: ${activeAlertId}`);
 
 			// Get the active alert
 			const alert = await this.alertRepo.getAlert(activeAlertId);
 			if (!alert) {
-				logger.warn(`Alert with id ${activeAlertId} not found, nothing to archive`);
+				logger.warn(`Alert with id ${activeAlertId} not found, nothing to resolve`);
 				return;
 			}
 
-			// Insert into archived table
-			await this.archivedAlertRepo.insertArchivedAlert(alert);
+			// Insert into resolved table
+			await this.resolvedAlertRepo.insertResolvedAlert(alert);
 
 			// Remove from active table
 			await this.alertRepo.deleteAlert(activeAlertId);
 
-			logger.info(`Archived alert ${activeAlertId}`);
+			logger.info(`Resolved alert ${activeAlertId}`);
 		} catch (error) {
 			logger.error(`Error archiving alert ${activeAlertId}`, error);
 			throw error;
 		}
 	}
 
-	async archiveNonActiveAlerts(activeAlertIds: Set<string>, alertType: AlertType) {
+	async resolveNonActiveAlerts(activeAlertIds: Set<string>, alertType: AlertType) {
 		try {
 			logger.info(`Archiving alerts not in ids for type: ${alertType}`);
-			// Get alerts that need to be archived
-			const alertsToArchive = await this.alertRepo.getAlertsNotInIds(activeAlertIds, alertType);
+			// Get alerts that need to be resolved
+			const alertsToResolve = await this.alertRepo.getAlertsNotInIds(activeAlertIds, alertType);
 
-			// Archive each alert
-			for (const alert of alertsToArchive) {
-				await this.archivedAlertRepo.insertArchivedAlert(alert);
+			// Resolve each alert
+			for (const alert of alertsToResolve) {
+				await this.resolvedAlertRepo.insertResolvedAlert(alert);
 			}
 
 			// Delete alerts from active table
 			await this.alertRepo.deleteAlertsNotInIds(activeAlertIds, alertType);
 
-			logger.info(`Archived ${alertsToArchive.length} alerts`);
+			logger.info(`Resolved ${alertsToResolve.length} alerts`);
 		} catch (error) {
 			logger.error('Error archiving alerts', error);
 			throw error;
 		}
 	}
 
-	async deleteArchivedAlert(alertId: string): Promise<void> {
+	async deleteResolvedAlert(alertId: string): Promise<void> {
 		try {
-			logger.info(`Permanently deleting archived alert with id: ${alertId}`);
-			await this.archivedAlertRepo.deleteArchivedAlert(alertId);
+			logger.info(`Permanently deleting resolved alert with id: ${alertId}`);
+			await this.resolvedAlertRepo.deleteResolvedAlert(alertId);
 		} catch (error) {
-			logger.error('Error deleting archived alert', error);
+			logger.error('Error deleting resolved alert', error);
 			throw error;
 		}
 	}
@@ -225,7 +225,7 @@ export class AlertBL {
 		// Merge two sources: automatic status transitions (trigger-populated) and user-driven
 		// events (ownership, dismissals, actions, comments), newest first.
 		const [statusHistory, events] = await Promise.all([
-			this.archivedAlertRepo.getAlertHistory(alertId),
+			this.resolvedAlertRepo.getAlertHistory(alertId),
 			this.alertHistoryRepo.getEvents(alertId),
 		]);
 
@@ -255,15 +255,15 @@ export class AlertBL {
 	async setAlertOwner(
 		alertId: string,
 		ownerId: string | null,
-		isArchived: boolean,
+		isResolved: boolean,
 		actorName?: string | null
 	): Promise<Alert | null> {
 		try {
-			logger.info(`Setting owner ${ownerId} for alert: ${alertId} is Archived ${isArchived}`);
+			logger.info(`Setting owner ${ownerId} for alert: ${alertId} is Resolved ${isResolved}`);
 			// Convert string to number for database storage
 			const numericOwnerId = ownerId !== null ? parseInt(ownerId, 10) : null;
-			const updated = isArchived
-				? await this.archivedAlertRepo.updateArchivedAlertOwner(alertId, numericOwnerId)
+			const updated = isResolved
+				? await this.resolvedAlertRepo.updateResolvedAlertOwner(alertId, numericOwnerId)
 				: await this.alertRepo.updateAlertOwner(alertId, numericOwnerId);
 
 			if (updated) {

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -166,7 +166,7 @@ export class AlertBL {
 
 	async resolveAlert(activeAlertId: string): Promise<void> {
 		try {
-			logger.info(`Archiving alert with id: ${activeAlertId}`);
+			logger.info(`Resolving alert with id: ${activeAlertId}`);
 
 			// Get the active alert
 			const alert = await this.alertRepo.getAlert(activeAlertId);
@@ -183,14 +183,14 @@ export class AlertBL {
 
 			logger.info(`Resolved alert ${activeAlertId}`);
 		} catch (error) {
-			logger.error(`Error archiving alert ${activeAlertId}`, error);
+			logger.error(`Error resolving alert ${activeAlertId}`, error);
 			throw error;
 		}
 	}
 
 	async resolveNonActiveAlerts(activeAlertIds: Set<string>, alertType: AlertType) {
 		try {
-			logger.info(`Archiving alerts not in ids for type: ${alertType}`);
+			logger.info(`Resolving alerts not in ids for type: ${alertType}`);
 			// Get alerts that need to be resolved
 			const alertsToResolve = await this.alertRepo.getAlertsNotInIds(activeAlertIds, alertType);
 
@@ -204,7 +204,7 @@ export class AlertBL {
 
 			logger.info(`Resolved ${alertsToResolve.length} alerts`);
 		} catch (error) {
-			logger.error('Error archiving alerts', error);
+			logger.error('Error resolving alerts', error);
 			throw error;
 		}
 	}

--- a/apps/server/src/bl/integrations/integration-connector/grafana-integration-connector.ts
+++ b/apps/server/src/bl/integrations/integration-connector/grafana-integration-connector.ts
@@ -16,7 +16,7 @@ export class GrafanaIntegrationConnector implements IntegrationConnector {
 	}
 
 	async deleteData(_: Integration, alertBL: AlertBL): Promise<void> {
-		await alertBL.archiveNonActiveAlerts(new Set(), 'Grafana');
+		await alertBL.resolveNonActiveAlerts(new Set(), 'Grafana');
 	}
 
 	async testConnection(integration: Integration): Promise<{ success: boolean; error?: string }> {

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -69,7 +69,7 @@ export type AlertRow = {
 	owner_id?: number | null;
 };
 
-export type ArchivedAlertRow = {
+export type ResolvedAlertRow = {
 	id: string;
 	type: AlertType;
 	status: string;

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -1,20 +1,29 @@
 import { AlertStatus, Alert as SharedAlert, AlertHistory, normalizeAlertSeverity } from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
-import { ArchivedAlertRow, TableInfoRow } from './models';
+import { ResolvedAlertRow, TableInfoRow } from './models';
 
-export class ArchivedAlertRepository {
+export class ResolvedAlertRepository {
 	private db: Database.Database;
 
 	constructor(db: Database.Database) {
 		this.db = db;
 	}
 
-	async initArchivedAlertsTable(): Promise<void> {
+	async initResolvedAlertsTable(): Promise<void> {
 		return runAsync(() => {
+			// Migration: this store used to be called "archived"; carry existing rows over.
+			// Only rename when the legacy table exists AND the new one does not yet, so a
+			// rollback then re-upgrade (both present) can't crash on the RENAME.
+			const tableExists = (name: string): boolean =>
+				!!this.db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`).get(name);
+			if (tableExists('alerts_archived') && !tableExists('alerts_resolved')) {
+				this.db.prepare(`ALTER TABLE alerts_archived RENAME TO alerts_resolved`).run();
+			}
+
 			this.db.exec(
 				`
-						CREATE TABLE IF NOT EXISTS alerts_archived (
+						CREATE TABLE IF NOT EXISTS alerts_resolved (
 																	   id TEXT PRIMARY KEY,
 																	   status TEXT NOT NULL,
 																	   severity TEXT,
@@ -39,7 +48,7 @@ export class ArchivedAlertRepository {
 						);
 
 						CREATE TRIGGER IF NOT EXISTS archive_alert_history_on_update
-							BEFORE UPDATE ON alerts_archived
+							BEFORE UPDATE ON alerts_resolved
 							FOR EACH ROW
 						BEGIN
 							INSERT INTO alerts_history (alert_id, status)
@@ -47,7 +56,7 @@ export class ArchivedAlertRepository {
 						END;
 
 						CREATE TRIGGER IF NOT EXISTS archive_alert_history_on_insert
-							AFTER INSERT ON alerts_archived
+							AFTER INSERT ON alerts_resolved
 							FOR EACH ROW
 						BEGIN
 							INSERT INTO alerts_history (alert_id, status)
@@ -57,31 +66,31 @@ export class ArchivedAlertRepository {
 			);
 
 			// Backward compatibility: ensure tags column exists
-			const columns = this.db.prepare(`PRAGMA table_info(alerts_archived)`).all() as TableInfoRow[];
+			const columns = this.db.prepare(`PRAGMA table_info(alerts_resolved)`).all() as TableInfoRow[];
 			const hasTags = columns.some((col: TableInfoRow) => col.name === 'tags');
 
 			if (!hasTags) {
-				this.db.prepare(`ALTER TABLE alerts_archived ADD COLUMN tags TEXT`).run();
+				this.db.prepare(`ALTER TABLE alerts_resolved ADD COLUMN tags TEXT`).run();
 			}
 
 			// Backward compatibility: ensure owner_id column exists
 			const hasOwnerId = columns.some((col: TableInfoRow) => col.name === 'owner_id');
 			if (!hasOwnerId) {
-				this.db.prepare(`ALTER TABLE alerts_archived ADD COLUMN owner_id INTEGER REFERENCES users(id)`).run();
+				this.db.prepare(`ALTER TABLE alerts_resolved ADD COLUMN owner_id INTEGER REFERENCES users(id)`).run();
 			}
 
 			// Backward compatibility: ensure severity column exists
 			const hasSeverity = columns.some((col: TableInfoRow) => col.name === 'severity');
 			if (!hasSeverity) {
-				this.db.prepare(`ALTER TABLE alerts_archived ADD COLUMN severity TEXT`).run();
+				this.db.prepare(`ALTER TABLE alerts_resolved ADD COLUMN severity TEXT`).run();
 			}
 		});
 	}
 
-	async insertArchivedAlert(alert: SharedAlert): Promise<{ changes: number }> {
+	async insertResolvedAlert(alert: SharedAlert): Promise<{ changes: number }> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
-                INSERT INTO alerts_archived
+                INSERT INTO alerts_resolved
                     (id, status, severity, tags, type, starts_at, updated_at, alert_url, alert_name, is_dismissed, summary, runbook_url, created_at, owner_id)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
@@ -122,7 +131,7 @@ export class ArchivedAlertRepository {
 		});
 	}
 
-	private toSharedAlert = (row: ArchivedAlertRow): SharedAlert => {
+	private toSharedAlert = (row: ResolvedAlertRow): SharedAlert => {
 		const tags = row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {};
 		return {
 			id: row.id,
@@ -143,26 +152,26 @@ export class ArchivedAlertRepository {
 		};
 	};
 
-	async getAllArchivedAlerts(): Promise<SharedAlert[]> {
+	async getAllResolvedAlerts(): Promise<SharedAlert[]> {
 		return runAsync(() => {
-			const stmt = this.db.prepare('SELECT * FROM alerts_archived ORDER BY archived_at DESC');
-			const rows = stmt.all() as ArchivedAlertRow[];
+			const stmt = this.db.prepare('SELECT * FROM alerts_resolved ORDER BY archived_at DESC');
+			const rows = stmt.all() as ResolvedAlertRow[];
 			return rows.map(this.toSharedAlert);
 		});
 	}
 
-	async deleteArchivedAlert(alertId: string): Promise<void> {
+	async deleteResolvedAlert(alertId: string): Promise<void> {
 		return runAsync(() => {
-			const stmt = this.db.prepare(`DELETE FROM alerts_archived WHERE id = ?`);
+			const stmt = this.db.prepare(`DELETE FROM alerts_resolved WHERE id = ?`);
 			stmt.run(alertId);
 		});
 	}
 
-	async updateArchivedAlertOwner(alertId: string, ownerId: number | null): Promise<SharedAlert | null> {
+	async updateResolvedAlertOwner(alertId: string, ownerId: number | null): Promise<SharedAlert | null> {
 		return runAsync(() => {
-			this.db.prepare('UPDATE alerts_archived SET owner_id = ? WHERE id = ?').run(ownerId, alertId);
-			const row = this.db.prepare('SELECT * FROM alerts_archived WHERE id = ?').get(alertId) as
-				| ArchivedAlertRow
+			this.db.prepare('UPDATE alerts_resolved SET owner_id = ? WHERE id = ?').run(ownerId, alertId);
+			const row = this.db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get(alertId) as
+				| ResolvedAlertRow
 				| undefined;
 			return row ? this.toSharedAlert(row) : null;
 		});

--- a/apps/server/src/dal/retentionRepository.ts
+++ b/apps/server/src/dal/retentionRepository.ts
@@ -10,7 +10,7 @@ const RESOURCE_TABLE: Record<RetentionResource, { table: string; column: string 
 	[RetentionResource.AlertHistoryEvents]: { table: 'alert_history_events', column: 'created_at' },
 	[RetentionResource.AlertStatusHistory]: { table: 'alerts_history', column: 'archived_at' },
 	[RetentionResource.ActiveAlerts]: { table: 'alerts', column: 'updated_at' },
-	[RetentionResource.ArchivedAlerts]: { table: 'alerts_archived', column: 'archived_at' },
+	[RetentionResource.ResolvedAlerts]: { table: 'alerts_resolved', column: 'archived_at' },
 	[RetentionResource.AlertComments]: { table: 'alert_comments', column: 'created_at' },
 };
 
@@ -21,7 +21,7 @@ const DEFAULT_POLICIES: { resource: RetentionResource; days: number }[] = [
 	{ resource: RetentionResource.AlertHistoryEvents, days: 90 },
 	{ resource: RetentionResource.AlertStatusHistory, days: 90 },
 	{ resource: RetentionResource.ActiveAlerts, days: 30 },
-	{ resource: RetentionResource.ArchivedAlerts, days: 180 },
+	{ resource: RetentionResource.ResolvedAlerts, days: 180 },
 	{ resource: RetentionResource.AlertComments, days: 365 },
 ];
 

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -9,13 +9,13 @@ const logger = new Logger('test-alerts');
 let app: SuperTest<Test>;
 let db: Database.Database;
 let testAlerts: Alert[] = [];
-let testAlertsArchived: Alert[] = [];
+let testResolvedAlerts: Alert[] = [];
 let jwtToken: string;
 
 const seedAlerts = () => {
 	// Clear existing alerts
 	db.exec('DELETE FROM alerts');
-	db.exec('DELETE FROM alerts_archived');
+	db.exec('DELETE FROM alerts_resolved');
 
 	// Create sample active alerts
 	const sampleAlerts: Omit<AlertRow, 'created_at'>[] = [
@@ -83,35 +83,35 @@ const seedAlerts = () => {
 	});
 
 	// -------------------------
-	// Add sample archived alert
+	// Add sample resolved alert
 	// -------------------------
 
-	const sampleArchivedAlerts = [
+	const sampleResolvedAlerts = [
 		{
-			id: 'archived-1',
+			id: 'resolved-1',
 			type: 'Grafana',
 			status: 'resolved',
 			tags: { tag: 'system' },
 			starts_at: new Date(Date.now() - 5 * 3600000).toISOString(), // 5 hours ago
 			updated_at: new Date().toISOString(),
-			alert_url: 'https://example.com/archived/1',
-			alert_name: 'Archived Test Alert',
-			summary: 'Archived Summary',
-			runbook_url: 'https://runbook.com/archived1',
+			alert_url: 'https://example.com/resolved/1',
+			alert_name: 'Resolved Test Alert',
+			summary: 'Resolved Summary',
+			runbook_url: 'https://runbook.com/resolved1',
 			archived_at: new Date().toISOString(),
 			is_dismissed: false,
 		},
 	];
 
-	const insertArchivedStmt = db.prepare(`
-        INSERT INTO alerts_archived
+	const insertResolvedStmt = db.prepare(`
+        INSERT INTO alerts_resolved
         (id, status, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, archived_at,
          is_dismissed)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
-	sampleArchivedAlerts.forEach((alert) => {
-		insertArchivedStmt.run(
+	sampleResolvedAlerts.forEach((alert) => {
+		insertResolvedStmt.run(
 			alert.id,
 			alert.status,
 			JSON.stringify(alert.tags ?? {}),
@@ -140,8 +140,8 @@ const seedAlerts = () => {
 		isDismissed: row.is_dismissed,
 	}));
 
-	// Optionally export archived alerts to tests
-	testAlertsArchived = sampleArchivedAlerts.map((row) => ({
+	// Optionally export resolved alerts to tests
+	testResolvedAlerts = sampleResolvedAlerts.map((row) => ({
 		id: row.id,
 		status: row.status == 'firing' ? AlertStatus.FIRING : AlertStatus.RESOLVED,
 		type: row.type,
@@ -154,7 +154,7 @@ const seedAlerts = () => {
 		isDismissed: row.is_dismissed,
 	}));
 
-	logger.info(`Seeded ${sampleAlerts.length} active alerts + ${sampleArchivedAlerts.length} archived alerts`);
+	logger.info(`Seeded ${sampleAlerts.length} active alerts + ${sampleResolvedAlerts.length} resolved alerts`);
 };
 
 beforeAll(async () => {
@@ -671,10 +671,10 @@ describe('Alerts API', () => {
 			expect(parsedTags).toEqual({ service: 'web', env: 'prod', severity: 'warning' });
 		});
 
-		test('should archive an existing Datadog alert when alert_transition is recovered', async () => {
+		test('should resolve an existing Datadog alert when alert_transition is recovered', async () => {
 			const now = '1765302826000';
-			const alertId = 'datadog-alert-archive';
-			const alertInstanceId = 'datadog-alert-archive-1';
+			const alertId = 'datadog-alert-resolve';
+			const alertInstanceId = 'datadog-alert-resolve-1';
 
 			const firingPayload = {
 				id: alertInstanceId,
@@ -726,9 +726,9 @@ describe('Alerts API', () => {
 			const rowAfter = db.prepare('SELECT * FROM alerts WHERE id = ?').get(alertInstanceId);
 			expect(rowAfter).toBeUndefined();
 
-			const archivedRow = db.prepare('SELECT * FROM alerts_archived WHERE id = ?').get(alertInstanceId);
-			expect(archivedRow).toBeDefined();
-			expect(archivedRow.id).toBe(alertInstanceId);
+			const resolvedRow = db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get(alertInstanceId);
+			expect(resolvedRow).toBeDefined();
+			expect(resolvedRow.id).toBe(alertInstanceId);
 		});
 
 		test('should return 400 for invalid Datadog payload', async () => {
@@ -875,9 +875,9 @@ describe('Alerts API', () => {
 		});
 
 		// --------------------------------------------------------
-		// TEST 2: Should archive an existing alert on UP (status 1)
+		// TEST 2: Should resolve an existing alert on UP (status 1)
 		// --------------------------------------------------------
-		test('should archive alert on UP status', async () => {
+		test('should resolve alert on UP status', async () => {
 			// First create alert
 			db.prepare(
 				`
@@ -909,8 +909,8 @@ describe('Alerts API', () => {
 			expect(response.status).toBe(200);
 			expect(response.body.data.alertId).toBe('UPTIMEKUMA_4');
 
-			const archived = db.prepare('SELECT * FROM alerts_archived WHERE id = ?').get('UPTIMEKUMA_4');
-			expect(archived).toBeDefined();
+			const resolvedAlert = db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get('UPTIMEKUMA_4');
+			expect(resolvedAlert).toBeDefined();
 
 			const active = db.prepare('SELECT * FROM alerts WHERE id = ?').get('UPTIMEKUMA_4');
 			expect(active).toBeUndefined();
@@ -1036,10 +1036,10 @@ describe('Alerts API', () => {
 			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(existingId);
 			expect(row).toBeUndefined();
 
-			const archivedRow = db.prepare('SELECT * FROM alerts_archived WHERE id = ?').get(existingId);
+			const resolvedRow = db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get(existingId);
 
-			expect(archivedRow).toBeDefined();
-			expect(archivedRow.id).toBe(existingId);
+			expect(resolvedRow).toBeDefined();
+			expect(resolvedRow.id).toBe(existingId);
 		});
 
 		test('should return 400 for missing incident field', async () => {
@@ -1156,10 +1156,10 @@ describe('Alerts API', () => {
 		});
 	});
 
-	describe('Archived Alerts API', () => {
-		describe('GET /api/v1/alerts/archived', () => {
-			test('should fetch all archived alerts successfully', async () => {
-				const response = await app.get('/api/v1/alerts/archived').set('Authorization', `Bearer ${jwtToken}`);
+	describe('Resolved Alerts API', () => {
+		describe('GET /api/v1/alerts/resolved', () => {
+			test('should fetch all resolved alerts successfully', async () => {
+				const response = await app.get('/api/v1/alerts/resolved').set('Authorization', `Bearer ${jwtToken}`);
 
 				expect(response.status).toBe(200);
 				expect(response.body.success).toBe(true);
@@ -1167,14 +1167,14 @@ describe('Alerts API', () => {
 				expect(response.body.data.alerts.length).toBe(1);
 
 				const alert = response.body.data.alerts[0];
-				expect(alert.id).toBe(testAlertsArchived[0].id);
-				expect(alert.alertName).toBe(testAlertsArchived[0].alertName);
+				expect(alert.id).toBe(testResolvedAlerts[0].id);
+				expect(alert.alertName).toBe(testResolvedAlerts[0].alertName);
 			});
 
-			test('should return empty array when no archived alerts exist', async () => {
-				db.exec('DELETE FROM alerts_archived');
+			test('should return empty array when no resolved alerts exist', async () => {
+				db.exec('DELETE FROM alerts_resolved');
 
-				const response = await app.get('/api/v1/alerts/archived').set('Authorization', `Bearer ${jwtToken}`);
+				const response = await app.get('/api/v1/alerts/resolved').set('Authorization', `Bearer ${jwtToken}`);
 
 				expect(response.status).toBe(200);
 				expect(response.body.success).toBe(true);
@@ -1182,15 +1182,15 @@ describe('Alerts API', () => {
 			});
 
 			test('should return 401 when no auth token is provided', async () => {
-				const response = await app.get('/api/v1/alerts/archived');
+				const response = await app.get('/api/v1/alerts/resolved');
 
 				expect(response.status).toBe(401);
 				expect(response.body.success).toBe(false);
 			});
 		});
 
-		describe('Active to Archived transition', () => {
-			test('should archive alert with resolved status when deleted', async () => {
+		describe('Active to Resolved transition', () => {
+			test('should resolve alert with resolved status when deleted', async () => {
 				// Create a new alert
 				const newAlertPayload = {
 					id: 'alert-to-delete',
@@ -1217,7 +1217,7 @@ describe('Alerts API', () => {
 				const activeRow = db.prepare('SELECT * FROM alerts WHERE id = ?').get(newAlertPayload.id);
 				expect(activeRow).toBeDefined();
 
-				// Delete the alert (this should archive it)
+				// Delete the alert (this should resolve it)
 				const deleteResponse = await app
 					.delete(`/api/v1/alerts/${newAlertPayload.id}`)
 					.set('Authorization', `Bearer ${jwtToken}`);
@@ -1229,34 +1229,34 @@ describe('Alerts API', () => {
 				const activeRowAfterDelete = db.prepare('SELECT * FROM alerts WHERE id = ?').get(newAlertPayload.id);
 				expect(activeRowAfterDelete).toBeUndefined();
 
-				// Verify alert is in archived alerts table with resolved status
-				const archivedRow = db
-					.prepare('SELECT * FROM alerts_archived WHERE id = ?')
+				// Verify alert is in resolved alerts table with resolved status
+				const resolvedRow = db
+					.prepare('SELECT * FROM alerts_resolved WHERE id = ?')
 					.get(newAlertPayload.id) as any;
-				expect(archivedRow).toBeDefined();
-				expect(archivedRow.id).toBe(newAlertPayload.id);
-				expect(archivedRow.status).toBe('resolved');
-				expect(archivedRow.alert_name).toBe(newAlertPayload.alertName);
-				expect(archivedRow.archived_at).toBeDefined();
+				expect(resolvedRow).toBeDefined();
+				expect(resolvedRow.id).toBe(newAlertPayload.id);
+				expect(resolvedRow.status).toBe('resolved');
+				expect(resolvedRow.alert_name).toBe(newAlertPayload.alertName);
+				expect(resolvedRow.archived_at).toBeDefined();
 			});
 		});
 
-		describe('DELETE /api/v1/alerts/archived/:id', () => {
-			test('should delete an archived alert successfully', async () => {
+		describe('DELETE /api/v1/alerts/resolved/:id', () => {
+			test('should delete a resolved alert successfully', async () => {
 				const response = await app
-					.delete(`/api/v1/alerts/archived/${testAlertsArchived[0].id}`)
+					.delete(`/api/v1/alerts/resolved/${testResolvedAlerts[0].id}`)
 					.set('Authorization', `Bearer ${jwtToken}`);
 
 				expect(response.status).toBe(200);
 				expect(response.body.success).toBe(true);
 
-				const row = db.prepare('SELECT * FROM alerts_archived WHERE id = ?').get('archived-del-1');
+				const row = db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get('resolved-del-1');
 
 				expect(row).toBeUndefined();
 			});
 
 			test('should return 401 when no auth token is provided', async () => {
-				const response = await app.delete('/api/v1/alerts/archived/some-id');
+				const response = await app.delete('/api/v1/alerts/resolved/some-id');
 
 				expect(response.status).toBe(401);
 				expect(response.body.success).toBe(false);

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1250,7 +1250,7 @@ describe('Alerts API', () => {
 				expect(response.status).toBe(200);
 				expect(response.body.success).toBe(true);
 
-				const row = db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get('resolved-del-1');
+				const row = db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get(testResolvedAlerts[0].id);
 
 				expect(row).toBeUndefined();
 			});

--- a/apps/server/tests/setup.ts
+++ b/apps/server/tests/setup.ts
@@ -15,7 +15,7 @@ import { ServiceCustomFieldRepository } from '../src/dal/serviceCustomFieldRepos
 import { ServiceCustomFieldValueRepository } from '../src/dal/serviceCustomFieldValueRepository.ts';
 import { PasswordResetsRepository } from '../src/dal/passwordResetsRepository.ts';
 import { CustomActionRepository } from '../src/dal/customActionRepository.ts';
-import { ArchivedAlertRepository } from '../src/dal/archivedAlertRepository.ts';
+import { ResolvedAlertRepository } from '../src/dal/resolvedAlertRepository.ts';
 
 // Mock the Kubernetes client to avoid ES module issues
 vi.mock('@kubernetes/client-node', () => ({
@@ -63,7 +63,7 @@ export async function setupDB(): Promise<Database.Database> {
 	const tagRepo = new TagRepository(db);
 	const integrationRepo = new IntegrationRepository(db);
 	const alertRepo = new AlertRepository(db);
-	const archivedAlertRepo = new ArchivedAlertRepository(db);
+	const resolvedAlertRepo = new ResolvedAlertRepository(db);
 	const userRepo = new UserRepository(db);
 	const auditLogRepo = new AuditLogRepository(db);
 	const secretsMetadataRepo = new SecretsMetadataRepository(db);
@@ -79,7 +79,7 @@ export async function setupDB(): Promise<Database.Database> {
 		dashboardRepo.initDashboardTable(),
 		tagRepo.initTagsTables(),
 		integrationRepo.initIntegrationsTable(),
-		archivedAlertRepo.initArchivedAlertsTable(), // should be prior to alertRepo.initAlertsTable()
+		resolvedAlertRepo.initResolvedAlertsTable(), // should be prior to alertRepo.initAlertsTable()
 		alertRepo.initAlertsTable(),
 		userRepo.initUsersTable(),
 		auditLogRepo.initAuditLogsTable(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -191,8 +191,8 @@ export interface Alert {
 	// Empty/undefined means the alert was not enriched. Not persisted.
 	appliedEnrichments?: AppliedEnrichment[];
 	// Transient: set client-side in the combined "All" view so a row knows it came from the
-	// archived list and can route its own actions. Not persisted.
-	isArchived?: boolean;
+	// resolved list and can route its own actions. Not persisted.
+	isResolved?: boolean;
 	ownerId?: string | null;
 }
 
@@ -487,10 +487,10 @@ export enum RetentionResource {
 	AuditLogs = 'audit_logs',
 	AlertHistoryEvents = 'alert_history_events',
 	AlertStatusHistory = 'alert_status_history',
-	// Active (non-archived) alerts. Aged by last-updated time, so stale alerts that never resolve
+	// Active (non-resolved) alerts. Aged by last-updated time, so stale alerts that never resolve
 	// (e.g. a source that stopped sending) get cleaned while genuinely-active ones are spared.
 	ActiveAlerts = 'active_alerts',
-	ArchivedAlerts = 'archived_alerts',
+	ResolvedAlerts = 'archived_alerts',
 	AlertComments = 'alert_comments',
 }
 


### PR DESCRIPTION
Renames the **archived-alerts** concept to **resolved** across the stack, mirroring the Silences → Mute Policies rename.

**Important:** the alert *status* (`AlertStatus.RESOLVED` / `FIRING`) is unchanged. This only renames the separate *archive store* — the place resolved alerts are moved to, its tab, and the action that moves them there.

## Server
- `ArchivedAlertRepository → ResolvedAlertRepository`; BL methods (`archiveAlert → resolveAlert`, `getAllArchivedAlerts → getAllResolvedAlerts`, `archiveNonActiveAlerts → resolveNonActiveAlerts`, `deleteArchivedAlert → deleteResolvedAlert`, …); controller + routes (`/alerts/archived → /alerts/resolved`).
- The `alerts_archived` table is renamed to `alerts_resolved` on startup, **guarded** so a rollback + re-upgrade (both tables present) can't crash on the `RENAME`.
- API response field `archived: true → resolved: true`.

## Client
- `AlertTab.Archived → Resolved`; hooks (`useArchivedAlerts → useResolvedAlerts`, `useDeleteArchivedAlert → useDeleteResolvedAlert`, `useSetArchivedAlertOwner → useSetResolvedAlertOwner`, `useArchivedTabStatusFilterReset → useResolvedTabStatusFilterReset`); api client; mocks; the transient `isArchived → isResolved` flag.
- UI: the **Archived** tab and **Archive** action become **Resolved** / **Resolve** with a check-circle icon; retention settings and the Zabbix/Custom/Grafana setup docs updated.

## Intentionally kept (to avoid data-loss / config migrations)
- The internal `archived_at` column name — renaming it needs a column migration for no user-visible gain.
- The retention config value `'archived_alerts'` (only its enum member renamed to `ResolvedAlerts`) — so existing retention rows don't orphan.
- SQLite trigger names (`archive_alert_history_on_*`) — invisible, no functional impact.

## Verification
- **112 server + 37 client tests pass**; both apps typecheck with no new errors (82 = pre-existing baseline).
- DB migration verified: carries rows over on a fresh upgrade, and is crash-safe when both tables exist.
- Browser-checked: the **Resolved** tab loads resolved alerts, the alert footer shows **Dismiss / Resolve**, and there's no "Archived" text anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the Archived alerts experience with a Resolved alerts workflow, including a new Resolved tab with counts, filtering, and updated row/bulk actions.
  * Added resolved alert listing, resolve ownership updates, delete/resolve bulk actions, and permanent deletion for resolved alerts.
  * Alerts from supported integrations now automatically resolve when recovered/cleared.
  * Added retention settings for resolved alerts and updated integration setup instructions/API examples to use resolve terminology.
* **Bug Fixes**
  * Improved refresh, routing, and optimistic update behavior for resolved alerts, including correct read-only handling and resolved list consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->