### PR TITLE
fix(alerts): re-firing alert no longer shows as both firing and resolved

### DIFF
--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -89,10 +89,8 @@ export class AlertBL {
 			// || (not ??) so a blank explicit severity falls through to the tag.
 			const severity = normalizeAlertSeverity(alert.severity?.trim() || alert.tags?.['severity']);
 			const tags = { ...(alert.tags ?? {}), severity };
-			// An alert id must never live in both tables: if this alert was previously resolved
-			// (manually or by a source) and is now firing again, drop the resolved copy — the
-			// active row is the truth. Delete first so no poll ever sees the alert twice.
-			await this.resolvedAlertRepo.deleteResolvedAlert(alert.id);
+			// The repository atomically drops any resolved copy of this id — a re-firing
+			// alert must never show as both firing and resolved.
 			return await this.alertRepo.insertOrUpdateAlert({ ...alert, tags, severity });
 		} catch (error) {
 			logger.error('Error inserting alert', error);

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -89,6 +89,10 @@ export class AlertBL {
 			// || (not ??) so a blank explicit severity falls through to the tag.
 			const severity = normalizeAlertSeverity(alert.severity?.trim() || alert.tags?.['severity']);
 			const tags = { ...(alert.tags ?? {}), severity };
+			// An alert id must never live in both tables: if this alert was previously resolved
+			// (manually or by a source) and is now firing again, drop the resolved copy — the
+			// active row is the truth. Delete first so no poll ever sees the alert twice.
+			await this.resolvedAlertRepo.deleteResolvedAlert(alert.id);
 			return await this.alertRepo.insertOrUpdateAlert({ ...alert, tags, severity });
 		} catch (error) {
 			logger.error('Error inserting alert', error);

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -28,20 +28,27 @@ export class AlertRepository {
 											  runbook_url=excluded.runbook_url
 			`);
 
-			const result = stmt.run(
-				alert.id,
-				alert.status,
-				alert.type,
-				alert.severity,
-				JSON.stringify(alert.tags ?? {}),
-				alert.startsAt,
-				alert.updatedAt,
-				alert.alertUrl,
-				alert.alertName,
-				alert.summary || null,
-				alert.runbookUrl || null
-			);
-			return { changes: result.changes };
+			// An alert id must never live in both tables: if this alert was previously
+			// resolved (manually or by a source) and is now firing again, drop the resolved
+			// copy — the active row is the truth. Same transaction as the upsert so a
+			// failure between the two can't leave the alert in neither table.
+			const upsert = this.db.transaction(() => {
+				this.db.prepare(`DELETE FROM alerts_resolved WHERE id = ?`).run(alert.id);
+				return stmt.run(
+					alert.id,
+					alert.status,
+					alert.type,
+					alert.severity,
+					JSON.stringify(alert.tags ?? {}),
+					alert.startsAt,
+					alert.updatedAt,
+					alert.alertUrl,
+					alert.alertName,
+					alert.summary || null,
+					alert.runbookUrl || null
+				);
+			});
+			return { changes: upsert().changes };
 		});
 	}
 

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -148,8 +148,16 @@ export class AlertRepository {
 			// to re-insert a previously-resolved alert into the active table without dropping
 			// its resolved copy, so it showed up twice in the UI. The active row wins — the
 			// alert is firing again. Runs after initResolvedAlertsTable (see app.ts), so
-			// alerts_resolved is guaranteed to exist.
-			this.db.prepare(`DELETE FROM alerts_resolved WHERE id IN (SELECT id FROM alerts)`).run();
+			// alerts_resolved is guaranteed to exist. The users guard is for brand-new
+			// databases: initUsersTable runs after this, and until the users table exists the
+			// dangling owner_id FK on alerts_resolved makes any write to it fail to compile
+			// ("no such table: main.users"). A fresh database has nothing to repair anyway.
+			const usersTableExists = !!this.db
+				.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'users'`)
+				.get();
+			if (usersTableExists) {
+				this.db.prepare(`DELETE FROM alerts_resolved WHERE id IN (SELECT id FROM alerts)`).run();
+			}
 		});
 	}
 

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -143,6 +143,13 @@ export class AlertRepository {
 			if (!hasSeverity) {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN severity TEXT`).run();
 			}
+
+			// Repair: an alert id must never exist as both active and resolved. Ingestion used
+			// to re-insert a previously-resolved alert into the active table without dropping
+			// its resolved copy, so it showed up twice in the UI. The active row wins — the
+			// alert is firing again. Runs after initResolvedAlertsTable (see app.ts), so
+			// alerts_resolved is guaranteed to exist.
+			this.db.prepare(`DELETE FROM alerts_resolved WHERE id IN (SELECT id FROM alerts)`).run();
 		});
 	}
 

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1239,6 +1239,44 @@ describe('Alerts API', () => {
 				expect(resolvedRow.alert_name).toBe(newAlertPayload.alertName);
 				expect(resolvedRow.archived_at).toBeDefined();
 			});
+
+			test('should drop the resolved copy when a resolved alert fires again', async () => {
+				const alertPayload = {
+					id: 'alert-refire',
+					status: 'active',
+					tags: { tag: 'testing' },
+					startsAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+					alertUrl: 'https://example.com/refire-test',
+					alertName: 'Alert that fires again',
+					summary: 'Resolved manually, then reported firing by the source',
+					runbookUrl: 'https://runbook.com/refire',
+				};
+
+				// Fire, then resolve manually (delete moves it to the resolved table)
+				const createResponse = await app
+					.post('/api/v1/alerts/custom')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send(alertPayload);
+				expect(createResponse.status).toBe(200);
+
+				const deleteResponse = await app
+					.delete(`/api/v1/alerts/${alertPayload.id}`)
+					.set('Authorization', `Bearer ${jwtToken}`);
+				expect(deleteResponse.status).toBe(200);
+				expect(db.prepare('SELECT 1 FROM alerts_resolved WHERE id = ?').get(alertPayload.id)).toBeDefined();
+
+				// The same alert fires again: it must exist as active ONLY — a lingering
+				// resolved copy showed the alert twice in the UI (firing + resolved).
+				const refireResponse = await app
+					.post('/api/v1/alerts/custom')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send(alertPayload);
+				expect(refireResponse.status).toBe(200);
+
+				expect(db.prepare('SELECT 1 FROM alerts WHERE id = ?').get(alertPayload.id)).toBeDefined();
+				expect(db.prepare('SELECT 1 FROM alerts_resolved WHERE id = ?').get(alertPayload.id)).toBeUndefined();
+			});
 		});
 
 		describe('DELETE /api/v1/alerts/resolved/:id', () => {


### PR DESCRIPTION
## Bug

Manually resolve an alert (Resolve button), then have the same alert fire again via the API — the alert appeared **twice**: once as resolved and once as firing. Clicking the firing one also showed the resolved footer actions (Unresolve / Delete), because the id was still present in the resolved table.

## Root cause

Ingestion (`AlertBL.insertOrUpdateAlert`, the funnel for every webhook/custom endpoint) re-inserted the alert into the active table but never removed its copy from `alerts_resolved`, so the same id lived in both tables.

## Fix

- **Ingestion**: before inserting the active row, drop the alert's resolved copy (delete-first, so no poll ever sees the alert twice). An id can now never be active and resolved at the same time.
- **Startup repair**: existing databases may already contain duplicated ids — `initAlertsTable` now deletes from `alerts_resolved` any id present in `alerts` (the active row wins: the alert is firing again). It runs after `initResolvedAlertsTable`, so the table is guaranteed to exist.

## Verified

Reproduced and verified end-to-end against a running instance:
1. Create custom alert → manual resolve → re-fire via `POST /alerts/custom` → previously appeared in **both** `GET /alerts` and `GET /alerts/resolved`; now only in `GET /alerts`.
2. Server restart with a pre-duplicated DB → repair removed the stale resolved copy.
3. History timeline reads correctly: firing → resolved manually → firing again.
4. Server type-check unchanged (9-error baseline), prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented alerts from appearing simultaneously as active and resolved when they return to a firing state.
  * Added startup data cleanup to remove duplicate resolved records while preserving the active alert.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->