### PR TITLE
feat(alerts): unresolve — move resolved alerts back to firing

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel.tsx
@@ -22,6 +22,7 @@ interface AlertDetailsPanelProps {
 	onSilence?: (alertId: string) => void;
 	onUnsilence?: (alertId: string) => void;
 	onDelete?: (alertId: string) => void;
+	onUnresolve?: (alertId: string) => void;
 }
 
 export const AlertDetailsPanel = ({
@@ -32,6 +33,7 @@ export const AlertDetailsPanel = ({
 	onSilence,
 	onUnsilence,
 	onDelete,
+	onUnresolve,
 }: AlertDetailsPanelProps) => {
 	const historyData = useAlertHistory(alert.id);
 	const [tab, setTab] = useState('details');
@@ -81,6 +83,7 @@ export const AlertDetailsPanel = ({
 					onSilence={onSilence}
 					onUnsilence={onUnsilence}
 					onDelete={onDelete}
+					onUnresolve={onUnresolve}
 				/>
 			</div>
 		</div>

--- a/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/AlertFooterActions.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertFooterActions/AlertFooterActions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Alert } from '@OpsiMate/shared';
-import { BellOff, CheckCircle2, RotateCcw, Trash2 } from 'lucide-react';
+import { BellOff, CheckCircle2, Flame, RotateCcw, Trash2 } from 'lucide-react';
 
 interface AlertFooterActionsProps {
 	alert: Alert;
@@ -8,17 +8,31 @@ interface AlertFooterActionsProps {
 	onSilence?: (alertId: string) => void;
 	onUnsilence?: (alertId: string) => void;
 	onDelete?: (alertId: string) => void;
+	onUnresolve?: (alertId: string) => void;
 }
 
 // The alert's primary actions, pinned as a one-row footer at the bottom of the details
 // panel (outside the scroll area) so they're always reachable.
-export const AlertFooterActions = ({ alert, isActive, onSilence, onUnsilence, onDelete }: AlertFooterActionsProps) => {
+export const AlertFooterActions = ({
+	alert,
+	isActive,
+	onSilence,
+	onUnsilence,
+	onDelete,
+	onUnresolve,
+}: AlertFooterActionsProps) => {
 	if (!isActive) {
 		return (
-			<Button variant="destructive" size="sm" className="w-full gap-2" onClick={() => onDelete?.(alert.id)}>
-				<Trash2 className="h-3 w-3" />
-				Delete Alert
-			</Button>
+			<div className="grid grid-cols-2 gap-2">
+				<Button variant="outline" size="sm" className="gap-2" onClick={() => onUnresolve?.(alert.id)}>
+					<Flame className="h-3 w-3" />
+					Unresolve
+				</Button>
+				<Button variant="destructive" size="sm" className="gap-2" onClick={() => onDelete?.(alert.id)}>
+					<Trash2 className="h-3 w-3" />
+					Delete Alert
+				</Button>
+			</div>
 		);
 	}
 

--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
@@ -1,5 +1,5 @@
 import { AlertHistoryData, AlertHistoryEventType, AlertStatus } from '@OpsiMate/shared';
-import { Bell, BellOff, Flame, MessageSquare, RefreshCw, UserMinus, UserPlus, Zap } from 'lucide-react';
+import { Bell, BellOff, CheckCircle2, Flame, MessageSquare, RefreshCw, UserMinus, UserPlus, Zap } from 'lucide-react';
 import { ComponentType } from 'react';
 
 interface AlertHistoryTimelineProps {
@@ -49,6 +49,14 @@ const EVENT_STYLES: Record<Exclude<AlertHistoryEventType, AlertHistoryEventType.
 		dotClass: 'bg-rose-500',
 		textClass: 'text-rose-600 dark:text-rose-400',
 		Icon: Bell,
+	},
+	// A user manually resolved the alert (API/source-driven resolution renders as a
+	// STATUS_CHANGED "Resolved" entry instead, without an actor).
+	[AlertHistoryEventType.RESOLVED]: {
+		label: 'Resolved',
+		dotClass: 'bg-green-500',
+		textClass: 'text-green-600 dark:text-green-400',
+		Icon: CheckCircle2,
 	},
 	[AlertHistoryEventType.UNRESOLVED]: {
 		label: 'Unresolved',

--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
@@ -1,5 +1,5 @@
 import { AlertHistoryData, AlertHistoryEventType, AlertStatus } from '@OpsiMate/shared';
-import { Bell, BellOff, MessageSquare, RefreshCw, UserMinus, UserPlus, Zap } from 'lucide-react';
+import { Bell, BellOff, Flame, MessageSquare, RefreshCw, UserMinus, UserPlus, Zap } from 'lucide-react';
 import { ComponentType } from 'react';
 
 interface AlertHistoryTimelineProps {
@@ -49,6 +49,12 @@ const EVENT_STYLES: Record<Exclude<AlertHistoryEventType, AlertHistoryEventType.
 		dotClass: 'bg-rose-500',
 		textClass: 'text-rose-600 dark:text-rose-400',
 		Icon: Bell,
+	},
+	[AlertHistoryEventType.UNRESOLVED]: {
+		label: 'Unresolved',
+		dotClass: 'bg-red-500',
+		textClass: 'text-red-600 dark:text-red-400',
+		Icon: Flame,
 	},
 	[AlertHistoryEventType.ACTION_RUN]: {
 		label: 'Action run',

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -76,11 +76,13 @@ const Alerts = () => {
 
 	const currentAlertData =
 		activeTab === AlertTab.Active ? alerts : activeTab === AlertTab.Resolved ? resolvedAlerts : allAlerts;
+	// Sync against both lists (not just the active tab's) so the details panel follows the
+	// alert through resolve/unresolve transitions instead of freezing on its pre-action state.
 	const syncedSelectedAlert = useMemo(() => {
 		if (!selectedAlert) return null;
-		const updatedAlert = currentAlertData.find((alert) => alert.id === selectedAlert.id);
+		const updatedAlert = allAlerts.find((alert) => alert.id === selectedAlert.id);
 		return updatedAlert || selectedAlert;
-	}, [selectedAlert, currentAlertData]);
+	}, [selectedAlert, allAlerts]);
 
 	const shouldPauseRefresh = showDashboardSettings;
 
@@ -605,9 +607,10 @@ const Alerts = () => {
 
 					{syncedSelectedAlert &&
 						(() => {
-							const selectedIsResolved =
-								activeTab === AlertTab.Resolved ||
-								(activeTab === AlertTab.All && resolvedIds.has(syncedSelectedAlert.id));
+							// Data-driven (not tab-driven): resolving an alert while its panel is
+							// open flips the panel to resolved mode in place, and unresolving
+							// flips it back.
+							const selectedIsResolved = resolvedIds.has(syncedSelectedAlert.id);
 							return (
 								<AlertDetailsPanel
 									alert={syncedSelectedAlert}

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -200,6 +200,7 @@ const Alerts = () => {
 		handleSilenceAlert,
 		handleUnsilenceAlert,
 		handleDeleteAlert,
+		handleUnresolveAlert,
 		handleSilenceAll,
 		handleAssignOwnerAll,
 		handleResolveAll,
@@ -540,6 +541,7 @@ const Alerts = () => {
 									onSilenceAlert={undefined}
 									onUnsilenceAlert={undefined}
 									onDeleteAlert={handleDeleteResolvedAlert}
+									onUnresolveAlert={handleUnresolveAlert}
 									onSelectAlerts={undefined}
 									selectedAlerts={[]}
 									isLoading={isLoadingResolved}
@@ -577,6 +579,7 @@ const Alerts = () => {
 									onSilenceAlert={handleSilenceAlert}
 									onUnsilenceAlert={handleUnsilenceAlert}
 									onDeleteAlert={handleDeleteAnyAlert}
+									onUnresolveAlert={handleUnresolveAlert}
 									onSelectAlerts={undefined}
 									selectedAlerts={[]}
 									isLoading={isLoading || isLoadingResolved}
@@ -614,6 +617,7 @@ const Alerts = () => {
 									onSilence={handleSilenceAlert}
 									onUnsilence={handleUnsilenceAlert}
 									onDelete={selectedIsResolved ? handleDeleteResolvedAlert : handleDeleteAlert}
+									onUnresolve={handleUnresolveAlert}
 								/>
 							);
 						})()}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -27,6 +27,7 @@ export interface AlertRowProps {
 	onSilenceAlert?: (alertId: string) => void;
 	onUnsilenceAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
+	onUnresolveAlert?: (alertId: string) => void;
 	onSelectAlerts?: (alerts: Alert[]) => void;
 	isResolved?: boolean;
 	isDragging?: boolean;
@@ -47,6 +48,7 @@ export const AlertRow = ({
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
+	onUnresolveAlert,
 	onSelectAlerts,
 	isResolved = false,
 	isDragging = false,
@@ -150,6 +152,7 @@ export const AlertRow = ({
 								onSilenceAlert={onSilenceAlert}
 								onUnsilenceAlert={onUnsilenceAlert}
 								onDeleteAlert={onDeleteAlert}
+								onUnresolveAlert={onUnresolveAlert}
 							/>
 						);
 					default:

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertActionsColumn/AlertActionsColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertActionsColumn/AlertActionsColumn.tsx
@@ -9,6 +9,7 @@ export interface AlertActionsColumnProps {
 	onSilenceAlert?: (alertId: string) => void;
 	onUnsilenceAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
+	onUnresolveAlert?: (alertId: string) => void;
 }
 
 export const AlertActionsColumn = ({
@@ -16,6 +17,7 @@ export const AlertActionsColumn = ({
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
+	onUnresolveAlert,
 }: AlertActionsColumnProps) => {
 	return (
 		<TableCell
@@ -27,6 +29,7 @@ export const AlertActionsColumn = ({
 				onSilenceAlert={onSilenceAlert}
 				onUnsilenceAlert={onUnsilenceAlert}
 				onDeleteAlert={onDeleteAlert}
+				onUnresolveAlert={onUnresolveAlert}
 			/>
 		</TableCell>
 	);

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
@@ -7,17 +7,18 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Alert } from '@OpsiMate/shared';
-import { BellOff, Book, CheckCircle2, ExternalLink, MoreVertical, RotateCcw, Trash2 } from 'lucide-react';
+import { BellOff, Book, CheckCircle2, ExternalLink, Flame, MoreVertical, RotateCcw, Trash2 } from 'lucide-react';
 
 export interface RowActionsProps {
 	alert: Alert;
 	onSilenceAlert?: (alertId: string) => void;
 	onUnsilenceAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
+	onUnresolveAlert?: (alertId: string) => void;
 }
 
 // All row actions live in the three-dots menu — no standalone quick buttons.
-export const RowActions = ({ alert, onSilenceAlert, onUnsilenceAlert, onDeleteAlert }: RowActionsProps) => {
+export const RowActions = ({ alert, onSilenceAlert, onUnsilenceAlert, onDeleteAlert, onUnresolveAlert }: RowActionsProps) => {
 	const { alertUrl, runbookUrl, isSilenced } = alert;
 	// In the combined "All" view a row carries a transient isResolved flag so it can present
 	// resolved behaviour (permanent delete, no silence/resolve) even though the table-level
@@ -26,7 +27,10 @@ export const RowActions = ({ alert, onSilenceAlert, onUnsilenceAlert, onDeleteAl
 	const isActive = !isResolvedAlert && Boolean(onSilenceAlert);
 	const canToggleSilence =
 		!isResolvedAlert && ((!isSilenced && Boolean(onSilenceAlert)) || (isSilenced && Boolean(onUnsilenceAlert)));
-	const hasActions = Boolean(alertUrl || runbookUrl || onDeleteAlert || canToggleSilence);
+	// Only resolved rows can be moved back to firing (isActive is false on the Resolved tab
+	// and on resolved rows in the All view).
+	const canUnresolve = !isActive && Boolean(onUnresolveAlert);
+	const hasActions = Boolean(alertUrl || runbookUrl || onDeleteAlert || canToggleSilence || canUnresolve);
 
 	const handleToggleSilence = (event: React.MouseEvent) => {
 		event.stopPropagation();
@@ -44,6 +48,11 @@ export const RowActions = ({ alert, onSilenceAlert, onUnsilenceAlert, onDeleteAl
 	const handleDelete = (event: React.MouseEvent) => {
 		event.stopPropagation();
 		onDeleteAlert?.(alert.id);
+	};
+
+	const handleUnresolve = (event: React.MouseEvent) => {
+		event.stopPropagation();
+		onUnresolveAlert?.(alert.id);
 	};
 
 	if (!hasActions) return null;
@@ -85,7 +94,13 @@ export const RowActions = ({ alert, onSilenceAlert, onUnsilenceAlert, onDeleteAl
 							Source
 						</DropdownMenuItem>
 					)}
-					{(runbookUrl || alertUrl) && (onDeleteAlert || canToggleSilence) && <DropdownMenuSeparator />}
+					{(runbookUrl || alertUrl) && (onDeleteAlert || canToggleSilence || canUnresolve) && <DropdownMenuSeparator />}
+					{canUnresolve && (
+						<DropdownMenuItem onClick={handleUnresolve}>
+							<Flame className="mr-2 h-3 w-3" />
+							Unresolve
+						</DropdownMenuItem>
+					)}
 					{onDeleteAlert && (
 						<DropdownMenuItem
 							onClick={handleDelete}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
@@ -18,7 +18,13 @@ export interface RowActionsProps {
 }
 
 // All row actions live in the three-dots menu — no standalone quick buttons.
-export const RowActions = ({ alert, onSilenceAlert, onUnsilenceAlert, onDeleteAlert, onUnresolveAlert }: RowActionsProps) => {
+export const RowActions = ({
+	alert,
+	onSilenceAlert,
+	onUnsilenceAlert,
+	onDeleteAlert,
+	onUnresolveAlert,
+}: RowActionsProps) => {
 	const { alertUrl, runbookUrl, isSilenced } = alert;
 	// In the combined "All" view a row carries a transient isResolved flag so it can present
 	// resolved behaviour (permanent delete, no silence/resolve) even though the table-level
@@ -94,7 +100,9 @@ export const RowActions = ({ alert, onSilenceAlert, onUnsilenceAlert, onDeleteAl
 							Source
 						</DropdownMenuItem>
 					)}
-					{(runbookUrl || alertUrl) && (onDeleteAlert || canToggleSilence || canUnresolve) && <DropdownMenuSeparator />}
+					{(runbookUrl || alertUrl) && (onDeleteAlert || canToggleSilence || canUnresolve) && (
+						<DropdownMenuSeparator />
+					)}
 					{canUnresolve && (
 						<DropdownMenuItem onClick={handleUnresolve}>
 							<Flame className="mr-2 h-3 w-3" />

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -40,6 +40,7 @@ export const AlertsTable = ({
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
+	onUnresolveAlert,
 	onSelectAlerts,
 	selectedAlerts = [],
 	isLoading = false,
@@ -263,6 +264,7 @@ export const AlertsTable = ({
 									onSilenceAlert={onSilenceAlert}
 									onUnsilenceAlert={onUnsilenceAlert}
 									onDeleteAlert={onDeleteAlert}
+									onUnresolveAlert={onUnresolveAlert}
 									onSelectAlerts={onSelectAlerts}
 									columnLabels={allColumnLabels}
 									isResolved={isResolved}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -19,6 +19,7 @@ export interface AlertsTableProps {
 	onSilenceAlert?: (alertId: string) => void;
 	onUnsilenceAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
+	onUnresolveAlert?: (alertId: string) => void;
 	onSelectAlerts?: (alerts: Alert[]) => void;
 	selectedAlerts?: Alert[];
 	isLoading?: boolean;

--- a/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
@@ -18,6 +18,7 @@ interface VirtualizedAlertListProps {
 	onSilenceAlert?: (alertId: string) => void;
 	onUnsilenceAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
+	onUnresolveAlert?: (alertId: string) => void;
 	onSelectAlerts?: (alerts: Alert[]) => void;
 	columnLabels?: Record<string, string>;
 	isResolved?: boolean;
@@ -41,6 +42,7 @@ export const VirtualizedAlertList = ({
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
+	onUnresolveAlert,
 	onSelectAlerts,
 	columnLabels,
 	isResolved = false,
@@ -119,6 +121,7 @@ export const VirtualizedAlertList = ({
 									onSilenceAlert={onSilenceAlert}
 									onUnsilenceAlert={onUnsilenceAlert}
 									onDeleteAlert={onDeleteAlert}
+									onUnresolveAlert={onUnresolveAlert}
 									onSelectAlerts={onSelectAlerts}
 									isResolved={isResolved}
 									severityColors={severityColors}

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -3,6 +3,7 @@ import {
 	useDeleteResolvedAlert,
 	useSilenceAlert,
 	useSetAlertOwner,
+	useUnresolveAlert,
 	useUnsilenceAlert,
 } from '@/hooks/queries/alerts';
 import { useToast } from '@/hooks/use-toast';
@@ -14,6 +15,7 @@ export const useAlertActions = () => {
 	const deleteAlertMutation = useDeleteAlert();
 	const setAlertOwnerMutation = useSetAlertOwner();
 	const deleteResolvedAlertMutation = useDeleteResolvedAlert();
+	const unresolveAlertMutation = useUnresolveAlert();
 	const { toast } = useToast();
 
 	const handleSilenceAlert = async (alertId: string) => {
@@ -51,6 +53,22 @@ export const useAlertActions = () => {
 			toast({
 				title: 'Error deleting alert',
 				description: 'Failed to delete alert',
+				variant: 'destructive',
+			});
+		}
+	};
+
+	const handleUnresolveAlert = async (alertId: string) => {
+		try {
+			await unresolveAlertMutation.mutateAsync(alertId);
+			toast({
+				title: 'Alert unresolved',
+				description: 'The alert was moved back to firing.',
+			});
+		} catch (error) {
+			toast({
+				title: 'Error unresolving alert',
+				description: 'Failed to move the alert back to firing',
 				variant: 'destructive',
 			});
 		}
@@ -149,6 +167,7 @@ export const useAlertActions = () => {
 		handleSilenceAlert,
 		handleUnsilenceAlert,
 		handleDeleteAlert,
+		handleUnresolveAlert,
 		handleSilenceAll,
 		handleAssignOwnerAll,
 		handleResolveAll,

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -42,17 +42,19 @@ export const useAlertActions = () => {
 		}
 	};
 
+	// Deleting an active alert IS resolving it (permanent delete only exists for resolved
+	// alerts), so the feedback speaks in resolve terms.
 	const handleDeleteAlert = async (alertId: string) => {
 		try {
 			await deleteAlertMutation.mutateAsync(alertId);
 			toast({
-				title: 'Alert deleted',
-				description: 'The alert has been permanently removed.',
+				title: 'Alert resolved',
+				description: 'The alert was moved to Resolved.',
 			});
 		} catch (error) {
 			toast({
-				title: 'Error deleting alert',
-				description: 'Failed to delete alert',
+				title: 'Error resolving alert',
+				description: 'Failed to resolve alert',
 				variant: 'destructive',
 			});
 		}

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -51,7 +51,7 @@ export const useAlertActions = () => {
 				title: 'Alert resolved',
 				description: 'The alert was moved to Resolved.',
 			});
-		} catch (error) {
+		} catch {
 			toast({
 				title: 'Error resolving alert',
 				description: 'Failed to resolve alert',
@@ -67,7 +67,7 @@ export const useAlertActions = () => {
 				title: 'Alert unresolved',
 				description: 'The alert was moved back to firing.',
 			});
-		} catch (error) {
+		} catch {
 			toast({
 				title: 'Error unresolving alert',
 				description: 'Failed to move the alert back to firing',

--- a/apps/client/src/hooks/queries/alerts/index.ts
+++ b/apps/client/src/hooks/queries/alerts/index.ts
@@ -2,6 +2,7 @@ export { useAlerts } from './useAlerts';
 export { useResolvedAlerts } from './useResolvedAlerts';
 export { useDeleteAlert } from './useDeleteAlert';
 export { useDeleteResolvedAlert } from './useDeleteResolvedAlert';
+export { useUnresolveAlert } from './useUnresolveAlert';
 export { useSilenceAlert } from './useSilenceAlert';
 export { useMarkAlertRead } from './useMarkAlertRead';
 export { useUnsilenceAlert } from './useUnsilenceAlert';

--- a/apps/client/src/hooks/queries/alerts/useUnresolveAlert.ts
+++ b/apps/client/src/hooks/queries/alerts/useUnresolveAlert.ts
@@ -1,0 +1,46 @@
+import { alertsApi } from '@/lib/api';
+import { Alert } from '@OpsiMate/shared';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+// Moves a resolved alert back to the active (firing) list — the reverse of resolving.
+export const useUnresolveAlert = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (alertId: string) => {
+			const response = await alertsApi.unresolveAlert(alertId);
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to unresolve alert');
+			}
+			return response.data;
+		},
+		onMutate: async (alertId: string) => {
+			// Cancel any outgoing refetches to avoid overwriting our optimistic update
+			await queryClient.cancelQueries({ queryKey: queryKeys.resolvedAlerts });
+
+			// Snapshot the previous value
+			const previousAlerts = queryClient.getQueryData<Alert[]>(queryKeys.resolvedAlerts);
+
+			// Optimistically remove the alert from the resolved list
+			queryClient.setQueryData<Alert[]>(queryKeys.resolvedAlerts, (old) => {
+				if (!old) return [];
+				return old.filter((alert) => alert.id !== alertId);
+			});
+
+			// Return a context object with the snapshotted value
+			return { previousAlerts };
+		},
+		onError: (err, alertId, context) => {
+			// If the mutation fails, use the context returned from onMutate to roll back
+			if (context?.previousAlerts) {
+				queryClient.setQueryData(queryKeys.resolvedAlerts, context.previousAlerts);
+			}
+		},
+		onSettled: () => {
+			// Always refetch after error or success: the alert left one list and joined the other
+			queryClient.invalidateQueries({ queryKey: queryKeys.resolvedAlerts });
+			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+		},
+	});
+};

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -610,6 +610,11 @@ export const alertsApi = {
 		return await apiRequest<void>(`/alerts/resolved/${alertId}`, 'DELETE');
 	},
 
+	// Move a resolved alert back to the active (firing) list
+	async unresolveAlert(alertId: string): Promise<ApiResponse<{ alert: SharedAlert }>> {
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/resolved/${alertId}/unresolve`, 'PATCH');
+	},
+
 	// Set alert owner
 	async setAlertOwner(alertId: string, ownerId: string | null): Promise<ApiResponse<{ alert: SharedAlert }>> {
 		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/owner`, 'PATCH', { ownerId });

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -224,6 +224,31 @@ export const handlers = [
 		return HttpResponse.json({ success: true, message: 'Alert deleted successfully' });
 	}),
 
+	http.patch(`${API_BASE}/alerts/resolved/:alertId/unresolve`, ({ params }) => {
+		const alertId = params.alertId as string;
+		const alertIndex = playgroundState.resolvedAlerts.findIndex((a) => a.id === alertId);
+
+		if (alertIndex === -1) {
+			return HttpResponse.json({ success: false, error: 'Resolved alert not found' }, { status: 404 });
+		}
+
+		const alert = { ...playgroundState.resolvedAlerts[alertIndex] };
+		alert.status = AlertStatus.FIRING;
+		alert.isRead = false;
+		alert.updatedAt = nowIso();
+
+		playgroundState.resolvedAlerts.splice(alertIndex, 1);
+		playgroundState.alerts.unshift(alert);
+		pushAlertEvent(alertId, {
+			date: nowIso(),
+			eventType: AlertHistoryEventType.UNRESOLVED,
+			actorName: PLAYGROUND_ACTOR,
+			description: 'Alert moved back to firing',
+		});
+
+		return HttpResponse.json({ success: true, data: { alert } });
+	}),
+
 	http.delete(`${API_BASE}/alerts/resolved/:alertId`, ({ params }) => {
 		const alertId = params.alertId as string;
 		playgroundState.resolvedAlerts = playgroundState.resolvedAlerts.filter((a) => a.id !== alertId);

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -224,6 +224,13 @@ export const handlers = [
 
 		playgroundState.alerts.splice(alertIndex, 1);
 		playgroundState.resolvedAlerts.unshift(alert);
+		// The playground "Resolve" action is always a manual resolve by the playground user.
+		pushAlertEvent(alertId, {
+			date: nowIso(),
+			eventType: AlertHistoryEventType.RESOLVED,
+			actorName: PLAYGROUND_ACTOR,
+			description: 'Alert resolved manually',
+		});
 
 		return HttpResponse.json({ success: true, message: 'Alert deleted successfully' });
 	}),

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -216,6 +216,10 @@ export const handlers = [
 		}
 
 		const alert = { ...playgroundState.alerts[alertIndex] };
+		// Resolving pins the status and clears silence — an alert is either silenced or
+		// resolved, never both.
+		alert.status = AlertStatus.RESOLVED;
+		alert.isSilenced = false;
 		alert.updatedAt = nowIso();
 
 		playgroundState.alerts.splice(alertIndex, 1);
@@ -234,6 +238,7 @@ export const handlers = [
 
 		const alert = { ...playgroundState.resolvedAlerts[alertIndex] };
 		alert.status = AlertStatus.FIRING;
+		alert.isSilenced = false;
 		alert.isRead = false;
 		alert.updatedAt = nowIso();
 

--- a/apps/client/src/mocks/state.ts
+++ b/apps/client/src/mocks/state.ts
@@ -409,11 +409,12 @@ const seedAlerts = () => {
 	}));
 };
 
+// An alert is either silenced or resolved, never both — resolved seeds are always unsilenced.
 const createResolvedAlerts = (alerts: Alert[]) =>
 	alerts.slice(0, 20).map((alert, index) => ({
 		...alert,
 		id: `resolved-${alert.id}-${index}`,
-		isSilenced: true,
+		isSilenced: false,
 		status: AlertStatus.RESOLVED,
 		updatedAt: new Date(Date.now() - 1000 * 60 * 60 * (index + 1)).toISOString(),
 	}));

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -504,6 +504,23 @@ export class AlertController {
 		}
 	}
 
+	async unresolveAlert(req: AuthenticatedRequest, res: Response) {
+		try {
+			const alertId = req.params.id;
+			if (!alertId) {
+				return res.status(400).json({ success: false, error: 'Alert id is required' });
+			}
+			const alert = await this.alertBL.unresolveAlert(alertId, req.user?.fullName);
+			if (!alert) {
+				return res.status(404).json({ success: false, error: 'Resolved alert not found' });
+			}
+			return res.json({ success: true, data: { alert } });
+		} catch (error) {
+			logger.error('Error unresolving alert:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
 	async deleteResolvedAlert(req: Request, res: Response) {
 		try {
 			const alertId = req.params.alertId;

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -480,13 +480,15 @@ export class AlertController {
 		}
 	}
 
-	async deleteAlert(req: Request, res: Response) {
+	async deleteAlert(req: AuthenticatedRequest, res: Response) {
 		try {
 			const alertId = req.params.alertId;
 			if (alertId.length < 1) {
 				return res.status(400).json({ success: false, error: 'Invalid alert ID' });
 			}
-			await this.alertBL.resolveAlert(alertId);
+			// This endpoint is the UI's "Resolve" action — a manual resolve, recorded with
+			// the acting user (unlike the integration webhooks, which resolve without one).
+			await this.alertBL.resolveAlert(alertId, req.user?.fullName ?? null);
 			return res.json({ success: true, message: 'Alert deleted successfully' });
 		} catch (error) {
 			logger.error('Error deleting alert:', error);

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -12,6 +12,7 @@ export default function createAlertRouter(controller: AlertController) {
 	router.get('/resolved', controller.getResolvedAlerts.bind(controller));
 	router.delete('/resolved/:alertId', controller.deleteResolvedAlert.bind(controller));
 	router.patch('/resolved/:id/owner', controller.setResolvedAlertOwner.bind(controller));
+	router.patch('/resolved/:id/unresolve', controller.unresolveAlert.bind(controller));
 
 	// Delete alert (parameterized route must come after specific routes)
 	router.delete('/:alertId', controller.deleteAlert.bind(controller));

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -238,6 +238,9 @@ export class AlertBL {
 				status: AlertStatus.FIRING,
 				// Resolving cleared any silence, so the alert always comes back audible.
 				isSilenced: false,
+				// Restored as unread (matches the is_read = 0 the repository writes) so the
+				// returned alert renders with the unread treatment without waiting for a refetch.
+				isRead: false,
 				updatedAt: new Date().toISOString(),
 			};
 

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -209,6 +209,40 @@ export class AlertBL {
 		}
 	}
 
+	// Moves a resolved alert back to the active table as firing — the reverse of resolveAlert.
+	async unresolveAlert(alertId: string, actorName?: string | null): Promise<Alert | null> {
+		try {
+			logger.info(`Unresolving alert with id: ${alertId}`);
+
+			const resolved = await this.resolvedAlertRepo.getResolvedAlert(alertId);
+			if (!resolved) {
+				logger.warn(`Resolved alert with id ${alertId} not found, nothing to unresolve`);
+				return null;
+			}
+
+			const alert: Alert = {
+				...resolved,
+				status: AlertStatus.FIRING,
+				updatedAt: new Date().toISOString(),
+			};
+
+			await this.alertRepo.restoreAlert(alert);
+			await this.resolvedAlertRepo.deleteResolvedAlert(alertId);
+			await this.recordHistoryEvent(
+				alertId,
+				AlertHistoryEventType.UNRESOLVED,
+				'Alert moved back to firing',
+				actorName
+			);
+
+			logger.info(`Unresolved alert ${alertId}`);
+			return alert;
+		} catch (error) {
+			logger.error(`Error unresolving alert ${alertId}`, error);
+			throw error;
+		}
+	}
+
 	async deleteResolvedAlert(alertId: string): Promise<void> {
 		try {
 			logger.info(`Permanently deleting resolved alert with id: ${alertId}`);

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -164,7 +164,11 @@ export class AlertBL {
 		}
 	}
 
-	async resolveAlert(activeAlertId: string): Promise<void> {
+	// manualActorName differentiates the two resolve flows: pass it (even as null) when a user
+	// resolved the alert from the UI — a RESOLVED history event is recorded with their name.
+	// Leave it undefined for API-driven resolution (a source reporting the alert as recovered),
+	// which only gets the automatic status-transition entry.
+	async resolveAlert(activeAlertId: string, manualActorName?: string | null): Promise<void> {
 		try {
 			logger.info(`Resolving alert with id: ${activeAlertId}`);
 
@@ -180,6 +184,15 @@ export class AlertBL {
 
 			// Remove from active table
 			await this.alertRepo.deleteAlert(activeAlertId);
+
+			if (manualActorName !== undefined) {
+				await this.recordHistoryEvent(
+					activeAlertId,
+					AlertHistoryEventType.RESOLVED,
+					'Alert resolved manually',
+					manualActorName
+				);
+			}
 
 			logger.info(`Resolved alert ${activeAlertId}`);
 		} catch (error) {
@@ -265,19 +278,32 @@ export class AlertBL {
 			this.alertHistoryRepo.getEvents(alertId),
 		]);
 
-		const statusEntries: AlertHistoryData[] = statusHistory.data.map((entry) => ({
-			...entry,
-			date: toIsoUtc(entry.date),
-			eventType: AlertHistoryEventType.STATUS_CHANGED,
-			description: entry.status === AlertStatus.FIRING ? 'Alert started firing' : 'Alert resolved',
-		}));
-
 		const eventEntries: AlertHistoryData[] = events.map((row) => ({
 			date: toIsoUtc(row.created_at),
 			eventType: row.event_type as AlertHistoryEventType,
 			actorName: row.actor_name ?? undefined,
 			description: row.description ?? undefined,
 		}));
+
+		// A manual resolve records a RESOLVED event (with the acting user) AND fires the
+		// automatic status trigger. Suppress the trigger's entry when a manual-resolve event
+		// sits right next to it, so the timeline shows one entry per resolve — with the actor
+		// for manual resolves, without one for API/source-driven resolution.
+		const manualResolveTimes = eventEntries
+			.filter((e) => e.eventType === AlertHistoryEventType.RESOLVED)
+			.map((e) => new Date(e.date).getTime());
+		const coveredByManualResolve = (entry: { date: string; status?: AlertStatus }): boolean =>
+			entry.status !== AlertStatus.FIRING &&
+			manualResolveTimes.some((t) => Math.abs(t - new Date(toIsoUtc(entry.date)).getTime()) < 10_000);
+
+		const statusEntries: AlertHistoryData[] = statusHistory.data
+			.filter((entry) => !coveredByManualResolve(entry))
+			.map((entry) => ({
+				...entry,
+				date: toIsoUtc(entry.date),
+				eventType: AlertHistoryEventType.STATUS_CHANGED,
+				description: entry.status === AlertStatus.FIRING ? 'Alert started firing' : 'Alert resolved',
+			}));
 
 		const data = [...statusEntries, ...eventEntries].sort(
 			(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -223,6 +223,8 @@ export class AlertBL {
 			const alert: Alert = {
 				...resolved,
 				status: AlertStatus.FIRING,
+				// Resolving cleared any silence, so the alert always comes back audible.
+				isSilenced: false,
 				updatedAt: new Date().toISOString(),
 			};
 

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -57,9 +57,7 @@ export class AlertRepository {
 				// (timestamp matching won't do: legacy trigger versions stamp CURRENT_TIMESTAMP
 				// while newer ones stamp starts_at).
 				const { maxRowId } = this.db
-					.prepare(
-						`SELECT COALESCE(MAX(rowid), 0) AS maxRowId FROM alerts_history WHERE alert_id = ?`
-					)
+					.prepare(`SELECT COALESCE(MAX(rowid), 0) AS maxRowId FROM alerts_history WHERE alert_id = ?`)
 					.get(alert.id) as { maxRowId: number };
 
 				this.db
@@ -89,9 +87,7 @@ export class AlertRepository {
 						alert.ownerId != null ? Number(alert.ownerId) : null
 					);
 
-				this.db
-					.prepare(`DELETE FROM alerts_history WHERE alert_id = ? AND rowid > ?`)
-					.run(alert.id, maxRowId);
+				this.db.prepare(`DELETE FROM alerts_history WHERE alert_id = ? AND rowid > ?`).run(alert.id, maxRowId);
 			});
 			restore();
 		});

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -49,46 +49,51 @@ export class AlertRepository {
 	// (owner, silence state, created_at) and marking it unread so it surfaces as new.
 	async restoreAlert(alert: SharedAlert): Promise<void> {
 		return runAsync(() => {
-			this.db
-				.prepare(
+			const restore = this.db.transaction(() => {
+				// The alerts insert trigger records a "firing" status entry for every insert.
+				// The alert's original firing was already recorded, and unresolve logs its own
+				// UNRESOLVED event — so whatever the trigger writes for this re-insert is
+				// noise. Snapshot the history high-water mark and delete past it afterwards
+				// (timestamp matching won't do: legacy trigger versions stamp CURRENT_TIMESTAMP
+				// while newer ones stamp starts_at).
+				const { maxRowId } = this.db
+					.prepare(
+						`SELECT COALESCE(MAX(rowid), 0) AS maxRowId FROM alerts_history WHERE alert_id = ?`
+					)
+					.get(alert.id) as { maxRowId: number };
+
+				this.db
+					.prepare(
+						`
+						INSERT INTO alerts (id, status, type, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed, is_read, created_at, owner_id)
+						VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+						ON CONFLICT(id) DO UPDATE SET
+													  status=excluded.status,
+													  updated_at=excluded.updated_at
 					`
-					INSERT INTO alerts (id, status, type, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed, is_read, created_at, owner_id)
-					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
-					ON CONFLICT(id) DO UPDATE SET
-												  status=excluded.status,
-												  updated_at=excluded.updated_at
-				`
-				)
-				.run(
-					alert.id,
-					alert.status,
-					alert.type,
-					alert.severity,
-					JSON.stringify(alert.tags ?? {}),
-					alert.startsAt,
-					alert.updatedAt,
-					alert.alertUrl,
-					alert.alertName,
-					alert.summary || null,
-					alert.runbookUrl || null,
-					alert.isSilenced ? 1 : 0,
-					alert.createdAt,
-					alert.ownerId != null ? Number(alert.ownerId) : null
-				);
-			// The insert trigger re-records "firing @ starts_at", which the alert's original
-			// insert already recorded — drop exact status-history duplicates so the timeline
-			// doesn't show the same transition twice.
-			this.db
-				.prepare(
-					`
-					DELETE FROM alerts_history
-					WHERE alert_id = ?
-					  AND rowid NOT IN (
-						SELECT MIN(rowid) FROM alerts_history WHERE alert_id = ? GROUP BY status, archived_at
-					  )
-				`
-				)
-				.run(alert.id, alert.id);
+					)
+					.run(
+						alert.id,
+						alert.status,
+						alert.type,
+						alert.severity,
+						JSON.stringify(alert.tags ?? {}),
+						alert.startsAt,
+						alert.updatedAt,
+						alert.alertUrl,
+						alert.alertName,
+						alert.summary || null,
+						alert.runbookUrl || null,
+						alert.isSilenced ? 1 : 0,
+						alert.createdAt,
+						alert.ownerId != null ? Number(alert.ownerId) : null
+					);
+
+				this.db
+					.prepare(`DELETE FROM alerts_history WHERE alert_id = ? AND rowid > ?`)
+					.run(alert.id, maxRowId);
+			});
+			restore();
 		});
 	}
 

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -45,6 +45,53 @@ export class AlertRepository {
 		});
 	}
 
+	// Puts a previously-resolved alert back in the active table, keeping its identity
+	// (owner, silence state, created_at) and marking it unread so it surfaces as new.
+	async restoreAlert(alert: SharedAlert): Promise<void> {
+		return runAsync(() => {
+			this.db
+				.prepare(
+					`
+					INSERT INTO alerts (id, status, type, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed, is_read, created_at, owner_id)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+					ON CONFLICT(id) DO UPDATE SET
+												  status=excluded.status,
+												  updated_at=excluded.updated_at
+				`
+				)
+				.run(
+					alert.id,
+					alert.status,
+					alert.type,
+					alert.severity,
+					JSON.stringify(alert.tags ?? {}),
+					alert.startsAt,
+					alert.updatedAt,
+					alert.alertUrl,
+					alert.alertName,
+					alert.summary || null,
+					alert.runbookUrl || null,
+					alert.isSilenced ? 1 : 0,
+					alert.createdAt,
+					alert.ownerId != null ? Number(alert.ownerId) : null
+				);
+			// The insert trigger re-records "firing @ starts_at", which the alert's original
+			// insert already recorded — drop exact status-history duplicates so the timeline
+			// doesn't show the same transition twice.
+			this.db
+				.prepare(
+					`
+					DELETE FROM alerts_history
+					WHERE alert_id = ?
+					  AND rowid NOT IN (
+						SELECT MIN(rowid) FROM alerts_history WHERE alert_id = ? GROUP BY status, archived_at
+					  )
+				`
+				)
+				.run(alert.id, alert.id);
+		});
+	}
+
 	async initAlertsTable(): Promise<void> {
 		return runAsync(() => {
 			this.db.exec(`

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -120,7 +120,8 @@ export class ResolvedAlertRepository {
 				alert.updatedAt,
 				alert.alertUrl,
 				alert.alertName,
-				alert.isSilenced ? 1 : 0,
+				// Resolving clears silence: an alert is either silenced or resolved, never both.
+				0,
 				alert.summary || null,
 				alert.runbookUrl || null,
 				alert.createdAt,
@@ -135,7 +136,9 @@ export class ResolvedAlertRepository {
 		const tags = row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {};
 		return {
 			id: row.id,
-			status: row.status == 'firing' ? AlertStatus.FIRING : AlertStatus.RESOLVED,
+			// Everything in this table is resolved by definition, whatever status the row
+			// carried when it was written.
+			status: AlertStatus.RESOLVED,
 			// Legacy rows (pre-severity column) fall back to their severity tag, then the default.
 			severity: normalizeAlertSeverity(row.severity ?? tags['severity']),
 			tags,
@@ -147,7 +150,9 @@ export class ResolvedAlertRepository {
 			summary: row.summary,
 			runbookUrl: row.runbook_url,
 			createdAt: row.created_at,
-			isSilenced: row.is_dismissed ? true : false,
+			// Resolved alerts are never silenced (legacy rows may still carry is_dismissed=1
+			// from before resolving cleared the flag).
+			isSilenced: false,
 			ownerId: row.owner_id != null ? String(row.owner_id) : null,
 		};
 	};

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -21,6 +21,17 @@ export class ResolvedAlertRepository {
 				this.db.prepare(`ALTER TABLE alerts_archived RENAME TO alerts_resolved`).run();
 			}
 
+			// The rename can leave the status-history triggers attached to the old table name,
+			// where they never fire (and CREATE TRIGGER IF NOT EXISTS below won't replace them,
+			// because the trigger *names* still exist). Drop the stale ones so they're recreated
+			// on alerts_resolved.
+			const staleTriggers = this.db
+				.prepare(`SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'alerts_archived'`)
+				.all() as { name: string }[];
+			for (const trigger of staleTriggers) {
+				this.db.prepare(`DROP TRIGGER IF EXISTS "${trigger.name}"`).run();
+			}
+
 			this.db.exec(
 				`
 						CREATE TABLE IF NOT EXISTS alerts_resolved (
@@ -64,6 +75,21 @@ export class ResolvedAlertRepository {
 						END;
 						`
 			);
+
+			// Backfill: rows resolved while the triggers were stale never got their 'resolved'
+			// status-history entry. Add one (stamped with the resolve time) where it's missing.
+			this.db
+				.prepare(
+					`
+					INSERT INTO alerts_history (alert_id, status, archived_at)
+					SELECT r.id, 'resolved', r.archived_at
+					FROM alerts_resolved r
+					WHERE NOT EXISTS (
+						SELECT 1 FROM alerts_history h WHERE h.alert_id = r.id AND h.status = 'resolved'
+					)
+				`
+				)
+				.run();
 
 			// Backward compatibility: ensure tags column exists
 			const columns = this.db.prepare(`PRAGMA table_info(alerts_resolved)`).all() as TableInfoRow[];

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -152,6 +152,15 @@ export class ResolvedAlertRepository {
 		};
 	};
 
+	async getResolvedAlert(alertId: string): Promise<SharedAlert | null> {
+		return runAsync(() => {
+			const row = this.db.prepare('SELECT * FROM alerts_resolved WHERE id = ?').get(alertId) as
+				| ResolvedAlertRow
+				| undefined;
+			return row ? this.toSharedAlert(row) : null;
+		});
+	}
+
 	async getAllResolvedAlerts(): Promise<SharedAlert[]> {
 		return runAsync(() => {
 			const stmt = this.db.prepare('SELECT * FROM alerts_resolved ORDER BY archived_at DESC');

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -217,6 +217,9 @@ export enum AlertHistoryEventType {
 	// existing history rows keep resolving to these events.
 	SILENCED = 'dismissed',
 	UNSILENCED = 'undismissed',
+	// A user manually resolved the alert. API-driven resolution (the source reporting the
+	// alert as recovered) shows up as an automatic STATUS_CHANGED entry instead.
+	RESOLVED = 'resolved',
 	UNRESOLVED = 'unresolved',
 	ACTION_RUN = 'action_run',
 	COMMENT_ADDED = 'comment_added',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -217,6 +217,7 @@ export enum AlertHistoryEventType {
 	// existing history rows keep resolving to these events.
 	SILENCED = 'dismissed',
 	UNSILENCED = 'undismissed',
+	UNRESOLVED = 'unresolved',
 	ACTION_RUN = 'action_run',
 	COMMENT_ADDED = 'comment_added',
 }


### PR DESCRIPTION
## What

Adds the ability to take a resolved alert back to firing (the reverse of resolving).

## How it works

**Server**
- `PATCH /api/v1/alerts/resolved/:id/unresolve` — looks up the resolved alert, re-inserts it into the active `alerts` table as **firing** and **unread** (owner, silence state, tags, and timestamps preserved), deletes it from `alerts_resolved`, and records an `unresolved` history event with the acting user's name.
- The `alerts` insert trigger re-records "firing @ starts_at", which the alert's original insert already recorded — exact status-history duplicates are dropped so the timeline doesn't show the same transition twice.
- New `AlertHistoryEventType.UNRESOLVED = 'unresolved'` in shared types.

**Client**
- **Row menu**: resolved rows (Resolved tab and resolved rows in the All view) get an *Unresolve* item (flame icon) above *Delete*.
- **Details footer**: resolved alerts now show *Unresolve* next to *Delete Alert*.
- **History timeline**: the move renders as a red **Unresolved — "Alert moved back to firing"** entry.
- `useUnresolveAlert` mutation with optimistic removal from the resolved list, invalidating both alert lists; success/error toasts.
- Playground (MSW) handler mirrors the server behavior.

## Verification

- Real-server E2E on a scratch DB: create → resolve → unresolve. Alert returns to active as firing/unread, leaves the resolved list, history reads `Firing → Resolved → Unresolved (by actor)` with no duplicate firing entries; unknown id → 404.
- Playground browser run: menu shows Runbook/Source/Unresolve/Delete, alert moves Resolved→Active, red Unresolved timeline entry, footer shows Unresolve + Delete Alert.
- Type-error baselines unchanged (client 82 pre-existing, server 9 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Unresolve** action for resolved alerts from both alert rows and the alert details panel.
  * Unresolved alerts return to the active alerts list, with the resolved/unresolved state reflected in the details view.
  * Unresolve actions (and resolve-style delete actions) now show success/error notifications.
  * Alert history now supports and displays **Unresolved** and **Resolved** events.
* **Bug Fixes**
  * Improved alert timeline rendering to avoid duplicate resolve entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->