### PR TITLE
feat(oncall): on-call page with team rotation and user phone numbers

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -17,6 +17,7 @@ import {
 	Register,
 	Settings,
 	MutePolicies,
+	Oncall,
 	TVMode,
 } from '@/pages';
 import { isPlaygroundMode } from '@/lib/playground';
@@ -72,6 +73,7 @@ const App: React.FC = () => {
 										<Route path="/register" element={<Register />} />
 										<Route path="/alerts" element={<Alerts />} />
 										<Route path="/mute-policies" element={<MutePolicies />} />
+										<Route path="/oncall" element={<Oncall />} />
 										<Route path="/actions" element={<Actions />} />
 										<Route path="/enrichments" element={<Enrichments />} />
 										<Route path="/alerts/tv-mode" element={<AlertsTVMode />} />

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
@@ -1,5 +1,5 @@
 import { AlertHistory, Alert as SharedAlert } from '@OpsiMate/shared';
-import { Clock, FileText, Link2, Tag } from 'lucide-react';
+import { Clock, FileText, Link2, PhoneCall, Tag } from 'lucide-react';
 import { TimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.types';
 import { hasAlertTags } from '../../utils/alertTags.utils';
 import { AlertActionsSection } from '../AlertActionsSection';
@@ -9,6 +9,7 @@ import { AlertLastCommentSection } from '../AlertLastCommentSection';
 import { AlertLinksSection } from '../AlertLinksSection';
 import { AlertSummarySection } from '../AlertSummarySection';
 import { AlertTagsSection } from '../AlertTagsSection';
+import { AlertTeamSection } from '../AlertTeamSection';
 import { AlertTimestampsSection } from '../AlertTimestampsSection';
 import { CollapsibleSection } from '../CollapsibleSection';
 
@@ -33,6 +34,12 @@ export const AlertDetailsBody = ({ alert, historyData, timeRange, onViewAllComme
 			{alert.summary && (
 				<CollapsibleSection title="Summary" icon={<FileText className="h-3.5 w-3.5" />} defaultOpen>
 					<AlertSummarySection summary={alert.summary} />
+				</CollapsibleSection>
+			)}
+
+			{alert.team && (
+				<CollapsibleSection title="Team" icon={<PhoneCall className="h-3.5 w-3.5" />} defaultOpen>
+					<AlertTeamSection team={alert.team} />
 				</CollapsibleSection>
 			)}
 

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
@@ -38,7 +38,7 @@ export const AlertDetailsBody = ({ alert, historyData, timeRange, onViewAllComme
 			)}
 
 			{alert.team && (
-				<CollapsibleSection title="Team" icon={<PhoneCall className="h-3.5 w-3.5" />} defaultOpen>
+				<CollapsibleSection title="Team" icon={<PhoneCall className="h-3.5 w-3.5" />} defaultOpen={false}>
 					<AlertTeamSection team={alert.team} />
 				</CollapsibleSection>
 			)}

--- a/apps/client/src/components/Alerts/AlertDetails/AlertTeamSection/AlertTeamSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertTeamSection/AlertTeamSection.tsx
@@ -8,8 +8,8 @@ interface AlertTeamSectionProps {
 	team: string;
 }
 
-// Shows the alert's owning team and who is on call for it right now (priority 1 of the
-// matching on-call team), with their phone number so the NOC can reach them directly.
+// One compact line: the alert's owning team and who is on call for it right now
+// (priority 1 of the matching on-call team), with a tel: link so the NOC can dial.
 export const AlertTeamSection = ({ team }: AlertTeamSectionProps) => {
 	const { data: teams = [] } = useOncallTeams();
 
@@ -20,39 +20,33 @@ export const AlertTeamSection = ({ team }: AlertTeamSectionProps) => {
 	const onCallNow = oncallTeam?.members.find((m) => m.priority === 1) ?? null;
 
 	return (
-		<div className="space-y-2 text-sm">
-			<div className="flex items-center gap-2">
-				<span className="text-muted-foreground">Team</span>
-				<span className="font-medium">{team}</span>
-			</div>
+		<div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+			<span className="font-medium">{team}</span>
 			{onCallNow ? (
-				<div className="flex flex-wrap items-center gap-2">
-					<span className="text-muted-foreground">On call now</span>
-					<span
-						data-testid="alert-team-oncall"
-						className="inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary/10 px-2.5 py-0.5 text-xs font-semibold"
-					>
-						<Badge variant="default" className="h-4 min-w-4 justify-center rounded-full px-1 text-[10px]">
-							1
-						</Badge>
-						{onCallNow.fullName}
-						{onCallNow.phoneNumber && (
-							<a
-								href={`tel:${onCallNow.phoneNumber.replace(/[^+\d]/g, '')}`}
-								onClick={(e) => e.stopPropagation()}
-								className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
-							>
-								<Phone className="h-3 w-3" />
-								{onCallNow.phoneNumber}
-							</a>
-						)}
-					</span>
-					{onCallNow && !onCallNow.phoneNumber && (
-						<span className="text-xs text-muted-foreground">(no phone number set)</span>
+				<span
+					data-testid="alert-team-oncall"
+					title="On call now"
+					className="inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary/10 px-2.5 py-0.5 text-xs font-semibold"
+				>
+					<Badge variant="default" className="h-4 min-w-4 justify-center rounded-full px-1 text-[10px]">
+						1
+					</Badge>
+					{onCallNow.fullName}
+					{onCallNow.phoneNumber ? (
+						<a
+							href={`tel:${onCallNow.phoneNumber.replace(/[^+\d]/g, '')}`}
+							onClick={(e) => e.stopPropagation()}
+							className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+						>
+							<Phone className="h-3 w-3" />
+							{onCallNow.phoneNumber}
+						</a>
+					) : (
+						<span className="font-normal text-muted-foreground">(no phone)</span>
 					)}
-				</div>
+				</span>
 			) : (
-				<div className="text-xs text-muted-foreground">No on-call schedule configured for this team.</div>
+				<span className="text-xs text-muted-foreground">no on-call schedule</span>
 			)}
 		</div>
 	);

--- a/apps/client/src/components/Alerts/AlertDetails/AlertTeamSection/AlertTeamSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertTeamSection/AlertTeamSection.tsx
@@ -1,0 +1,59 @@
+import { Badge } from '@/components/ui/badge';
+import { useOncallTeams } from '@/hooks/queries/oncall';
+import { Phone } from 'lucide-react';
+import { useMemo } from 'react';
+
+interface AlertTeamSectionProps {
+	// The alert's owning team name (matched case-insensitively against on-call teams).
+	team: string;
+}
+
+// Shows the alert's owning team and who is on call for it right now (priority 1 of the
+// matching on-call team), with their phone number so the NOC can reach them directly.
+export const AlertTeamSection = ({ team }: AlertTeamSectionProps) => {
+	const { data: teams = [] } = useOncallTeams();
+
+	const oncallTeam = useMemo(
+		() => teams.find((t) => t.name.toLowerCase() === team.toLowerCase()) ?? null,
+		[teams, team]
+	);
+	const onCallNow = oncallTeam?.members.find((m) => m.priority === 1) ?? null;
+
+	return (
+		<div className="space-y-2 text-sm">
+			<div className="flex items-center gap-2">
+				<span className="text-muted-foreground">Team</span>
+				<span className="font-medium">{team}</span>
+			</div>
+			{onCallNow ? (
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-muted-foreground">On call now</span>
+					<span
+						data-testid="alert-team-oncall"
+						className="inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary/10 px-2.5 py-0.5 text-xs font-semibold"
+					>
+						<Badge variant="default" className="h-4 min-w-4 justify-center rounded-full px-1 text-[10px]">
+							1
+						</Badge>
+						{onCallNow.fullName}
+						{onCallNow.phoneNumber && (
+							<a
+								href={`tel:${onCallNow.phoneNumber.replace(/[^+\d]/g, '')}`}
+								onClick={(e) => e.stopPropagation()}
+								className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+							>
+								<Phone className="h-3 w-3" />
+								{onCallNow.phoneNumber}
+							</a>
+						)}
+					</span>
+					{onCallNow && !onCallNow.phoneNumber && (
+						<span className="text-xs text-muted-foreground">(no phone number set)</span>
+					)}
+				</div>
+			) : (
+				<div className="text-xs text-muted-foreground">No on-call schedule configured for this team.</div>
+			)}
+		</div>
+	);
+};

--- a/apps/client/src/components/Alerts/AlertDetails/AlertTeamSection/index.ts
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertTeamSection/index.ts
@@ -1,0 +1,1 @@
+export { AlertTeamSection } from './AlertTeamSection';

--- a/apps/client/src/components/LeftSidebar.tsx
+++ b/apps/client/src/components/LeftSidebar.tsx
@@ -79,17 +79,6 @@ export const LeftSidebar = ({ collapsed }: LeftSidebarProps) => {
 				</Button>
 
 				<Button
-					variant={location.pathname === '/oncall' ? 'default' : 'ghost'}
-					className={cn('gap-3 h-10', collapsed ? 'w-10 justify-center p-0' : 'w-full justify-start px-3')}
-					asChild
-				>
-					<PreserveQueryLink to="/oncall">
-						<PhoneCall className="h-5 w-5 flex-shrink-0" />
-						<span className={cn('font-medium', collapsed && 'sr-only')}>On-Call</span>
-					</PreserveQueryLink>
-				</Button>
-
-				<Button
 					variant={location.pathname === '/actions' ? 'default' : 'ghost'}
 					className={cn('gap-3 h-10', collapsed ? 'w-10 justify-center p-0' : 'w-full justify-start px-3')}
 					asChild
@@ -144,6 +133,19 @@ export const LeftSidebar = ({ collapsed }: LeftSidebarProps) => {
 							</PreserveQueryLink>
 						</Button>
 					)}
+					<Button
+						variant={location.pathname === '/oncall' ? 'default' : 'ghost'}
+						className={cn(
+							'gap-3 h-10 items-center',
+							collapsed ? 'w-10 justify-center p-0' : 'w-full justify-start px-3'
+						)}
+						asChild
+					>
+						<PreserveQueryLink to="/oncall">
+							<PhoneCall className="h-5 w-5 flex-shrink-0" />
+							<span className={cn('font-medium', collapsed && 'sr-only')}>On-Call</span>
+						</PreserveQueryLink>
+					</Button>
 					<ProfileButton collapsed={collapsed} />
 
 					<TooltipProvider>

--- a/apps/client/src/components/LeftSidebar.tsx
+++ b/apps/client/src/components/LeftSidebar.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Bell, BellOff, LayoutDashboard, Puzzle, Settings, Sparkles, Zap } from 'lucide-react';
+import { Bell, BellOff, LayoutDashboard, PhoneCall, Puzzle, Settings, Sparkles, Zap } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
 import { isAdmin, isEditor } from '../lib/auth';
 import { AppIcon } from './icons/AppIcon';
@@ -75,6 +75,17 @@ export const LeftSidebar = ({ collapsed }: LeftSidebarProps) => {
 					<PreserveQueryLink to="/mute-policies">
 						<BellOff className="h-5 w-5 flex-shrink-0" />
 						<span className={cn('font-medium', collapsed && 'sr-only')}>Mute Policies</span>
+					</PreserveQueryLink>
+				</Button>
+
+				<Button
+					variant={location.pathname === '/oncall' ? 'default' : 'ghost'}
+					className={cn('gap-3 h-10', collapsed ? 'w-10 justify-center p-0' : 'w-full justify-start px-3')}
+					asChild
+				>
+					<PreserveQueryLink to="/oncall">
+						<PhoneCall className="h-5 w-5 flex-shrink-0" />
+						<span className={cn('font-medium', collapsed && 'sr-only')}>On-Call</span>
 					</PreserveQueryLink>
 				</Button>
 

--- a/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
+++ b/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
@@ -1,0 +1,203 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { UserInfo } from '@/hooks/queries/users/useUsers';
+import { OncallTeam } from '@OpsiMate/shared';
+import { ArrowDown, ArrowUp, Phone, Plus, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+export interface OncallTeamDraft {
+	name: string;
+	rotationIntervalDays: number | null;
+	// Ordered: index 0 is call priority 1.
+	userIds: string[];
+}
+
+interface OncallTeamFormDialogProps {
+	open: boolean;
+	// null = create a new team.
+	team: OncallTeam | null;
+	users: UserInfo[];
+	saving: boolean;
+	onClose: () => void;
+	onSave: (draft: OncallTeamDraft) => void;
+}
+
+// Create/edit an on-call team: name, rotation cadence, and the ordered member list
+// (the order is the call order — first member is on call first).
+export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSave }: OncallTeamFormDialogProps) => {
+	const [name, setName] = useState('');
+	const [rotationDays, setRotationDays] = useState('');
+	const [userIds, setUserIds] = useState<string[]>([]);
+
+	// Reset the draft each time the dialog opens; editing starts from the team's CURRENT
+	// call order (priority), so what the admin sees is what saving will keep.
+	useEffect(() => {
+		if (!open) return;
+		setName(team?.name ?? '');
+		setRotationDays(team?.rotationIntervalDays ? String(team.rotationIntervalDays) : '');
+		setUserIds(team ? [...team.members].sort((a, b) => a.priority - b.priority).map((m) => m.userId) : []);
+	}, [open, team]);
+
+	const usersById = useMemo(() => new Map(users.map((u) => [u.id, u])), [users]);
+	const availableUsers = useMemo(() => users.filter((u) => !userIds.includes(u.id)), [users, userIds]);
+
+	const move = (index: number, delta: number) => {
+		const target = index + delta;
+		if (target < 0 || target >= userIds.length) return;
+		const next = [...userIds];
+		[next[index], next[target]] = [next[target], next[index]];
+		setUserIds(next);
+	};
+
+	const canSave = name.trim().length > 0 && userIds.length > 0 && !saving;
+
+	return (
+		<Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+			<DialogContent className="max-w-lg">
+				<DialogHeader>
+					<DialogTitle>{team ? 'Edit team' : 'New on-call team'}</DialogTitle>
+					<DialogDescription>
+						Members are called in the order below — the first one is on call now. Saving the member list
+						restarts the rotation clock from today.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					<div>
+						<label className="text-sm font-semibold text-muted-foreground">Team name</label>
+						<Input
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder="backend"
+							className="mt-1"
+							disabled={saving}
+						/>
+					</div>
+
+					<div>
+						<label className="text-sm font-semibold text-muted-foreground">Rotate every (days)</label>
+						<Input
+							type="number"
+							min={0}
+							max={365}
+							value={rotationDays}
+							onChange={(e) => setRotationDays(e.target.value)}
+							placeholder="e.g. 3 — leave empty for a fixed order"
+							className="mt-1"
+							disabled={saving}
+						/>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Every interval the on-call duty moves one place down the list, wrapping around.
+						</p>
+					</div>
+
+					<div>
+						<label className="text-sm font-semibold text-muted-foreground">Members (call order)</label>
+						<ul className="mt-2 space-y-1.5">
+							{userIds.map((userId, index) => {
+								const user = usersById.get(userId);
+								return (
+									<li
+										key={userId}
+										className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-1.5"
+									>
+										<Badge variant={index === 0 ? 'default' : 'secondary'} className="w-7 justify-center">
+											{index + 1}
+										</Badge>
+										<span className="flex-1 truncate text-sm">
+											{user?.fullName ?? `user #${userId}`}
+											{user?.phoneNumber && (
+												<span className="ml-2 inline-flex items-center gap-1 text-xs text-muted-foreground">
+													<Phone className="h-3 w-3" />
+													{user.phoneNumber}
+												</span>
+											)}
+										</span>
+										<Button
+											variant="ghost"
+											size="icon"
+											className="h-6 w-6"
+											disabled={saving || index === 0}
+											onClick={() => move(index, -1)}
+											title="Move up"
+										>
+											<ArrowUp className="h-3.5 w-3.5" />
+										</Button>
+										<Button
+											variant="ghost"
+											size="icon"
+											className="h-6 w-6"
+											disabled={saving || index === userIds.length - 1}
+											onClick={() => move(index, 1)}
+											title="Move down"
+										>
+											<ArrowDown className="h-3.5 w-3.5" />
+										</Button>
+										<Button
+											variant="ghost"
+											size="icon"
+											className="h-6 w-6 text-destructive hover:text-destructive"
+											disabled={saving}
+											onClick={() => setUserIds(userIds.filter((id) => id !== userId))}
+											title="Remove"
+										>
+											<X className="h-3.5 w-3.5" />
+										</Button>
+									</li>
+								);
+							})}
+						</ul>
+
+						{availableUsers.length > 0 ? (
+							<Select value="" onValueChange={(userId) => setUserIds([...userIds, userId])}>
+								<SelectTrigger className="mt-2" disabled={saving}>
+									<span className="flex items-center gap-2 text-muted-foreground">
+										<Plus className="h-3.5 w-3.5" />
+										<SelectValue placeholder="Add a member" />
+									</span>
+								</SelectTrigger>
+								<SelectContent>
+									{availableUsers.map((user) => (
+										<SelectItem key={user.id} value={user.id}>
+											{user.fullName} ({user.email})
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						) : (
+							<p className="mt-2 text-xs text-muted-foreground">All users are already in this team.</p>
+						)}
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={onClose} disabled={saving}>
+						Cancel
+					</Button>
+					<Button
+						onClick={() =>
+							onSave({
+								name: name.trim(),
+								rotationIntervalDays: rotationDays ? parseInt(rotationDays, 10) || null : null,
+								userIds,
+							})
+						}
+						disabled={!canSave}
+					>
+						{saving ? 'Saving...' : 'Save team'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
+++ b/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
@@ -229,7 +229,10 @@ export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSav
 						onClick={() =>
 							onSave({
 								name: name.trim(),
-								rotationIntervalDays: rotationDays ? parseInt(rotationDays, 10) || null : null,
+								// Clamp: the number input hints min 0 but doesn't stop manual "-3".
+								rotationIntervalDays: rotationDays
+									? Math.max(0, parseInt(rotationDays, 10)) || null
+									: null,
 								userIds,
 							})
 						}

--- a/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
+++ b/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
@@ -12,7 +12,24 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { UserInfo } from '@/hooks/queries/users/useUsers';
 import { OncallTeam } from '@OpsiMate/shared';
-import { ArrowDown, ArrowUp, Phone, Plus, X } from 'lucide-react';
+import {
+	closestCenter,
+	DndContext,
+	DragEndEvent,
+	KeyboardSensor,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core';
+import {
+	arrayMove,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	useSortable,
+	verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Phone, Plus, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 export interface OncallTeamDraft {
@@ -32,8 +49,68 @@ interface OncallTeamFormDialogProps {
 	onSave: (draft: OncallTeamDraft) => void;
 }
 
+interface SortableMemberRowProps {
+	userId: string;
+	index: number;
+	user: UserInfo | undefined;
+	disabled: boolean;
+	onRemove: () => void;
+}
+
+// One member row in the call-order list, reorderable by dragging its grip (or the row itself).
+const SortableMemberRow = ({ userId, index, user, disabled, onRemove }: SortableMemberRowProps) => {
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+		id: userId,
+		disabled,
+	});
+
+	return (
+		<li
+			ref={setNodeRef}
+			style={{ transform: CSS.Transform.toString(transform), transition }}
+			className={
+				'flex items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-1.5' +
+				(isDragging ? ' z-10 opacity-80 shadow-md' : '')
+			}
+		>
+			<span
+				{...attributes}
+				{...listeners}
+				className={
+					disabled ? 'text-muted-foreground/40' : 'cursor-grab text-muted-foreground hover:text-foreground'
+				}
+				title="Drag to reorder"
+			>
+				<GripVertical className="h-4 w-4" />
+			</span>
+			<Badge variant={index === 0 ? 'default' : 'secondary'} className="w-7 justify-center">
+				{index + 1}
+			</Badge>
+			<span className="flex-1 truncate text-sm">
+				{user?.fullName ?? `user #${userId}`}
+				{user?.phoneNumber && (
+					<span className="ml-2 inline-flex items-center gap-1 text-xs text-muted-foreground">
+						<Phone className="h-3 w-3" />
+						{user.phoneNumber}
+					</span>
+				)}
+			</span>
+			<Button
+				variant="ghost"
+				size="icon"
+				className="h-6 w-6 text-destructive hover:text-destructive"
+				disabled={disabled}
+				onClick={onRemove}
+				title="Remove"
+			>
+				<X className="h-3.5 w-3.5" />
+			</Button>
+		</li>
+	);
+};
+
 // Create/edit an on-call team: name, rotation cadence, and the ordered member list
-// (the order is the call order — first member is on call first).
+// (the order is the call order — first member is on call first; drag rows to reorder).
 export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSave }: OncallTeamFormDialogProps) => {
 	const [name, setName] = useState('');
 	const [rotationDays, setRotationDays] = useState('');
@@ -51,12 +128,14 @@ export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSav
 	const usersById = useMemo(() => new Map(users.map((u) => [u.id, u])), [users]);
 	const availableUsers = useMemo(() => users.filter((u) => !userIds.includes(u.id)), [users, userIds]);
 
-	const move = (index: number, delta: number) => {
-		const target = index + delta;
-		if (target < 0 || target >= userIds.length) return;
-		const next = [...userIds];
-		[next[index], next[target]] = [next[target], next[index]];
-		setUserIds(next);
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+	);
+
+	const handleDragEnd = ({ active, over }: DragEndEvent) => {
+		if (!over || active.id === over.id) return;
+		setUserIds((ids) => arrayMove(ids, ids.indexOf(String(active.id)), ids.indexOf(String(over.id))));
 	};
 
 	const canSave = name.trim().length > 0 && userIds.length > 0 && !saving;
@@ -103,60 +182,22 @@ export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSav
 
 					<div>
 						<label className="text-sm font-semibold text-muted-foreground">Members (call order)</label>
-						<ul className="mt-2 space-y-1.5">
-							{userIds.map((userId, index) => {
-								const user = usersById.get(userId);
-								return (
-									<li
-										key={userId}
-										className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-2 py-1.5"
-									>
-										<Badge variant={index === 0 ? 'default' : 'secondary'} className="w-7 justify-center">
-											{index + 1}
-										</Badge>
-										<span className="flex-1 truncate text-sm">
-											{user?.fullName ?? `user #${userId}`}
-											{user?.phoneNumber && (
-												<span className="ml-2 inline-flex items-center gap-1 text-xs text-muted-foreground">
-													<Phone className="h-3 w-3" />
-													{user.phoneNumber}
-												</span>
-											)}
-										</span>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="h-6 w-6"
-											disabled={saving || index === 0}
-											onClick={() => move(index, -1)}
-											title="Move up"
-										>
-											<ArrowUp className="h-3.5 w-3.5" />
-										</Button>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="h-6 w-6"
-											disabled={saving || index === userIds.length - 1}
-											onClick={() => move(index, 1)}
-											title="Move down"
-										>
-											<ArrowDown className="h-3.5 w-3.5" />
-										</Button>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="h-6 w-6 text-destructive hover:text-destructive"
+						<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+							<SortableContext items={userIds} strategy={verticalListSortingStrategy}>
+								<ul className="mt-2 space-y-1.5">
+									{userIds.map((userId, index) => (
+										<SortableMemberRow
+											key={userId}
+											userId={userId}
+											index={index}
+											user={usersById.get(userId)}
 											disabled={saving}
-											onClick={() => setUserIds(userIds.filter((id) => id !== userId))}
-											title="Remove"
-										>
-											<X className="h-3.5 w-3.5" />
-										</Button>
-									</li>
-								);
-							})}
-						</ul>
+											onRemove={() => setUserIds(userIds.filter((id) => id !== userId))}
+										/>
+									))}
+								</ul>
+							</SortableContext>
+						</DndContext>
 
 						{availableUsers.length > 0 ? (
 							<Select value="" onValueChange={(userId) => setUserIds([...userIds, userId])}>

--- a/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
+++ b/apps/client/src/components/Oncall/OncallTeamFormDialog.tsx
@@ -8,8 +8,9 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { UserInfo } from '@/hooks/queries/users/useUsers';
 import { OncallTeam } from '@OpsiMate/shared';
 import {
@@ -115,6 +116,7 @@ export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSav
 	const [name, setName] = useState('');
 	const [rotationDays, setRotationDays] = useState('');
 	const [userIds, setUserIds] = useState<string[]>([]);
+	const [addOpen, setAddOpen] = useState(false);
 
 	// Reset the draft each time the dialog opens; editing starts from the team's CURRENT
 	// call order (priority), so what the admin sees is what saving will keep.
@@ -184,7 +186,9 @@ export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSav
 						<label className="text-sm font-semibold text-muted-foreground">Members (call order)</label>
 						<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
 							<SortableContext items={userIds} strategy={verticalListSortingStrategy}>
-								<ul className="mt-2 space-y-1.5">
+								{/* Capped height: big teams scroll here instead of growing the dialog
+								    past the viewport (which pushed the Save button off-screen). */}
+								<ul className="mt-2 max-h-60 space-y-1.5 overflow-y-auto pr-1">
 									{userIds.map((userId, index) => (
 										<SortableMemberRow
 											key={userId}
@@ -200,21 +204,43 @@ export const OncallTeamFormDialog = ({ open, team, users, saving, onClose, onSav
 						</DndContext>
 
 						{availableUsers.length > 0 ? (
-							<Select value="" onValueChange={(userId) => setUserIds([...userIds, userId])}>
-								<SelectTrigger className="mt-2" disabled={saving}>
-									<span className="flex items-center gap-2 text-muted-foreground">
+							<Popover open={addOpen} onOpenChange={setAddOpen}>
+								<PopoverTrigger asChild>
+									<Button
+										variant="outline"
+										className="mt-2 w-full justify-start gap-2 font-normal text-muted-foreground"
+										disabled={saving}
+									>
 										<Plus className="h-3.5 w-3.5" />
-										<SelectValue placeholder="Add a member" />
-									</span>
-								</SelectTrigger>
-								<SelectContent>
-									{availableUsers.map((user) => (
-										<SelectItem key={user.id} value={user.id}>
-											{user.fullName} ({user.email})
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+										Add a member
+									</Button>
+								</PopoverTrigger>
+								<PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+									<Command>
+										<CommandInput placeholder="Search users..." />
+										<CommandList>
+											<CommandEmpty>No users found</CommandEmpty>
+											<CommandGroup>
+												{availableUsers.map((user) => (
+													<CommandItem
+														key={user.id}
+														value={`${user.fullName} ${user.email}`}
+														onSelect={() => {
+															setUserIds((ids) => [...ids, user.id]);
+															setAddOpen(false);
+														}}
+													>
+														{user.fullName}
+														<span className="ml-1.5 truncate text-xs text-muted-foreground">
+															{user.email}
+														</span>
+													</CommandItem>
+												))}
+											</CommandGroup>
+										</CommandList>
+									</Command>
+								</PopoverContent>
+							</Popover>
 						) : (
 							<p className="mt-2 text-xs text-muted-foreground">All users are already in this team.</p>
 						)}

--- a/apps/client/src/components/Profile/Profile.types.ts
+++ b/apps/client/src/components/Profile/Profile.types.ts
@@ -1,6 +1,7 @@
 // using User type from shared package instead of local UserProfile
 export interface ProfileFormData {
 	fullName: string;
+	phoneNumber: string;
 	newPassword: string;
 	confirmPassword: string;
 }

--- a/apps/client/src/components/Profile/components/EditProfileForm/EditProfileForm.tsx
+++ b/apps/client/src/components/Profile/components/EditProfileForm/EditProfileForm.tsx
@@ -59,6 +59,22 @@ export const EditProfileForm = ({
 					{errors.fullName && <ErrorAlert message={errors.fullName} className="mt-2" />}
 				</div>
 
+				<div className="max-w-md">
+					<label htmlFor="phoneNumber" className="text-sm font-semibold text-muted-foreground">
+						Phone Number (Optional)
+					</label>
+					<Input
+						id="phoneNumber"
+						type="tel"
+						value={formData.phoneNumber}
+						onChange={(e) => onFormDataChange({ ...formData, phoneNumber: e.target.value })}
+						className="mt-1"
+						disabled={saving}
+						placeholder="+972 50 123 4567"
+					/>
+					{errors.phoneNumber && <ErrorAlert message={errors.phoneNumber} className="mt-2" />}
+				</div>
+
 				<div className="space-y-3">
 					<h4 className="text-sm font-semibold text-muted-foreground">Change Password (Optional)</h4>
 

--- a/apps/client/src/components/Profile/components/ProfileContent/ProfileContent.tsx
+++ b/apps/client/src/components/Profile/components/ProfileContent/ProfileContent.tsx
@@ -43,7 +43,12 @@ export const ProfileContent = ({
 					<CardContent className="space-y-6">
 						{generalError && <ErrorAlert message={generalError} />}
 
-						<ProfileInformation email={profile.email} role={profile.role} createdAt={profile.createdAt} />
+						<ProfileInformation
+							email={profile.email}
+							role={profile.role}
+							createdAt={profile.createdAt}
+							phoneNumber={profile.phoneNumber}
+						/>
 
 						<ThemePreferences />
 

--- a/apps/client/src/components/Profile/components/ProfileInformation/ProfileInformation.tsx
+++ b/apps/client/src/components/Profile/components/ProfileInformation/ProfileInformation.tsx
@@ -5,9 +5,10 @@ interface ProfileInformationProps {
 	email: string;
 	role: string;
 	createdAt: string;
+	phoneNumber?: string | null;
 }
 
-export const ProfileInformation = ({ email, role, createdAt }: ProfileInformationProps) => {
+export const ProfileInformation = ({ email, role, createdAt, phoneNumber }: ProfileInformationProps) => {
 	return (
 		<div className="space-y-4">
 			<div className="flex items-center gap-3">
@@ -27,6 +28,10 @@ export const ProfileInformation = ({ email, role, createdAt }: ProfileInformatio
 				<div>
 					<label className="text-sm font-semibold text-muted-foreground">Member Since</label>
 					<div className="mt-1 text-sm text-foreground">{formatDate(createdAt)}</div>
+				</div>
+				<div>
+					<label className="text-sm font-semibold text-muted-foreground">Phone Number</label>
+					<div className="mt-1 text-sm text-foreground">{phoneNumber || '—'}</div>
 				</div>
 			</div>
 		</div>

--- a/apps/client/src/components/Profile/hooks/useProfileData.ts
+++ b/apps/client/src/components/Profile/hooks/useProfileData.ts
@@ -32,6 +32,7 @@ export const useProfileData = (): UseProfileDataReturn => {
 							fullName: response.data.fullName,
 							role: response.data.role,
 							createdAt: response.data.createdAt,
+							phoneNumber: response.data.phoneNumber ?? null,
 						});
 					} else {
 						logger.warn('Failed to fetch user profile from server, using JWT data as fallback');

--- a/apps/client/src/components/Profile/hooks/useProfileEdit.ts
+++ b/apps/client/src/components/Profile/hooks/useProfileEdit.ts
@@ -39,6 +39,7 @@ export const useProfileEdit = ({ profile, setProfile }: UseProfileEditProps): Us
 	const [saving, setSaving] = useState(false);
 	const [formData, setFormData] = useState<ProfileFormData>({
 		fullName: profile?.fullName || '',
+		phoneNumber: profile?.phoneNumber || '',
 		newPassword: '',
 		confirmPassword: '',
 	});
@@ -47,7 +48,7 @@ export const useProfileEdit = ({ profile, setProfile }: UseProfileEditProps): Us
 	// Update formData when profile changes
 	useEffect(() => {
 		if (profile) {
-			setFormData((prev) => ({ ...prev, fullName: profile.fullName }));
+			setFormData((prev) => ({ ...prev, fullName: profile.fullName, phoneNumber: profile.phoneNumber || '' }));
 		}
 	}, [profile]);
 
@@ -60,6 +61,7 @@ export const useProfileEdit = ({ profile, setProfile }: UseProfileEditProps): Us
 		setIsEditing(false);
 		setFormData({
 			fullName: profile?.fullName || '',
+			phoneNumber: profile?.phoneNumber || '',
 			newPassword: '',
 			confirmPassword: '',
 		});
@@ -93,8 +95,9 @@ export const useProfileEdit = ({ profile, setProfile }: UseProfileEditProps): Us
 		}
 
 		try {
-			const updateData: { fullName: string; newPassword?: string } = {
+			const updateData: { fullName: string; phoneNumber: string; newPassword?: string } = {
 				fullName: formData.fullName,
+				phoneNumber: formData.phoneNumber.trim(),
 			};
 
 			if (formData.newPassword) {
@@ -110,7 +113,11 @@ export const useProfileEdit = ({ profile, setProfile }: UseProfileEditProps): Us
 				}
 
 				// update local profile state to reflect changes in UI
-				setProfile((prev) => (prev ? { ...prev, fullName: updateData.fullName } : prev));
+				setProfile((prev) =>
+					prev
+						? { ...prev, fullName: updateData.fullName, phoneNumber: updateData.phoneNumber || null }
+						: prev
+				);
 
 				setIsEditing(false);
 				setFormData((prev) => ({

--- a/apps/client/src/hooks/queries/oncall/index.ts
+++ b/apps/client/src/hooks/queries/oncall/index.ts
@@ -1,0 +1,2 @@
+export { useOncallTeams } from './useOncallTeams';
+export { useOncallTeamMutations } from './useOncallTeamMutations';

--- a/apps/client/src/hooks/queries/oncall/useOncallTeamMutations.ts
+++ b/apps/client/src/hooks/queries/oncall/useOncallTeamMutations.ts
@@ -1,0 +1,54 @@
+import { OncallTeamPayload, oncallApi } from '@/lib/api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+// CRUD mutations for on-call teams; each one refreshes the teams list on settle.
+export const useOncallTeamMutations = () => {
+	const queryClient = useQueryClient();
+	const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.oncallTeams });
+
+	const createTeam = useMutation({
+		mutationFn: async (payload: OncallTeamPayload) => {
+			const response = await oncallApi.createTeam(payload);
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to create team');
+			}
+			return response.data.team;
+		},
+		onSettled: invalidate,
+	});
+
+	const updateTeam = useMutation({
+		mutationFn: async ({ teamId, payload }: { teamId: number; payload: Partial<OncallTeamPayload> }) => {
+			const response = await oncallApi.updateTeam(teamId, payload);
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to update team');
+			}
+			return response.data.team;
+		},
+		onSettled: invalidate,
+	});
+
+	const deleteTeam = useMutation({
+		mutationFn: async (teamId: number) => {
+			const response = await oncallApi.deleteTeam(teamId);
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to delete team');
+			}
+		},
+		onSettled: invalidate,
+	});
+
+	const setTeamMembers = useMutation({
+		mutationFn: async ({ teamId, userIds }: { teamId: number; userIds: string[] }) => {
+			const response = await oncallApi.setTeamMembers(teamId, userIds);
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to update team members');
+			}
+			return response.data.team;
+		},
+		onSettled: invalidate,
+	});
+
+	return { createTeam, updateTeam, deleteTeam, setTeamMembers };
+};

--- a/apps/client/src/hooks/queries/oncall/useOncallTeams.ts
+++ b/apps/client/src/hooks/queries/oncall/useOncallTeams.ts
@@ -1,0 +1,18 @@
+import { oncallApi } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+export const useOncallTeams = () => {
+	return useQuery({
+		queryKey: queryKeys.oncallTeams,
+		queryFn: async () => {
+			const response = await oncallApi.getTeams();
+			if (!response.success) {
+				throw new Error(response.error || 'Failed to fetch on-call teams');
+			}
+			return response.data?.teams ?? [];
+		},
+		// The current on-call order is time-derived (rotation), so refresh periodically.
+		refetchInterval: 60_000,
+	});
+};

--- a/apps/client/src/hooks/queries/queryKeys.ts
+++ b/apps/client/src/hooks/queries/queryKeys.ts
@@ -21,6 +21,7 @@ export const queryKeys = {
 	dashboards: ['dashboards'] as const,
 	dashboardTags: ['dashboardTags'] as const,
 	mutePolicies: ['mutePolicies'] as const,
+	oncallTeams: ['oncallTeams'] as const,
 	enrichments: ['enrichments'] as const,
 	actions: ['actions'] as const,
 	retention: ['retention'] as const,

--- a/apps/client/src/hooks/queries/users/useUsers.ts
+++ b/apps/client/src/hooks/queries/users/useUsers.ts
@@ -7,6 +7,7 @@ export interface UserInfo {
 	email: string;
 	fullName: string;
 	role: string;
+	phoneNumber?: string | null;
 }
 
 export const useUsers = () => {

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -24,6 +24,7 @@ import {
 	Service,
 	ServiceWithProvider,
 	Alert as SharedAlert,
+	OncallTeam,
 	Tag,
 } from '@OpsiMate/shared';
 import { isPlaygroundMode } from './playground';
@@ -645,6 +646,22 @@ export const mutePoliciesApi = {
 	deleteMutePolicy: (id: number) => apiRequest<void>(`/mute-policies/${id}`, 'DELETE'),
 };
 
+export type OncallTeamPayload = {
+	name: string;
+	rotationIntervalDays: number | null;
+};
+
+export const oncallApi = {
+	getTeams: () => apiRequest<{ teams: OncallTeam[] }>('/oncall/teams'),
+	createTeam: (payload: OncallTeamPayload) => apiRequest<{ team: OncallTeam }>('/oncall/teams', 'POST', payload),
+	updateTeam: (teamId: number, payload: Partial<OncallTeamPayload>) =>
+		apiRequest<{ team: OncallTeam }>(`/oncall/teams/${teamId}`, 'PATCH', payload),
+	deleteTeam: (teamId: number) => apiRequest<void>(`/oncall/teams/${teamId}`, 'DELETE'),
+	// Ordered list — index 0 becomes call priority 1; saving restarts the rotation clock.
+	setTeamMembers: (teamId: number, userIds: string[]) =>
+		apiRequest<{ team: OncallTeam }>(`/oncall/teams/${teamId}/members`, 'PUT', { userIds }),
+};
+
 export type EnrichmentPayload = {
 	name: string;
 	nameContains?: string | null;
@@ -831,7 +848,9 @@ export const customActionsApi = {
 export const usersApi = {
 	// Get all users
 	getAllUsers: () => {
-		return apiRequest<{ id: string; email: string; fullName: string; role: string }[]>('/users');
+		return apiRequest<{ id: string; email: string; fullName: string; role: string; phoneNumber?: string | null }[]>(
+			'/users'
+		);
 	},
 };
 

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -1,6 +1,6 @@
-import { AlertHistoryData, AlertHistoryEventType, AlertStatus } from '@OpsiMate/shared';
+import { AlertHistoryData, AlertHistoryEventType, AlertStatus, OncallTeam } from '@OpsiMate/shared';
 import { http, HttpResponse } from 'msw';
-import { getPlaygroundUser, playgroundState, randomId } from './state';
+import { getPlaygroundUser, OncallTeamState, playgroundState, randomId } from './state';
 
 const API_BASE = '*/api/v1';
 const nowIso = () => new Date().toISOString();
@@ -107,6 +107,41 @@ const withAppliedEnrichments = <T extends { alertName?: string; tags?: Record<st
 		})
 		.map((e) => ({ id: e.id, name: e.name }));
 	return applied.length > 0 ? { ...alert, appliedEnrichments: applied } : alert;
+};
+
+// Mirrors the server's rotation arithmetic: every rotationIntervalDays since the anchor,
+// the on-call duty shifts one place down the member list, wrapping around.
+const toOncallTeam = (team: OncallTeamState): OncallTeam => {
+	const interval = team.rotationIntervalDays ?? 0;
+	const count = team.userIds.length;
+	let shift = 0;
+	let nextRotationAt: string | null = null;
+	if (interval > 0 && count > 0) {
+		const anchorMs = new Date(team.rotationAnchor).getTime();
+		const elapsed = Math.max(0, Date.now() - anchorMs);
+		const periods = Math.floor(elapsed / (interval * DAY));
+		shift = periods % count;
+		nextRotationAt = new Date(anchorMs + (periods + 1) * interval * DAY).toISOString();
+	}
+	const members = team.userIds.map((userId, position) => {
+		const user = playgroundState.users.find((u) => u.id === userId);
+		return {
+			userId,
+			fullName: user?.fullName ?? `user #${userId}`,
+			email: user?.email ?? '',
+			phoneNumber: user?.phoneNumber ?? null,
+			priority: ((position - shift + count) % count) + 1,
+		};
+	});
+	members.sort((a, b) => a.priority - b.priority);
+	return {
+		id: team.id,
+		name: team.name,
+		rotationIntervalDays: team.rotationIntervalDays,
+		rotationAnchor: team.rotationAnchor,
+		members,
+		nextRotationAt,
+	};
 };
 
 export const handlers = [
@@ -592,10 +627,76 @@ export const handlers = [
 	}),
 
 	http.get(`${API_BASE}/users/profile`, () => {
+		// Serve from state so seeded/edited fields (e.g. phone number) show up.
+		const user = playgroundState.users.find((u) => u.id === getPlaygroundUser().id) ?? getPlaygroundUser();
 		return HttpResponse.json({
 			success: true,
-			data: getPlaygroundUser(),
+			data: user,
 		});
+	}),
+
+	http.patch(`${API_BASE}/users/profile`, async ({ request }) => {
+		const body = (await request.json()) as { fullName: string; phoneNumber?: string; newPassword?: string };
+		const user = playgroundState.users.find((u) => u.id === getPlaygroundUser().id);
+		if (user) {
+			user.fullName = body.fullName;
+			user.phoneNumber = body.phoneNumber || null;
+		}
+		return HttpResponse.json({
+			success: true,
+			data: { user: { ...getPlaygroundUser(), fullName: body.fullName, phoneNumber: body.phoneNumber || null } },
+		});
+	}),
+
+	// ==================== ON-CALL ====================
+	http.get(`${API_BASE}/oncall/teams`, () => {
+		return HttpResponse.json({
+			success: true,
+			data: { teams: playgroundState.oncallTeams.map(toOncallTeam) },
+		});
+	}),
+
+	http.post(`${API_BASE}/oncall/teams`, async ({ request }) => {
+		const body = (await request.json()) as { name: string; rotationIntervalDays?: number | null };
+		const team = {
+			id: randomId(),
+			name: body.name,
+			rotationIntervalDays: body.rotationIntervalDays || null,
+			rotationAnchor: nowIso(),
+			userIds: [],
+		};
+		playgroundState.oncallTeams.push(team);
+		return HttpResponse.json({ success: true, data: { team: toOncallTeam(team) } }, { status: 201 });
+	}),
+
+	http.patch(`${API_BASE}/oncall/teams/:teamId`, async ({ params, request }) => {
+		const team = playgroundState.oncallTeams.find((t) => t.id === Number(params.teamId));
+		if (!team) {
+			return HttpResponse.json({ success: false, error: 'Team not found' }, { status: 404 });
+		}
+		const body = (await request.json()) as { name?: string; rotationIntervalDays?: number | null };
+		if (body.name !== undefined) team.name = body.name;
+		if (body.rotationIntervalDays !== undefined) {
+			team.rotationIntervalDays = body.rotationIntervalDays || null;
+			team.rotationAnchor = nowIso();
+		}
+		return HttpResponse.json({ success: true, data: { team: toOncallTeam(team) } });
+	}),
+
+	http.delete(`${API_BASE}/oncall/teams/:teamId`, ({ params }) => {
+		playgroundState.oncallTeams = playgroundState.oncallTeams.filter((t) => t.id !== Number(params.teamId));
+		return HttpResponse.json({ success: true, message: 'Team deleted' });
+	}),
+
+	http.put(`${API_BASE}/oncall/teams/:teamId/members`, async ({ params, request }) => {
+		const team = playgroundState.oncallTeams.find((t) => t.id === Number(params.teamId));
+		if (!team) {
+			return HttpResponse.json({ success: false, error: 'Team not found' }, { status: 404 });
+		}
+		const body = (await request.json()) as { userIds: (string | number)[] };
+		team.userIds = body.userIds.map(String);
+		team.rotationAnchor = nowIso();
+		return HttpResponse.json({ success: true, data: { team: toOncallTeam(team) } });
 	}),
 
 	// ==================== AUDIT ====================

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -658,6 +658,12 @@ export const handlers = [
 
 	http.post(`${API_BASE}/oncall/teams`, async ({ request }) => {
 		const body = (await request.json()) as { name: string; rotationIntervalDays?: number | null };
+		if (playgroundState.oncallTeams.some((t) => t.name.toLowerCase() === body.name.toLowerCase())) {
+			return HttpResponse.json(
+				{ success: false, error: `A team named "${body.name}" already exists` },
+				{ status: 409 }
+			);
+		}
 		const team = {
 			id: randomId(),
 			name: body.name,
@@ -675,6 +681,17 @@ export const handlers = [
 			return HttpResponse.json({ success: false, error: 'Team not found' }, { status: 404 });
 		}
 		const body = (await request.json()) as { name?: string; rotationIntervalDays?: number | null };
+		if (
+			body.name !== undefined &&
+			playgroundState.oncallTeams.some(
+				(t) => t.id !== team.id && t.name.toLowerCase() === body.name!.toLowerCase()
+			)
+		) {
+			return HttpResponse.json(
+				{ success: false, error: `A team named "${body.name}" already exists` },
+				{ status: 409 }
+			);
+		}
 		if (body.name !== undefined) team.name = body.name;
 		if (body.rotationIntervalDays !== undefined) {
 			team.rotationIntervalDays = body.rotationIntervalDays || null;

--- a/apps/client/src/mocks/state.ts
+++ b/apps/client/src/mocks/state.ts
@@ -251,7 +251,7 @@ const createUsers = (): User[] => [
 const createOncallTeams = (): OncallTeamState[] => [
 	{
 		id: 1,
-		name: 'backend',
+		name: 'platform',
 		rotationIntervalDays: 3,
 		rotationAnchor: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
 		userIds: [getPlaygroundUser().id, '1', '2'],
@@ -426,18 +426,24 @@ const TAG_TEAM = ['platform', 'data', 'frontend', 'sre'];
 
 const seedAlerts = () => {
 	const alerts = generateDiverseMockAlerts(500);
-	return alerts.map((alert, idx) => ({
-		...alert,
-		// First-class severity mirrors production ingestion (derived from the severity tag).
-		severity: normalizeAlertSeverity(TAG_SEVERITY[idx % TAG_SEVERITY.length]),
-		tags: {
-			severity: TAG_SEVERITY[idx % TAG_SEVERITY.length],
-			service: TAG_SERVICE[idx % TAG_SERVICE.length],
-			environment: TAG_ENVIRONMENT[idx % TAG_ENVIRONMENT.length],
-			team: TAG_TEAM[idx % TAG_TEAM.length],
-		},
-		ownerId: idx % 7 === 0 ? getPlaygroundUser().id : null,
-	}));
+	return alerts.map((alert, idx) => {
+		// Every fifth alert has no owning team — the field defaults to none.
+		const team = idx % 5 === 0 ? null : TAG_TEAM[idx % TAG_TEAM.length];
+		return {
+			...alert,
+			// First-class severity mirrors production ingestion (derived from the severity tag).
+			severity: normalizeAlertSeverity(TAG_SEVERITY[idx % TAG_SEVERITY.length]),
+			// First-class team mirrors production ingestion (derived from the team tag).
+			team,
+			tags: {
+				severity: TAG_SEVERITY[idx % TAG_SEVERITY.length],
+				service: TAG_SERVICE[idx % TAG_SERVICE.length],
+				environment: TAG_ENVIRONMENT[idx % TAG_ENVIRONMENT.length],
+				...(team ? { team } : {}),
+			},
+			ownerId: idx % 7 === 0 ? getPlaygroundUser().id : null,
+		};
+	});
 };
 
 // An alert is either silenced or resolved, never both — resolved seeds are always unsilenced.

--- a/apps/client/src/mocks/state.ts
+++ b/apps/client/src/mocks/state.ts
@@ -50,6 +50,17 @@ export interface PlaygroundState {
 	// Per-alert history events appended live as the user acts in the sandbox (ownership,
 	// silencings, actions, comments). Merged with generated base history by the history handler.
 	alertHistoryEvents: Record<string, AlertHistoryData[]>;
+	// Raw on-call teams; the handler derives the rotated call order the same way the server does.
+	oncallTeams: OncallTeamState[];
+}
+
+export interface OncallTeamState {
+	id: number;
+	name: string;
+	rotationIntervalDays: number | null;
+	rotationAnchor: string;
+	// Ordered — index 0 is base call priority 1.
+	userIds: string[];
 }
 
 const nowIso = () => new Date().toISOString();
@@ -217,13 +228,14 @@ const createViews = (): SavedView[] => [
 ];
 
 const createUsers = (): User[] => [
-	getPlaygroundUser(),
+	{ ...getPlaygroundUser(), phoneNumber: '+972 50 111 2233' },
 	{
 		id: '1',
 		email: 'editor@opsimate.local',
 		fullName: 'Demo Editor',
 		role: Role.Editor,
 		createdAt: nowIso(),
+		phoneNumber: '+972 52 444 5566',
 	},
 	{
 		id: '2',
@@ -231,6 +243,25 @@ const createUsers = (): User[] => [
 		fullName: 'Demo Viewer',
 		role: Role.Viewer,
 		createdAt: nowIso(),
+	},
+];
+
+// Anchored 4 days back with a 3-day interval, so the demo team is already one shift in —
+// the second member is on call when the playground loads.
+const createOncallTeams = (): OncallTeamState[] => [
+	{
+		id: 1,
+		name: 'backend',
+		rotationIntervalDays: 3,
+		rotationAnchor: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(),
+		userIds: [getPlaygroundUser().id, '1', '2'],
+	},
+	{
+		id: 2,
+		name: 'frontend',
+		rotationIntervalDays: null,
+		rotationAnchor: nowIso(),
+		userIds: ['1', '2'],
 	},
 ];
 
@@ -452,6 +483,7 @@ export const playgroundState: PlaygroundState = {
 	actions: createActions(),
 	enrichments: createEnrichments(),
 	alertHistoryEvents: {},
+	oncallTeams: createOncallTeams(),
 };
 
 let idCounter = 10000;

--- a/apps/client/src/pages/Oncall.tsx
+++ b/apps/client/src/pages/Oncall.tsx
@@ -72,6 +72,18 @@ const Oncall = () => {
 	};
 
 	const handleSave = async (draft: OncallTeamDraft) => {
+		// Instant feedback for the common case; the server enforces this too (409).
+		const duplicate = teams.some(
+			(t) => t.id !== editingTeam?.id && t.name.toLowerCase() === draft.name.toLowerCase()
+		);
+		if (duplicate) {
+			toast({
+				title: 'Team name already exists',
+				description: `"${draft.name}" is already an on-call team — pick a different name.`,
+				variant: 'destructive',
+			});
+			return;
+		}
 		setSaving(true);
 		// Tracked so a failed member save can roll back a just-created team — otherwise
 		// retrying the dialog would leave an empty duplicate behind.

--- a/apps/client/src/pages/Oncall.tsx
+++ b/apps/client/src/pages/Oncall.tsx
@@ -13,14 +13,15 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useOncallTeamMutations, useOncallTeams } from '@/hooks/queries/oncall';
 import { useUsers } from '@/hooks/queries/users';
 import { useToast } from '@/hooks/use-toast';
 import { isAdmin } from '@/lib/auth';
 import { OncallTeam } from '@OpsiMate/shared';
-import { Pencil, Phone, PhoneCall, Plus, Repeat, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { Pencil, Phone, PhoneCall, Plus, Repeat, Search, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 const formatDateTime = (iso: string | null): string => {
 	if (!iso) return '—';
@@ -38,10 +39,24 @@ const Oncall = () => {
 	const { data: users = [] } = useUsers();
 	const { createTeam, updateTeam, deleteTeam, setTeamMembers } = useOncallTeamMutations();
 
+	const [searchTerm, setSearchTerm] = useState('');
 	const [formOpen, setFormOpen] = useState(false);
 	const [editingTeam, setEditingTeam] = useState<OncallTeam | null>(null);
 	const [teamToDelete, setTeamToDelete] = useState<OncallTeam | null>(null);
 	const [saving, setSaving] = useState(false);
+
+	// Match on team name or any member's name/email.
+	const filteredTeams = useMemo(() => {
+		const term = searchTerm.trim().toLowerCase();
+		if (!term) return teams;
+		return teams.filter(
+			(team) =>
+				team.name.toLowerCase().includes(term) ||
+				team.members.some(
+					(m) => m.fullName.toLowerCase().includes(term) || m.email.toLowerCase().includes(term)
+				)
+		);
+	}, [teams, searchTerm]);
 
 	const openCreate = () => {
 		setEditingTeam(null);
@@ -114,6 +129,16 @@ const Oncall = () => {
 					)}
 				</div>
 
+				<div className="relative max-w-sm">
+					<Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						value={searchTerm}
+						onChange={(e) => setSearchTerm(e.target.value)}
+						placeholder="Search teams or members..."
+						className="pl-8"
+					/>
+				</div>
+
 				<Card>
 					<CardContent className="p-0">
 						<Table>
@@ -136,17 +161,19 @@ const Oncall = () => {
 											Loading on-call teams...
 										</TableCell>
 									</TableRow>
-								) : teams.length === 0 ? (
+								) : filteredTeams.length === 0 ? (
 									<TableRow>
 										<TableCell
 											colSpan={admin ? 5 : 4}
 											className="h-24 text-center text-muted-foreground"
 										>
-											No on-call teams yet{admin ? ' — add the first one.' : '.'}
+											{searchTerm
+												? 'No teams match your search.'
+												: `No on-call teams yet${admin ? ' — add the first one.' : '.'}`}
 										</TableCell>
 									</TableRow>
 								) : (
-									teams.map((team) => (
+									filteredTeams.map((team) => (
 										<TableRow key={team.id}>
 											<TableCell className="font-medium">{team.name}</TableCell>
 											<TableCell>

--- a/apps/client/src/pages/Oncall.tsx
+++ b/apps/client/src/pages/Oncall.tsx
@@ -23,6 +23,9 @@ import { OncallTeam } from '@OpsiMate/shared';
 import { Pencil, Phone, PhoneCall, Plus, Repeat, Search, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
+// Big teams: the table shows the first chips in call order and folds the rest into "+X".
+const MAX_VISIBLE_MEMBERS = 5;
+
 const formatDateTime = (iso: string | null): string => {
 	if (!iso) return '—';
 	const d = new Date(iso);
@@ -193,7 +196,7 @@ const Oncall = () => {
 															No members
 														</span>
 													)}
-													{team.members.map((member) => (
+													{team.members.slice(0, MAX_VISIBLE_MEMBERS).map((member) => (
 														<span
 															key={member.userId}
 															data-testid={
@@ -223,6 +226,17 @@ const Oncall = () => {
 															)}
 														</span>
 													))}
+													{team.members.length > MAX_VISIBLE_MEMBERS && (
+														<span
+															title={team.members
+																.slice(MAX_VISIBLE_MEMBERS)
+																.map((m) => `${m.priority}. ${m.fullName}`)
+																.join('\n')}
+															className="inline-flex items-center rounded-full border border-border bg-muted/40 px-2.5 py-0.5 text-xs text-muted-foreground"
+														>
+															+{team.members.length - MAX_VISIBLE_MEMBERS} more
+														</span>
+													)}
 												</div>
 											</TableCell>
 											<TableCell>

--- a/apps/client/src/pages/Oncall.tsx
+++ b/apps/client/src/pages/Oncall.tsx
@@ -215,7 +215,7 @@ const Oncall = () => {
 																{member.priority}
 															</Badge>
 															{member.fullName}
-															{member.priority === 1 && member.phoneNumber && (
+															{member.phoneNumber && (
 																<span className="inline-flex items-center gap-1 text-muted-foreground">
 																	<Phone className="h-3 w-3" />
 																	{member.phoneNumber}

--- a/apps/client/src/pages/Oncall.tsx
+++ b/apps/client/src/pages/Oncall.tsx
@@ -70,11 +70,18 @@ const Oncall = () => {
 
 	const handleSave = async (draft: OncallTeamDraft) => {
 		setSaving(true);
+		// Tracked so a failed member save can roll back a just-created team — otherwise
+		// retrying the dialog would leave an empty duplicate behind.
+		let createdTeamId: number | null = null;
 		try {
 			const payload = { name: draft.name, rotationIntervalDays: draft.rotationIntervalDays };
-			const teamId = editingTeam
-				? (await updateTeam.mutateAsync({ teamId: editingTeam.id, payload })).id
-				: (await createTeam.mutateAsync(payload)).id;
+			let teamId: number;
+			if (editingTeam) {
+				teamId = (await updateTeam.mutateAsync({ teamId: editingTeam.id, payload })).id;
+			} else {
+				teamId = (await createTeam.mutateAsync(payload)).id;
+				createdTeamId = teamId;
+			}
 			await setTeamMembers.mutateAsync({ teamId, userIds: draft.userIds });
 			setFormOpen(false);
 			toast({
@@ -82,6 +89,9 @@ const Oncall = () => {
 				description: `"${draft.name}" now has ${draft.userIds.length} member${draft.userIds.length !== 1 ? 's' : ''}.`,
 			});
 		} catch (err) {
+			if (createdTeamId !== null) {
+				await deleteTeam.mutateAsync(createdTeamId).catch(() => undefined);
+			}
 			toast({
 				title: 'Failed to save team',
 				description: err instanceof Error ? err.message : 'Unknown error',

--- a/apps/client/src/pages/Oncall.tsx
+++ b/apps/client/src/pages/Oncall.tsx
@@ -1,0 +1,270 @@
+import { DashboardLayout } from '@/components/DashboardLayout';
+import { OncallTeamDraft, OncallTeamFormDialog } from '@/components/Oncall/OncallTeamFormDialog';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useOncallTeamMutations, useOncallTeams } from '@/hooks/queries/oncall';
+import { useUsers } from '@/hooks/queries/users';
+import { useToast } from '@/hooks/use-toast';
+import { isAdmin } from '@/lib/auth';
+import { OncallTeam } from '@OpsiMate/shared';
+import { Pencil, Phone, PhoneCall, Plus, Repeat, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+const formatDateTime = (iso: string | null): string => {
+	if (!iso) return '—';
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return '—';
+	return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+};
+
+// On-call schedule: one row per team, members shown in current call order (1 = the person
+// the NOC phones now). Admins manage teams, members, and the rotation cadence.
+const Oncall = () => {
+	const { toast } = useToast();
+	const admin = isAdmin();
+	const { data: teams = [], isLoading } = useOncallTeams();
+	const { data: users = [] } = useUsers();
+	const { createTeam, updateTeam, deleteTeam, setTeamMembers } = useOncallTeamMutations();
+
+	const [formOpen, setFormOpen] = useState(false);
+	const [editingTeam, setEditingTeam] = useState<OncallTeam | null>(null);
+	const [teamToDelete, setTeamToDelete] = useState<OncallTeam | null>(null);
+	const [saving, setSaving] = useState(false);
+
+	const openCreate = () => {
+		setEditingTeam(null);
+		setFormOpen(true);
+	};
+
+	const openEdit = (team: OncallTeam) => {
+		setEditingTeam(team);
+		setFormOpen(true);
+	};
+
+	const handleSave = async (draft: OncallTeamDraft) => {
+		setSaving(true);
+		try {
+			const payload = { name: draft.name, rotationIntervalDays: draft.rotationIntervalDays };
+			const teamId = editingTeam
+				? (await updateTeam.mutateAsync({ teamId: editingTeam.id, payload })).id
+				: (await createTeam.mutateAsync(payload)).id;
+			await setTeamMembers.mutateAsync({ teamId, userIds: draft.userIds });
+			setFormOpen(false);
+			toast({
+				title: editingTeam ? 'Team updated' : 'Team created',
+				description: `"${draft.name}" now has ${draft.userIds.length} member${draft.userIds.length !== 1 ? 's' : ''}.`,
+			});
+		} catch (err) {
+			toast({
+				title: 'Failed to save team',
+				description: err instanceof Error ? err.message : 'Unknown error',
+				variant: 'destructive',
+			});
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (!teamToDelete) return;
+		try {
+			await deleteTeam.mutateAsync(teamToDelete.id);
+			toast({ title: 'Team deleted', description: `"${teamToDelete.name}" was removed.` });
+		} catch (err) {
+			toast({
+				title: 'Failed to delete team',
+				description: err instanceof Error ? err.message : 'Unknown error',
+				variant: 'destructive',
+			});
+		} finally {
+			setTeamToDelete(null);
+		}
+	};
+
+	return (
+		<DashboardLayout>
+			<div className="p-6 space-y-4">
+				<div className="flex items-center justify-between">
+					<div>
+						<h1 className="text-2xl font-bold flex items-center gap-2">
+							<PhoneCall className="h-6 w-6" />
+							On-Call
+						</h1>
+						<p className="text-sm text-muted-foreground mt-1">
+							Who to call when alerts fire — each team's members in call order, rotated automatically.
+						</p>
+					</div>
+					{admin && (
+						<Button onClick={openCreate} className="gap-2">
+							<Plus className="h-4 w-4" />
+							Add Team
+						</Button>
+					)}
+				</div>
+
+				<Card>
+					<CardContent className="p-0">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead className="w-[180px]">Team</TableHead>
+									<TableHead>Members (call order)</TableHead>
+									<TableHead className="w-[160px]">Rotation</TableHead>
+									<TableHead className="w-[160px]">Next rotation</TableHead>
+									{admin && <TableHead className="w-[90px]" />}
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{isLoading ? (
+									<TableRow>
+										<TableCell
+											colSpan={admin ? 5 : 4}
+											className="h-24 text-center text-muted-foreground"
+										>
+											Loading on-call teams...
+										</TableCell>
+									</TableRow>
+								) : teams.length === 0 ? (
+									<TableRow>
+										<TableCell
+											colSpan={admin ? 5 : 4}
+											className="h-24 text-center text-muted-foreground"
+										>
+											No on-call teams yet{admin ? ' — add the first one.' : '.'}
+										</TableCell>
+									</TableRow>
+								) : (
+									teams.map((team) => (
+										<TableRow key={team.id}>
+											<TableCell className="font-medium">{team.name}</TableCell>
+											<TableCell>
+												<div className="flex flex-wrap gap-1.5">
+													{team.members.length === 0 && (
+														<span className="text-sm text-muted-foreground">
+															No members
+														</span>
+													)}
+													{team.members.map((member) => (
+														<span
+															key={member.userId}
+															data-testid={
+																member.priority === 1 ? 'oncall-now' : undefined
+															}
+															title={member.email}
+															className={
+																member.priority === 1
+																	? 'inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary/10 px-2.5 py-0.5 text-xs font-semibold'
+																	: 'inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2.5 py-0.5 text-xs'
+															}
+														>
+															<Badge
+																variant={
+																	member.priority === 1 ? 'default' : 'secondary'
+																}
+																className="h-4 min-w-4 justify-center rounded-full px-1 text-[10px]"
+															>
+																{member.priority}
+															</Badge>
+															{member.fullName}
+															{member.priority === 1 && member.phoneNumber && (
+																<span className="inline-flex items-center gap-1 text-muted-foreground">
+																	<Phone className="h-3 w-3" />
+																	{member.phoneNumber}
+																</span>
+															)}
+														</span>
+													))}
+												</div>
+											</TableCell>
+											<TableCell>
+												{team.rotationIntervalDays ? (
+													<span className="inline-flex items-center gap-1.5 text-sm">
+														<Repeat className="h-3.5 w-3.5 text-muted-foreground" />
+														Every {team.rotationIntervalDays} day
+														{team.rotationIntervalDays !== 1 ? 's' : ''}
+													</span>
+												) : (
+													<span className="text-sm text-muted-foreground">Fixed order</span>
+												)}
+											</TableCell>
+											<TableCell className="text-sm text-muted-foreground">
+												{formatDateTime(team.nextRotationAt)}
+											</TableCell>
+											{admin && (
+												<TableCell>
+													<div className="flex items-center justify-end gap-1">
+														<Button
+															variant="ghost"
+															size="icon"
+															className="h-7 w-7"
+															onClick={() => openEdit(team)}
+															title="Edit team"
+														>
+															<Pencil className="h-3.5 w-3.5" />
+														</Button>
+														<Button
+															variant="ghost"
+															size="icon"
+															className="h-7 w-7 text-destructive hover:text-destructive"
+															onClick={() => setTeamToDelete(team)}
+															title="Delete team"
+														>
+															<Trash2 className="h-3.5 w-3.5" />
+														</Button>
+													</div>
+												</TableCell>
+											)}
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</CardContent>
+				</Card>
+			</div>
+
+			<OncallTeamFormDialog
+				open={formOpen}
+				team={editingTeam}
+				users={users}
+				saving={saving}
+				onClose={() => setFormOpen(false)}
+				onSave={handleSave}
+			/>
+
+			<AlertDialog open={!!teamToDelete} onOpenChange={(open) => !open && setTeamToDelete(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete team "{teamToDelete?.name}"?</AlertDialogTitle>
+						<AlertDialogDescription>
+							The team and its on-call schedule will be removed. The users themselves are not affected.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleDelete}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</DashboardLayout>
+	);
+};
+
+export default Oncall;

--- a/apps/client/src/pages/index.ts
+++ b/apps/client/src/pages/index.ts
@@ -10,4 +10,5 @@ export { Providers } from '../components/Providers';
 export { default as Register } from './Register';
 export { default as Settings } from './Settings';
 export { default as MutePolicies } from './MutePolicies';
+export { default as Oncall } from './Oncall';
 export { default as TVMode } from './TVMode';

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -444,6 +444,7 @@ export class AlertController {
 				type: 'Custom',
 				status: AlertStatus.FIRING,
 				severity: alert.severity,
+				team: alert.team,
 				tags: alert.tags,
 				startsAt: alert.startsAt || new Date().toISOString(),
 				updatedAt: alert.updatedAt || new Date().toISOString(),

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -43,6 +43,8 @@ export const HttpAlertWebhookSchema = z.object({
 	// Free-form; normalized onto the fixed critical/warning/info scale at ingestion
 	// (unknown or missing values default to warning).
 	severity: z.string().optional(),
+	// Owning team; falls back to a `team` tag at ingestion, null when neither is present.
+	team: z.string().optional(),
 });
 
 /**

--- a/apps/server/src/api/v1/oncall/controller.ts
+++ b/apps/server/src/api/v1/oncall/controller.ts
@@ -1,0 +1,111 @@
+import { Logger, OncallTeamMembersSchema, OncallTeamSchema, Role } from '@OpsiMate/shared';
+import { Response } from 'express';
+import { OncallBL } from '../../../bl/oncall/oncall.bl';
+import { AuthenticatedRequest } from '../../../middleware/auth.ts';
+import { isZodError } from '../../../utils/isZodError';
+
+const logger = new Logger('api/v1/oncall/controller');
+
+export class OncallController {
+	constructor(private oncallBL: OncallBL) {}
+
+	// Reading the schedule is open to any authenticated user (the NOC needs it);
+	// changing it is admins only.
+	private requireAdmin(req: AuthenticatedRequest, res: Response): boolean {
+		if (!req.user || req.user.role !== Role.Admin) {
+			res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
+			return false;
+		}
+		return true;
+	}
+
+	private parseTeamId(req: AuthenticatedRequest, res: Response): number | null {
+		const teamId = parseInt(req.params.teamId, 10);
+		if (isNaN(teamId) || teamId <= 0) {
+			res.status(400).json({ success: false, error: 'Invalid team id' });
+			return null;
+		}
+		return teamId;
+	}
+
+	listTeamsHandler = async (_req: AuthenticatedRequest, res: Response) => {
+		try {
+			const teams = await this.oncallBL.getAllTeams();
+			return res.json({ success: true, data: { teams } });
+		} catch (error) {
+			logger.error('Error listing on-call teams', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	createTeamHandler = async (req: AuthenticatedRequest, res: Response) => {
+		if (!this.requireAdmin(req, res)) return;
+		try {
+			const { name, rotationIntervalDays } = OncallTeamSchema.parse(req.body);
+			const team = await this.oncallBL.createTeam(name, rotationIntervalDays ?? null);
+			return res.status(201).json({ success: true, data: { team } });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error creating on-call team', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	updateTeamHandler = async (req: AuthenticatedRequest, res: Response) => {
+		if (!this.requireAdmin(req, res)) return;
+		const teamId = this.parseTeamId(req, res);
+		if (teamId === null) return;
+		try {
+			const updates = OncallTeamSchema.partial().parse(req.body);
+			const team = await this.oncallBL.updateTeam(teamId, updates);
+			if (!team) {
+				return res.status(404).json({ success: false, error: 'Team not found' });
+			}
+			return res.json({ success: true, data: { team } });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error updating on-call team', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	deleteTeamHandler = async (req: AuthenticatedRequest, res: Response) => {
+		if (!this.requireAdmin(req, res)) return;
+		const teamId = this.parseTeamId(req, res);
+		if (teamId === null) return;
+		try {
+			await this.oncallBL.deleteTeam(teamId);
+			return res.json({ success: true, message: 'Team deleted' });
+		} catch (error) {
+			logger.error('Error deleting on-call team', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+
+	setTeamMembersHandler = async (req: AuthenticatedRequest, res: Response) => {
+		if (!this.requireAdmin(req, res)) return;
+		const teamId = this.parseTeamId(req, res);
+		if (teamId === null) return;
+		try {
+			const { userIds } = OncallTeamMembersSchema.parse(req.body);
+			if (new Set(userIds).size !== userIds.length) {
+				return res.status(400).json({ success: false, error: 'Duplicate users in member list' });
+			}
+			const team = await this.oncallBL.setTeamMembers(teamId, userIds);
+			if (!team) {
+				return res.status(404).json({ success: false, error: 'Team not found' });
+			}
+			return res.json({ success: true, data: { team } });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error setting on-call team members', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	};
+}

--- a/apps/server/src/api/v1/oncall/controller.ts
+++ b/apps/server/src/api/v1/oncall/controller.ts
@@ -1,6 +1,6 @@
 import { Logger, OncallTeamMembersSchema, OncallTeamSchema, Role } from '@OpsiMate/shared';
 import { Response } from 'express';
-import { OncallBL } from '../../../bl/oncall/oncall.bl';
+import { DuplicateTeamNameError, OncallBL } from '../../../bl/oncall/oncall.bl';
 import { AuthenticatedRequest } from '../../../middleware/auth.ts';
 import { isZodError } from '../../../utils/isZodError';
 
@@ -48,6 +48,9 @@ export class OncallController {
 			if (isZodError(error)) {
 				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
 			}
+			if (error instanceof DuplicateTeamNameError) {
+				return res.status(409).json({ success: false, error: error.message });
+			}
 			logger.error('Error creating on-call team', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
@@ -67,6 +70,9 @@ export class OncallController {
 		} catch (error) {
 			if (isZodError(error)) {
 				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			if (error instanceof DuplicateTeamNameError) {
+				return res.status(409).json({ success: false, error: error.message });
 			}
 			logger.error('Error updating on-call team', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/oncall/controller.ts
+++ b/apps/server/src/api/v1/oncall/controller.ts
@@ -91,10 +91,8 @@ export class OncallController {
 		const teamId = this.parseTeamId(req, res);
 		if (teamId === null) return;
 		try {
+			// The schema also rejects duplicate userIds.
 			const { userIds } = OncallTeamMembersSchema.parse(req.body);
-			if (new Set(userIds).size !== userIds.length) {
-				return res.status(400).json({ success: false, error: 'Duplicate users in member list' });
-			}
 			const team = await this.oncallBL.setTeamMembers(teamId, userIds);
 			if (!team) {
 				return res.status(404).json({ success: false, error: 'Team not found' });

--- a/apps/server/src/api/v1/oncall/router.ts
+++ b/apps/server/src/api/v1/oncall/router.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import PromiseRouter from 'express-promise-router';
+import { OncallController } from './controller';
+
+export default function createOncallRouter(controller: OncallController) {
+	const router = PromiseRouter();
+
+	router.get('/teams', controller.listTeamsHandler);
+	router.post('/teams', controller.createTeamHandler);
+	router.patch('/teams/:teamId', controller.updateTeamHandler);
+	router.delete('/teams/:teamId', controller.deleteTeamHandler);
+	router.put('/teams/:teamId/members', controller.setTeamMembersHandler);
+
+	return router;
+}

--- a/apps/server/src/api/v1/users/controller.ts
+++ b/apps/server/src/api/v1/users/controller.ts
@@ -175,8 +175,8 @@ export class UsersController {
 		}
 
 		try {
-			const { fullName, newPassword } = UpdateProfileSchema.parse(req.body);
-			const updatedUser = await this.userBL.updateProfile(numericUserId, fullName, newPassword);
+			const { fullName, newPassword, phoneNumber } = UpdateProfileSchema.parse(req.body);
+			const updatedUser = await this.userBL.updateProfile(numericUserId, fullName, newPassword, phoneNumber);
 
 			const responseData: { user: User; token?: string | undefined } = { user: updatedUser };
 

--- a/apps/server/src/api/v1/v1.ts
+++ b/apps/server/src/api/v1/v1.ts
@@ -27,6 +27,8 @@ import { EnrichmentController } from './enrichments/controller';
 import createEnrichmentRouter from './enrichments/router';
 import { MutePolicyController } from './mute-policies/controller';
 import createMutePolicyRouter from './mute-policies/router';
+import { OncallController } from './oncall/controller';
+import createOncallRouter from './oncall/router';
 import { TagController } from './tags/controller';
 import tagRouter from './tags/router';
 import { UsersController } from './users/controller';
@@ -50,7 +52,8 @@ export default function createV1Router(
 	mutePolicyController: MutePolicyController,
 	enrichmentController: EnrichmentController,
 	actionController: ActionController,
-	retentionController: RetentionController
+	retentionController: RetentionController,
+	oncallController: OncallController
 ) {
 	const router = PromiseRouter();
 
@@ -77,6 +80,7 @@ export default function createV1Router(
 	router.use('/custom-fields', createCustomFieldsRouter(customFieldsController));
 	router.use('/custom-actions', createCustomActionsRouter(customActionsController));
 	router.use('/mute-policies', createMutePolicyRouter(mutePolicyController));
+	router.use('/oncall', createOncallRouter(oncallController));
 	router.use('/enrichments', createEnrichmentRouter(enrichmentController));
 	router.use('/actions', createActionRouter(actionController));
 	// All other /users endpoints (except /register and /login) are protected

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -16,6 +16,7 @@ import { SecretsController } from './api/v1/secrets/controller';
 import { ServiceController } from './api/v1/services/controller';
 import { EnrichmentController } from './api/v1/enrichments/controller';
 import { MutePolicyController } from './api/v1/mute-policies/controller';
+import { OncallController } from './api/v1/oncall/controller';
 import { TagController } from './api/v1/tags/controller';
 import { UsersController } from './api/v1/users/controller';
 import createV1Router from './api/v1/v1';
@@ -31,6 +32,7 @@ import { SecretsMetadataBL } from './bl/secrets/secretsMetadata.bl';
 import { ServicesBL } from './bl/services/services.bl';
 import { EnrichmentBL } from './bl/enrichments/enrichment.bl';
 import { MutePolicyBL } from './bl/mute-policies/mutePolicy.bl';
+import { OncallBL } from './bl/oncall/oncall.bl';
 import { TagBL } from './bl/tags/tag.bl';
 import { UserBL } from './bl/users/user.bl';
 import { ActionRepository } from './dal/actionRepository';
@@ -52,6 +54,7 @@ import { ServiceCustomFieldValueRepository } from './dal/serviceCustomFieldValue
 import { ServiceRepository } from './dal/serviceRepository';
 import { EnrichmentRepository } from './dal/enrichmentRepository';
 import { MutePolicyRepository } from './dal/mutePolicyRepository';
+import { OncallRepository } from './dal/oncallRepository';
 import { TagRepository } from './dal/tagRepository';
 import { UserRepository } from './dal/userRepository';
 import { RefreshJob } from './jobs/refresh-job';
@@ -138,6 +141,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const customActionRepo = new CustomActionRepository(db);
 	const playgroundRepo = new PlaygroundRepository(db);
 	const mutePolicyRepo = new MutePolicyRepository(db);
+	const oncallRepo = new OncallRepository(db);
 	const enrichmentRepo = new EnrichmentRepository(db);
 	const actionRepo = new ActionRepository(db);
 
@@ -156,6 +160,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 		customActionRepo.initCustomActionsTable(),
 		playgroundRepo.initPlaygroundTable(),
 		mutePolicyRepo.initMutePoliciesTable(),
+		oncallRepo.initOncallTables(),
 		enrichmentRepo.initEnrichmentsTable(),
 		actionRepo.initActionsTable(),
 	]);
@@ -170,6 +175,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const dashboardBL = new DashboardBL(dashboardRepository, auditBL, tagBL);
 	const playgroundBL = new PlaygroundBL(playgroundRepo, mailClient);
 	const mutePolicyBL = new MutePolicyBL(mutePolicyRepo);
+	const oncallBL = new OncallBL(oncallRepo);
 	alertBL.setMutePolicyBL(mutePolicyBL);
 	const enrichmentBL = new EnrichmentBL(enrichmentRepo, auditBL);
 	alertBL.setEnrichmentBL(enrichmentBL);
@@ -196,6 +202,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const customActionsController = new CustomActionsController(customActionBL);
 	const playgroundController = new PlaygroundController(playgroundBL);
 	const mutePolicyController = new MutePolicyController(mutePolicyBL);
+	const oncallController = new OncallController(oncallBL);
 	const enrichmentController = new EnrichmentController(enrichmentBL);
 	const actionController = new ActionController(actionBL);
 	const retentionController = new RetentionController(retentionBL);
@@ -220,7 +227,8 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 			mutePolicyController,
 			enrichmentController,
 			actionController,
-			retentionController
+			retentionController,
+			oncallController
 		)
 	);
 

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -88,8 +88,11 @@ export class AlertBL {
 			logger.info(`Inserting alert: ${alert.id}`);
 			// || (not ??) so a blank explicit severity falls through to the tag.
 			const severity = normalizeAlertSeverity(alert.severity?.trim() || alert.tags?.['severity']);
+			// Same funnel for the owning team: explicit field wins, then a `team` tag,
+			// otherwise none. Unlike severity there is no fixed scale — any name is kept.
+			const team = alert.team?.trim() || alert.tags?.['team'] || null;
 			const tags = { ...(alert.tags ?? {}), severity };
-			return await this.alertRepo.insertOrUpdateAlert({ ...alert, tags, severity });
+			return await this.alertRepo.insertOrUpdateAlert({ ...alert, tags, severity, team });
 		} catch (error) {
 			logger.error('Error inserting alert', error);
 			throw error;

--- a/apps/server/src/bl/oncall/oncall.bl.ts
+++ b/apps/server/src/bl/oncall/oncall.bl.ts
@@ -28,14 +28,17 @@ export class OncallBL {
 			nextRotationAt = new Date(anchorMs + (periods + 1) * interval * DAY_MS).toISOString();
 		}
 
-		const members: OncallTeamMember[] = memberRows.map((row) => ({
+		const members: OncallTeamMember[] = memberRows.map((row, index) => ({
 			userId: String(row.user_id),
 			fullName: row.full_name,
 			email: row.email,
 			phoneNumber: row.phone_number ?? null,
 			// Rotate the base order by `shift`: the member at base position `shift` becomes
-			// priority 1, the one before them wraps to the end.
-			priority: ((row.position - shift + count) % count) + 1,
+			// priority 1, the one before them wraps to the end. The dense index is used
+			// (rows are position-ordered) rather than the stored position, which can have
+			// gaps after a member's user is deleted (FK cascade) — gaps would make the
+			// modulo assign duplicate priorities.
+			priority: ((index - shift + count) % count) + 1,
 		}));
 		members.sort((a, b) => a.priority - b.priority);
 

--- a/apps/server/src/bl/oncall/oncall.bl.ts
+++ b/apps/server/src/bl/oncall/oncall.bl.ts
@@ -1,5 +1,5 @@
 import { Logger, OncallTeam, OncallTeamMember } from '@OpsiMate/shared';
-import { OncallRepository } from '../../dal/oncallRepository';
+import { OncallRepository, OncallTeamUpdate } from '../../dal/oncallRepository';
 import { OncallTeamMemberRow, OncallTeamRow } from './../../dal/models';
 
 const logger = new Logger('bl/oncall.bl');
@@ -93,10 +93,7 @@ export class OncallBL {
 		}
 	}
 
-	async updateTeam(
-		teamId: number,
-		updates: { name?: string; rotationIntervalDays?: number | null }
-	): Promise<OncallTeam | null> {
+	async updateTeam(teamId: number, updates: OncallTeamUpdate): Promise<OncallTeam | null> {
 		try {
 			logger.info(`Updating on-call team ${teamId}`);
 			const existing = await this.oncallRepo.getTeam(teamId);

--- a/apps/server/src/bl/oncall/oncall.bl.ts
+++ b/apps/server/src/bl/oncall/oncall.bl.ts
@@ -1,0 +1,125 @@
+import { Logger, OncallTeam, OncallTeamMember } from '@OpsiMate/shared';
+import { OncallRepository } from '../../dal/oncallRepository';
+import { OncallTeamMemberRow, OncallTeamRow } from './../../dal/models';
+
+const logger = new Logger('bl/oncall.bl');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export class OncallBL {
+	constructor(private oncallRepo: OncallRepository) {}
+
+	// The rotation is pure arithmetic — no background job. Members hold a fixed base order
+	// (position). Every `rotationIntervalDays` since the anchor, the on-call duty shifts one
+	// place down the list: shift = floor(daysSinceAnchor / interval) mod memberCount, and the
+	// member at base position `shift` is on call now (priority 1), followed by the rest in
+	// base order, wrapping around.
+	private toSharedTeam(team: OncallTeamRow, memberRows: OncallTeamMemberRow[], now: Date): OncallTeam {
+		const interval = team.rotation_interval_days ?? 0;
+		const count = memberRows.length;
+
+		let shift = 0;
+		let nextRotationAt: string | null = null;
+		if (interval > 0 && count > 0) {
+			const anchorMs = new Date(team.rotation_anchor).getTime();
+			const elapsed = Math.max(0, now.getTime() - anchorMs);
+			const periods = Math.floor(elapsed / (interval * DAY_MS));
+			shift = periods % count;
+			nextRotationAt = new Date(anchorMs + (periods + 1) * interval * DAY_MS).toISOString();
+		}
+
+		const members: OncallTeamMember[] = memberRows.map((row) => ({
+			userId: String(row.user_id),
+			fullName: row.full_name,
+			email: row.email,
+			phoneNumber: row.phone_number ?? null,
+			// Rotate the base order by `shift`: the member at base position `shift` becomes
+			// priority 1, the one before them wraps to the end.
+			priority: ((row.position - shift + count) % count) + 1,
+		}));
+		members.sort((a, b) => a.priority - b.priority);
+
+		return {
+			id: team.id,
+			name: team.name,
+			rotationIntervalDays: team.rotation_interval_days,
+			rotationAnchor: team.rotation_anchor,
+			members,
+			nextRotationAt,
+		};
+	}
+
+	async getAllTeams(): Promise<OncallTeam[]> {
+		try {
+			const now = new Date();
+			const teams = await this.oncallRepo.getAllTeams();
+			return await Promise.all(
+				teams.map(async (team) => this.toSharedTeam(team, await this.oncallRepo.getTeamMembers(team.id), now))
+			);
+		} catch (error) {
+			logger.error('Error fetching on-call teams', error);
+			throw error;
+		}
+	}
+
+	async getTeam(teamId: number): Promise<OncallTeam | null> {
+		const team = await this.oncallRepo.getTeam(teamId);
+		if (!team) return null;
+		return this.toSharedTeam(team, await this.oncallRepo.getTeamMembers(teamId), new Date());
+	}
+
+	async createTeam(name: string, rotationIntervalDays: number | null): Promise<OncallTeam> {
+		try {
+			logger.info(`Creating on-call team: ${name}`);
+			const teamId = await this.oncallRepo.createTeam(name, rotationIntervalDays || null);
+			return (await this.getTeam(teamId)) as OncallTeam;
+		} catch (error) {
+			logger.error('Error creating on-call team', error);
+			throw error;
+		}
+	}
+
+	async updateTeam(
+		teamId: number,
+		updates: { name?: string; rotationIntervalDays?: number | null }
+	): Promise<OncallTeam | null> {
+		try {
+			logger.info(`Updating on-call team ${teamId}`);
+			const existing = await this.oncallRepo.getTeam(teamId);
+			if (!existing) return null;
+			await this.oncallRepo.updateTeam(teamId, {
+				...updates,
+				...(updates.rotationIntervalDays !== undefined && {
+					rotationIntervalDays: updates.rotationIntervalDays || null,
+				}),
+			});
+			return this.getTeam(teamId);
+		} catch (error) {
+			logger.error(`Error updating on-call team ${teamId}`, error);
+			throw error;
+		}
+	}
+
+	async deleteTeam(teamId: number): Promise<void> {
+		try {
+			logger.info(`Deleting on-call team ${teamId}`);
+			await this.oncallRepo.deleteTeam(teamId);
+		} catch (error) {
+			logger.error(`Error deleting on-call team ${teamId}`, error);
+			throw error;
+		}
+	}
+
+	async setTeamMembers(teamId: number, userIds: number[]): Promise<OncallTeam | null> {
+		try {
+			logger.info(`Setting members for on-call team ${teamId}: [${userIds.join(', ')}]`);
+			const existing = await this.oncallRepo.getTeam(teamId);
+			if (!existing) return null;
+			await this.oncallRepo.setTeamMembers(teamId, userIds);
+			return this.getTeam(teamId);
+		} catch (error) {
+			logger.error(`Error setting members for on-call team ${teamId}`, error);
+			throw error;
+		}
+	}
+}

--- a/apps/server/src/bl/oncall/oncall.bl.ts
+++ b/apps/server/src/bl/oncall/oncall.bl.ts
@@ -6,6 +6,14 @@ const logger = new Logger('bl/oncall.bl');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+// Thrown when a create/rename would collide with an existing team's name (the API
+// maps it to 409). Names identify teams — alerts reference them by name.
+export class DuplicateTeamNameError extends Error {
+	constructor(name: string) {
+		super(`A team named "${name}" already exists`);
+	}
+}
+
 export class OncallBL {
 	constructor(private oncallRepo: OncallRepository) {}
 
@@ -74,6 +82,9 @@ export class OncallBL {
 	async createTeam(name: string, rotationIntervalDays: number | null): Promise<OncallTeam> {
 		try {
 			logger.info(`Creating on-call team: ${name}`);
+			if (await this.oncallRepo.getTeamByName(name)) {
+				throw new DuplicateTeamNameError(name);
+			}
 			const teamId = await this.oncallRepo.createTeam(name, rotationIntervalDays || null);
 			return (await this.getTeam(teamId)) as OncallTeam;
 		} catch (error) {
@@ -90,6 +101,12 @@ export class OncallBL {
 			logger.info(`Updating on-call team ${teamId}`);
 			const existing = await this.oncallRepo.getTeam(teamId);
 			if (!existing) return null;
+			if (updates.name !== undefined) {
+				const clash = await this.oncallRepo.getTeamByName(updates.name);
+				if (clash && clash.id !== teamId) {
+					throw new DuplicateTeamNameError(updates.name);
+				}
+			}
 			await this.oncallRepo.updateTeam(teamId, {
 				...updates,
 				...(updates.rotationIntervalDays !== undefined && {

--- a/apps/server/src/bl/users/user.bl.ts
+++ b/apps/server/src/bl/users/user.bl.ts
@@ -94,13 +94,18 @@ export class UserBL {
 		return count > 0;
 	}
 
-	async updateProfile(id: number, fullName: string, newPassword?: string): Promise<User> {
+	async updateProfile(
+		id: number,
+		fullName: string,
+		newPassword?: string,
+		phoneNumber?: string | null
+	): Promise<User> {
 		let passwordHash: string | undefined;
 		if (newPassword) {
 			passwordHash = await bcrypt.hash(newPassword, 10);
 		}
 
-		await this.userRepo.updateUserProfile(id, fullName, passwordHash);
+		await this.userRepo.updateUserProfile(id, fullName, passwordHash, phoneNumber);
 		const updatedUser = await this.userRepo.getUserById(id);
 		if (!updatedUser) {
 			throw new Error('User not found');

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -13,12 +13,13 @@ export class AlertRepository {
 	async insertOrUpdateAlert(alert: Omit<SharedAlert, 'createdAt' | 'isSilenced'>): Promise<{ changes: number }> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
-				INSERT INTO alerts (id, status, type, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				ON CONFLICT(id) DO UPDATE SET
 											  status=excluded.status,
 											  type=excluded.type,
 											  severity=excluded.severity,
+											  team=excluded.team,
 											  tags=excluded.tags,
 											  starts_at=excluded.starts_at,
 											  updated_at=excluded.updated_at,
@@ -33,6 +34,7 @@ export class AlertRepository {
 				alert.status,
 				alert.type,
 				alert.severity,
+				alert.team ?? null,
 				JSON.stringify(alert.tags ?? {}),
 				alert.startsAt,
 				alert.updatedAt,
@@ -63,8 +65,8 @@ export class AlertRepository {
 				this.db
 					.prepare(
 						`
-						INSERT INTO alerts (id, status, type, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed, is_read, created_at, owner_id)
-						VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+						INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed, is_read, created_at, owner_id)
+						VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
 						ON CONFLICT(id) DO UPDATE SET
 													  status=excluded.status,
 													  updated_at=excluded.updated_at
@@ -75,6 +77,7 @@ export class AlertRepository {
 						alert.status,
 						alert.type,
 						alert.severity,
+						alert.team ?? null,
 						JSON.stringify(alert.tags ?? {}),
 						alert.startsAt,
 						alert.updatedAt,
@@ -143,6 +146,12 @@ export class AlertRepository {
 			if (!hasSeverity) {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN severity TEXT`).run();
 			}
+
+			// Backward compatibility: ensure team column exists
+			const hasTeam = columns.some((col: TableInfoRow) => col.name === 'team');
+			if (!hasTeam) {
+				this.db.prepare(`ALTER TABLE alerts ADD COLUMN team TEXT`).run();
+			}
 		});
 	}
 
@@ -156,6 +165,8 @@ export class AlertRepository {
 			type: row.type,
 			// Legacy rows (pre-severity column) fall back to their severity tag, then the default.
 			severity: normalizeAlertSeverity(row.severity ?? tags['severity']),
+			// Legacy rows (pre-team column) fall back to their team tag.
+			team: row.team ?? tags['team'] ?? null,
 			tags,
 			startsAt: row.starts_at,
 			updatedAt: row.updated_at,

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -157,6 +157,18 @@ export type TableInfoRow = {
 	pk: number;
 };
 
+// Row shape of PRAGMA foreign_key_list(<table>).
+export type ForeignKeyInfoRow = {
+	id: number;
+	seq: number;
+	table: string;
+	from: string;
+	to: string;
+	on_update: string;
+	on_delete: string;
+	match: string;
+};
+
 export type AlertCommentRow = {
 	id: string;
 	alert_id: string;

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -94,6 +94,25 @@ export type UserRow = {
 	full_name: string;
 	role: Role;
 	created_at: string;
+	phone_number: string | null;
+};
+
+export type OncallTeamRow = {
+	id: number;
+	name: string;
+	rotation_interval_days: number | null;
+	rotation_anchor: string;
+	created_at: string;
+};
+
+export type OncallTeamMemberRow = {
+	id: number;
+	team_id: number;
+	user_id: number;
+	position: number;
+	full_name: string;
+	email: string;
+	phone_number: string | null;
 };
 
 export type AuditLogRow = {

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -56,6 +56,7 @@ export type AlertRow = {
 	type: AlertType;
 	status: string;
 	severity?: string | null;
+	team?: string | null;
 	tags: string;
 	starts_at: string;
 	updated_at: string;
@@ -74,6 +75,7 @@ export type ResolvedAlertRow = {
 	type: AlertType;
 	status: string;
 	severity?: string | null;
+	team?: string | null;
 	tags: string;
 	starts_at: string;
 	updated_at: string;

--- a/apps/server/src/dal/oncallRepository.ts
+++ b/apps/server/src/dal/oncallRepository.ts
@@ -52,6 +52,34 @@ export class OncallRepository {
 				});
 				rebuild();
 			}
+
+			// A team's name is its identity (alerts reference teams by name), so enforce
+			// uniqueness case-insensitively. Duplicates created before the index existed
+			// are renamed (suffixed with their id) rather than dropped.
+			const dupes = this.db
+				.prepare(
+					`SELECT id, name FROM oncall_teams
+					 WHERE id NOT IN (SELECT MIN(id) FROM oncall_teams GROUP BY name COLLATE NOCASE)`
+				)
+				.all() as { id: number; name: string }[];
+			for (const dupe of dupes) {
+				this.db
+					.prepare(`UPDATE oncall_teams SET name = ? WHERE id = ?`)
+					.run(`${dupe.name} (${dupe.id})`, dupe.id);
+			}
+			this.db.exec(
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_oncall_teams_name ON oncall_teams (name COLLATE NOCASE)`
+			);
+		});
+	}
+
+	// Case-insensitive name lookup, used to reject duplicate team names with a clear error.
+	async getTeamByName(name: string): Promise<OncallTeamRow | null> {
+		return runAsync(() => {
+			const row = this.db.prepare('SELECT * FROM oncall_teams WHERE name = ? COLLATE NOCASE').get(name) as
+				| OncallTeamRow
+				| undefined;
+			return row ?? null;
 		});
 	}
 

--- a/apps/server/src/dal/oncallRepository.ts
+++ b/apps/server/src/dal/oncallRepository.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
-import { OncallTeamMemberRow, OncallTeamRow } from './models';
+import { ForeignKeyInfoRow, OncallTeamMemberRow, OncallTeamRow } from './models';
 
 export class OncallRepository {
 	private db: Database.Database;
@@ -23,11 +23,35 @@ export class OncallRepository {
 				CREATE TABLE IF NOT EXISTS oncall_team_members (
 					id INTEGER PRIMARY KEY AUTOINCREMENT,
 					team_id INTEGER NOT NULL REFERENCES oncall_teams(id) ON DELETE CASCADE,
-					user_id INTEGER NOT NULL REFERENCES users(id),
+					user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 					position INTEGER NOT NULL,
 					UNIQUE(team_id, user_id)
 				);
 			`);
+
+			// Migration: early versions created the user_id FK without ON DELETE CASCADE, so
+			// deleting a user who was on a team threw an FK error. SQLite can't alter an FK
+			// in place — rebuild the table when the old shape is detected.
+			const fks = this.db.prepare(`PRAGMA foreign_key_list(oncall_team_members)`).all() as ForeignKeyInfoRow[];
+			const userFk = fks.find((fk) => fk.from === 'user_id');
+			if (userFk && userFk.on_delete !== 'CASCADE') {
+				const rebuild = this.db.transaction(() => {
+					this.db.exec(`
+						CREATE TABLE oncall_team_members_new (
+							id INTEGER PRIMARY KEY AUTOINCREMENT,
+							team_id INTEGER NOT NULL REFERENCES oncall_teams(id) ON DELETE CASCADE,
+							user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+							position INTEGER NOT NULL,
+							UNIQUE(team_id, user_id)
+						);
+						INSERT INTO oncall_team_members_new (id, team_id, user_id, position)
+							SELECT id, team_id, user_id, position FROM oncall_team_members;
+						DROP TABLE oncall_team_members;
+						ALTER TABLE oncall_team_members_new RENAME TO oncall_team_members;
+					`);
+				});
+				rebuild();
+			}
 		});
 	}
 

--- a/apps/server/src/dal/oncallRepository.ts
+++ b/apps/server/src/dal/oncallRepository.ts
@@ -1,0 +1,122 @@
+import Database from 'better-sqlite3';
+import { runAsync } from './db';
+import { OncallTeamMemberRow, OncallTeamRow } from './models';
+
+export class OncallRepository {
+	private db: Database.Database;
+
+	constructor(db: Database.Database) {
+		this.db = db;
+	}
+
+	async initOncallTables(): Promise<void> {
+		return runAsync(() => {
+			this.db.exec(`
+				CREATE TABLE IF NOT EXISTS oncall_teams (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					name TEXT NOT NULL,
+					rotation_interval_days INTEGER,
+					rotation_anchor TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+				);
+
+				CREATE TABLE IF NOT EXISTS oncall_team_members (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					team_id INTEGER NOT NULL REFERENCES oncall_teams(id) ON DELETE CASCADE,
+					user_id INTEGER NOT NULL REFERENCES users(id),
+					position INTEGER NOT NULL,
+					UNIQUE(team_id, user_id)
+				);
+			`);
+		});
+	}
+
+	async getAllTeams(): Promise<OncallTeamRow[]> {
+		return runAsync(() => {
+			return this.db.prepare('SELECT * FROM oncall_teams ORDER BY name').all() as OncallTeamRow[];
+		});
+	}
+
+	async getTeam(teamId: number): Promise<OncallTeamRow | null> {
+		return runAsync(() => {
+			const row = this.db.prepare('SELECT * FROM oncall_teams WHERE id = ?').get(teamId) as
+				| OncallTeamRow
+				| undefined;
+			return row ?? null;
+		});
+	}
+
+	// Members in base order (position), joined with the user fields the page displays.
+	async getTeamMembers(teamId: number): Promise<OncallTeamMemberRow[]> {
+		return runAsync(() => {
+			return this.db
+				.prepare(
+					`
+					SELECT m.id, m.team_id, m.user_id, m.position, u.full_name, u.email, u.phone_number
+					FROM oncall_team_members m
+					JOIN users u ON u.id = m.user_id
+					WHERE m.team_id = ?
+					ORDER BY m.position
+				`
+				)
+				.all(teamId) as OncallTeamMemberRow[];
+		});
+	}
+
+	async createTeam(name: string, rotationIntervalDays: number | null): Promise<number> {
+		return runAsync(() => {
+			const result = this.db
+				.prepare(`INSERT INTO oncall_teams (name, rotation_interval_days, rotation_anchor) VALUES (?, ?, ?)`)
+				.run(name, rotationIntervalDays, new Date().toISOString());
+			return result.lastInsertRowid as number;
+		});
+	}
+
+	// Changing the rotation interval resets the anchor: the current order stays put and the
+	// new cadence counts from now.
+	async updateTeam(teamId: number, updates: { name?: string; rotationIntervalDays?: number | null }): Promise<void> {
+		return runAsync(() => {
+			const setClauses: string[] = [];
+			const values: (string | number | null)[] = [];
+			if (updates.name !== undefined) {
+				setClauses.push('name = ?');
+				values.push(updates.name);
+			}
+			if (updates.rotationIntervalDays !== undefined) {
+				setClauses.push('rotation_interval_days = ?', 'rotation_anchor = ?');
+				values.push(updates.rotationIntervalDays, new Date().toISOString());
+			}
+			if (setClauses.length === 0) return;
+			values.push(teamId);
+			this.db.prepare(`UPDATE oncall_teams SET ${setClauses.join(', ')} WHERE id = ?`).run(...values);
+		});
+	}
+
+	async deleteTeam(teamId: number): Promise<void> {
+		return runAsync(() => {
+			const remove = this.db.transaction(() => {
+				this.db.prepare('DELETE FROM oncall_team_members WHERE team_id = ?').run(teamId);
+				this.db.prepare('DELETE FROM oncall_teams WHERE id = ?').run(teamId);
+			});
+			remove();
+		});
+	}
+
+	// Replaces the member list with the given ordered user ids and resets the rotation
+	// anchor — the new order IS the current call order, and rotation counts from now.
+	async setTeamMembers(teamId: number, userIds: number[]): Promise<void> {
+		return runAsync(() => {
+			const replace = this.db.transaction(() => {
+				this.db.prepare('DELETE FROM oncall_team_members WHERE team_id = ?').run(teamId);
+				const insert = this.db.prepare(
+					'INSERT INTO oncall_team_members (team_id, user_id, position) VALUES (?, ?, ?)'
+				);
+				userIds.forEach((userId, position) => insert.run(teamId, userId, position));
+				this.db
+					.prepare('UPDATE oncall_teams SET rotation_anchor = ? WHERE id = ?')
+					.run(new Date().toISOString(), teamId);
+			});
+			replace();
+		});
+	}
+}

--- a/apps/server/src/dal/oncallRepository.ts
+++ b/apps/server/src/dal/oncallRepository.ts
@@ -2,6 +2,12 @@ import Database from 'better-sqlite3';
 import { runAsync } from './db';
 import { ForeignKeyInfoRow, OncallTeamMemberRow, OncallTeamRow } from './models';
 
+// Partial team fields accepted by updateTeam (and the BL's update flow).
+export interface OncallTeamUpdate {
+	name?: string;
+	rotationIntervalDays?: number | null;
+}
+
 export class OncallRepository {
 	private db: Database.Database;
 
@@ -126,7 +132,7 @@ export class OncallRepository {
 
 	// Changing the rotation interval resets the anchor: the current order stays put and the
 	// new cadence counts from now.
-	async updateTeam(teamId: number, updates: { name?: string; rotationIntervalDays?: number | null }): Promise<void> {
+	async updateTeam(teamId: number, updates: OncallTeamUpdate): Promise<void> {
 		return runAsync(() => {
 			const setClauses: string[] = [];
 			const values: (string | number | null)[] = [];

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -110,6 +110,12 @@ export class ResolvedAlertRepository {
 			if (!hasSeverity) {
 				this.db.prepare(`ALTER TABLE alerts_resolved ADD COLUMN severity TEXT`).run();
 			}
+
+			// Backward compatibility: ensure team column exists
+			const hasTeam = columns.some((col: TableInfoRow) => col.name === 'team');
+			if (!hasTeam) {
+				this.db.prepare(`ALTER TABLE alerts_resolved ADD COLUMN team TEXT`).run();
+			}
 		});
 	}
 
@@ -117,11 +123,12 @@ export class ResolvedAlertRepository {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
                 INSERT INTO alerts_resolved
-                    (id, status, severity, tags, type, starts_at, updated_at, alert_url, alert_name, is_dismissed, summary, runbook_url, created_at, owner_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (id, status, severity, team, tags, type, starts_at, updated_at, alert_url, alert_name, is_dismissed, summary, runbook_url, created_at, owner_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     status = excluded.status,
                     severity = excluded.severity,
+                    team = excluded.team,
                     tags = excluded.tags,
                     type = excluded.type,
                     starts_at = excluded.starts_at,
@@ -140,6 +147,7 @@ export class ResolvedAlertRepository {
 				alert.id,
 				AlertStatus.RESOLVED,
 				alert.severity,
+				alert.team ?? null,
 				JSON.stringify(alert.tags),
 				alert.type,
 				alert.startsAt,
@@ -167,6 +175,8 @@ export class ResolvedAlertRepository {
 			status: AlertStatus.RESOLVED,
 			// Legacy rows (pre-severity column) fall back to their severity tag, then the default.
 			severity: normalizeAlertSeverity(row.severity ?? tags['severity']),
+			// Legacy rows (pre-team column) fall back to their team tag.
+			team: row.team ?? tags['team'] ?? null,
 			tags,
 			type: row.type,
 			startsAt: row.starts_at,

--- a/apps/server/src/dal/userRepository.ts
+++ b/apps/server/src/dal/userRepository.ts
@@ -26,6 +26,12 @@ export class UserRepository {
             `
 				)
 				.run();
+
+			// Backward compatibility: ensure phone_number column exists
+			const columns = this.db.prepare(`PRAGMA table_info(users)`).all() as { name: string }[];
+			if (!columns.some((col) => col.name === 'phone_number')) {
+				this.db.prepare(`ALTER TABLE users ADD COLUMN phone_number TEXT`).run();
+			}
 		});
 	}
 
@@ -69,7 +75,7 @@ export class UserRepository {
 
 	async getAllUsers(): Promise<User[]> {
 		return runAsync(() => {
-			const stmt = this.db.prepare('SELECT id, email, full_name, role, created_at FROM users');
+			const stmt = this.db.prepare('SELECT id, email, full_name, role, created_at, phone_number FROM users');
 			const userRows = stmt.all() as UserRow[];
 			return userRows.map(this.toSharedUser);
 		});
@@ -78,7 +84,7 @@ export class UserRepository {
 	async getUserById(id: number): Promise<User | null> {
 		return runAsync(() => {
 			const row = this.db
-				.prepare('SELECT id, email, full_name, role, created_at FROM users WHERE id = ?')
+				.prepare('SELECT id, email, full_name, role, created_at, phone_number FROM users WHERE id = ?')
 				.get(id) as UserRow | undefined;
 			return row ? this.toSharedUser(row) : null;
 		});
@@ -90,15 +96,26 @@ export class UserRepository {
 		});
 	}
 
-	async updateUserProfile(id: number, fullName: string, passwordHash?: string): Promise<void> {
+	async updateUserProfile(
+		id: number,
+		fullName: string,
+		passwordHash?: string,
+		phoneNumber?: string | null
+	): Promise<void> {
 		return runAsync(() => {
+			const setClauses = ['full_name = ?'];
+			const values: (string | number | null)[] = [fullName];
 			if (passwordHash) {
-				const stmt = this.db.prepare('UPDATE users SET full_name = ?, password_hash = ? WHERE id = ?');
-				stmt.run(fullName, passwordHash, id);
-			} else {
-				const stmt = this.db.prepare('UPDATE users SET full_name = ? WHERE id = ?');
-				stmt.run(fullName, id);
+				setClauses.push('password_hash = ?');
+				values.push(passwordHash);
 			}
+			// undefined = leave unchanged; null/'' = clear.
+			if (phoneNumber !== undefined) {
+				setClauses.push('phone_number = ?');
+				values.push(phoneNumber || null);
+			}
+			values.push(id);
+			this.db.prepare(`UPDATE users SET ${setClauses.join(', ')} WHERE id = ?`).run(...values);
 		});
 	}
 
@@ -147,13 +164,14 @@ export class UserRepository {
 			fullName: row.full_name,
 			role: row.role,
 			createdAt: row.created_at,
+			phoneNumber: row.phone_number ?? null,
 		};
 	};
 
 	async getUserByEmail(email: string): Promise<User | null> {
 		return runAsync(() => {
 			const row = this.db
-				.prepare('SELECT id, email, full_name, role, created_at FROM users WHERE email = ?')
+				.prepare('SELECT id, email, full_name, role, created_at, phone_number FROM users WHERE email = ?')
 				.get(email) as UserRow | undefined;
 			return row ? this.toSharedUser(row) : null;
 		});

--- a/apps/server/src/dal/userRepository.ts
+++ b/apps/server/src/dal/userRepository.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
-import { UserRow } from './models';
+import { TableInfoRow, UserRow } from './models';
 import { User } from '@OpsiMate/shared';
 
 export class UserRepository {
@@ -28,7 +28,7 @@ export class UserRepository {
 				.run();
 
 			// Backward compatibility: ensure phone_number column exists
-			const columns = this.db.prepare(`PRAGMA table_info(users)`).all() as { name: string }[];
+			const columns = this.db.prepare(`PRAGMA table_info(users)`).all() as TableInfoRow[];
 			if (!columns.some((col) => col.name === 'phone_number')) {
 				this.db.prepare(`ALTER TABLE users ADD COLUMN phone_number TEXT`).run();
 			}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -206,12 +206,17 @@ export const LoginSchema = z.object({
 
 export const UpdateProfileSchema = z.object({
 	fullName: z.string().min(1, 'Full name is required'),
-	// Optional contact number; an empty string clears it.
+	// Optional contact number; an empty string clears it. Formatting characters are
+	// allowed, but the number must contain 7-15 digits (E.164 range) to be callable.
 	phoneNumber: z
 		.string()
 		.trim()
 		.max(30, 'Phone number is too long')
-		.regex(/^[+\d][\d\s()-]*$/, 'Invalid phone number')
+		.regex(/^\+?[\d\s()-]+$/, 'Invalid phone number')
+		.refine((val) => {
+			const digits = val.replace(/\D/g, '');
+			return digits.length >= 7 && digits.length <= 15;
+		}, 'Invalid phone number')
 		.or(z.literal(''))
 		.optional(),
 	newPassword: z
@@ -560,5 +565,8 @@ export const OncallTeamSchema = z.object({
 
 export const OncallTeamMembersSchema = z.object({
 	// Ordered list — the base call priority (before rotation) follows this order.
-	userIds: z.array(z.coerce.number().int().positive()).max(50),
+	userIds: z
+		.array(z.coerce.number().int().positive())
+		.max(50)
+		.refine((ids) => new Set(ids).size === ids.length, 'Each user may appear only once'),
 });

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -206,6 +206,14 @@ export const LoginSchema = z.object({
 
 export const UpdateProfileSchema = z.object({
 	fullName: z.string().min(1, 'Full name is required'),
+	// Optional contact number; an empty string clears it.
+	phoneNumber: z
+		.string()
+		.trim()
+		.max(30, 'Phone number is too long')
+		.regex(/^[+\d][\d\s()-]*$/, 'Invalid phone number')
+		.or(z.literal(''))
+		.optional(),
 	newPassword: z
 		.string()
 		.min(6, 'Password must be at least 6 characters')
@@ -542,4 +550,15 @@ export const UpdateRetentionConfigSchema = z
 
 export const RetentionResourceParamSchema = z.object({
 	resourceType: z.nativeEnum(RetentionResource),
+});
+
+export const OncallTeamSchema = z.object({
+	name: z.string().trim().min(1, 'Team name is required').max(100),
+	// Days between rotation shifts; 0 or null keeps the order fixed.
+	rotationIntervalDays: z.number().int().min(0).max(365).nullable().optional(),
+});
+
+export const OncallTeamMembersSchema = z.object({
+	// Ordered list — the base call priority (before rotation) follows this order.
+	userIds: z.array(z.coerce.number().int().positive()).max(50),
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -44,6 +44,32 @@ export interface User {
 	fullName: string;
 	role: Role;
 	createdAt: string;
+	// Optional contact number, shown on the on-call page so responders can be phoned.
+	phoneNumber?: string | null;
+}
+
+// On-call scheduling: a team is an ordered group of users where the order defines call
+// priority (1 = called first). With a rotation interval set, the order shifts by one
+// place every interval — computed from the anchor date, so no background job is needed.
+export interface OncallTeamMember {
+	userId: string;
+	fullName: string;
+	email: string;
+	phoneNumber?: string | null;
+	// 1-based call priority after applying the rotation shift (1 = on call now).
+	priority: number;
+}
+
+export interface OncallTeam {
+	id: number;
+	name: string;
+	// Days between rotation shifts; null (or 0) keeps the order fixed.
+	rotationIntervalDays: number | null;
+	// When the current base order took effect; rotation shifts are computed from here.
+	rotationAnchor: string;
+	members: OncallTeamMember[];
+	// When the next shift happens (null when rotation is off or the team is empty).
+	nextRotationAt: string | null;
 }
 
 export interface IntegrationUrls {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -200,6 +200,9 @@ export interface Alert {
 	status: AlertStatus;
 	// Always present on API responses; alerts sent without one default to warning.
 	severity: AlertSeverity;
+	// Owning team, resolved at ingestion from an explicit field or a `team` tag; null when
+	// the alert has no team. Links the alert to the on-call schedule in the details panel.
+	team?: string | null;
 	tags: Record<string, string>;
 	startsAt: string;
 	updatedAt: string;


### PR DESCRIPTION
## What

A new **On-Call** page (sidebar entry + `/oncall`) where admins define who to call when alerts fire, plus an optional **phone number** on the user profile.

- Each **row is a team**; each cell a member (an OpsiMate user), shown in **call order** — priority **1** is on call now, highlighted with their phone number for the NOC.
- **Priorities rotate**: set "rotate every N days" per team and the duty shifts one place down the list every interval (e.g. idan → nadav → noy; after 3 days nadav is first and idan last), wrapping around. Leave empty for a fixed order.
- Admins add/delete teams, add/remove/reorder members (the order in the dialog is the call order), and configure the cadence. Non-admins can view the schedule but not change it.

## How

**Server**
- `oncall_teams` (name, rotation_interval_days, rotation_anchor) + `oncall_team_members` (team_id, user_id, position).
- Rotation is **pure arithmetic** — no cron: `shift = floor(daysSinceAnchor / interval) mod memberCount`; the member at base position `shift` is priority 1. Editing members or the interval resets the anchor so the shown order is the current order.
- Routes: `GET /oncall/teams` (any authenticated user), `POST/PATCH/DELETE /oncall/teams[/:id]` and `PUT /oncall/teams/:id/members` (admins only).
- `users.phone_number` column (guarded migration); `PATCH /users/profile` accepts an optional validated `phoneNumber` (empty clears it).

**Client**
- On-Call page: teams table with ordered member chips (priority-1 highlighted + phone), rotation cadence and next-rotation time; team form dialog with ordered member list (add / remove / move up/down).
- Profile: optional phone input in the edit form + display in profile info.
- Playground: seeded teams (one mid-rotation) and full mock handlers mirroring the server's rotation math.

## Verification

- **Rotation E2E on a real scratch server**: team [idan, nadav, noy] with a 3-day interval; anchor backdated 4 days → nadav first / idan last; 7 days → noy first; 10 days → full cycle back to idan. Admin-only mutations verified (403 for editors, read allowed).
- **Browser (playground)**: page renders both seeded teams with the correct rotated order and on-call phone; creating a team with reordering works; profile shows and saves the phone number.
- Type-error baselines unchanged (client 82 / server 9 pre-existing), prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an On-Call dashboard at `/oncall` with searchable teams, call-order member display, and rotation cadence/next-rotation timing.
  * Admins can create, edit, and delete teams, and drag-and-drop reorder team members.
  * Added optional phone number support across profile, on-call member display, and alert details (with a clickable `tel:` link when available).
* **Bug Fixes**
  * Phone numbers now persist and display end-to-end.
  * Alert “team” information is now persisted and shown consistently across alert views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Added in follow-up commits

- **Drag-and-drop member ordering** in the team dialog (dnd-kit grip handle) instead of up/down arrows; **team search** box matching team names and member names/emails; sidebar entry moved next to Profile.
- **First-class `team` field on alerts** (like severity): resolved at ingestion — explicit field wins, then a `team` tag, default none — persisted through the active/resolved tables and across unresolve. When set, the alert details panel shows a **Team section** with the matching on-call team's current priority-1 responder and a `tel:` link to their phone. Verified E2E (explicit field / tag fallback / none; survives resolve→unresolve) and in the playground browser.