### PR TITLE
feat(server): audit logging for action mutations

### DIFF
--- a/apps/server/src/api/v1/actions/controller.ts
+++ b/apps/server/src/api/v1/actions/controller.ts
@@ -43,16 +43,19 @@ export class ActionController {
 		}
 	};
 
-	createHandler = async (req: Request, res: Response) => {
+	createHandler = async (req: AuthenticatedRequest, res: Response) => {
 		try {
 			const data = CreateActionSchema.parse(req.body);
-			const action = await this.actionBL.create({
-				name: data.name,
-				type: data.type,
-				config: data.config,
-				nameContains: data.nameContains ?? null,
-				labelMatchers: data.labelMatchers ?? [],
-			});
+			const action = await this.actionBL.create(
+				{
+					name: data.name,
+					type: data.type,
+					config: data.config,
+					nameContains: data.nameContains ?? null,
+					labelMatchers: data.labelMatchers ?? [],
+				},
+				req.user
+			);
 			return res.status(201).json({ success: true, data: action, message: 'Action created' });
 		} catch (error) {
 			if (isZodError(error)) {
@@ -115,7 +118,7 @@ export class ActionController {
 		}
 	};
 
-	updateHandler = async (req: Request, res: Response) => {
+	updateHandler = async (req: AuthenticatedRequest, res: Response) => {
 		try {
 			const { actionId } = ActionIdSchema.parse({ actionId: req.params.actionId });
 			const data = UpdateActionSchema.parse(req.body);
@@ -125,13 +128,17 @@ export class ActionController {
 				return res.status(404).json({ success: false, error: 'Action not found' });
 			}
 
-			const updated = await this.actionBL.update(actionId, {
-				name: data.name,
-				type: data.type,
-				config: data.config,
-				nameContains: data.nameContains ?? null,
-				labelMatchers: data.labelMatchers ?? [],
-			});
+			const updated = await this.actionBL.update(
+				actionId,
+				{
+					name: data.name,
+					type: data.type,
+					config: data.config,
+					nameContains: data.nameContains ?? null,
+					labelMatchers: data.labelMatchers ?? [],
+				},
+				req.user
+			);
 			return res.json({ success: true, data: updated, message: 'Action updated' });
 		} catch (error) {
 			if (isZodError(error)) {
@@ -142,14 +149,14 @@ export class ActionController {
 		}
 	};
 
-	deleteHandler = async (req: Request, res: Response) => {
+	deleteHandler = async (req: AuthenticatedRequest, res: Response) => {
 		try {
 			const { actionId } = ActionIdSchema.parse({ actionId: req.params.actionId });
 			const existing = await this.actionBL.get(actionId);
 			if (!existing) {
 				return res.status(404).json({ success: false, error: 'Action not found' });
 			}
-			await this.actionBL.delete(actionId);
+			await this.actionBL.delete(actionId, req.user);
 			return res.json({ success: true, message: 'Action deleted' });
 		} catch (error) {
 			if (isZodError(error)) {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -173,7 +173,7 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	alertBL.setMutePolicyBL(mutePolicyBL);
 	const enrichmentBL = new EnrichmentBL(enrichmentRepo, auditBL);
 	alertBL.setEnrichmentBL(enrichmentBL);
-	const actionBL = new ActionBL(actionRepo, alertHistoryRepo);
+	const actionBL = new ActionBL(actionRepo, auditBL, alertHistoryRepo);
 
 	// Controllers (only for SERVER)
 	const providerController = new ProviderController(providerBL, secretsMetadataRepo);

--- a/apps/server/src/bl/actions/action.bl.ts
+++ b/apps/server/src/bl/actions/action.bl.ts
@@ -1,6 +1,17 @@
-import { Action, AlertHistoryEventType, ActionOverrides, ActionPreview, ActionTestResult } from '@OpsiMate/shared';
+import {
+	Action,
+	AlertHistoryEventType,
+	ActionOverrides,
+	ActionPreview,
+	ActionTestResult,
+	AuditActionType,
+	AuditResourceType,
+	Logger,
+	User,
+} from '@OpsiMate/shared';
 import { ActionRepository, CreateActionInput, UpdateActionInput } from '../../dal/actionRepository';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
+import { AuditBL } from '../audit/audit.bl';
 import {
 	AlertContextInput,
 	buildAlertContext,
@@ -10,9 +21,15 @@ import {
 	previewAction,
 } from './actionExecutor';
 
+const logger = new Logger('bl/action.bl');
+
+const API_TOKEN_ACTOR_ID = 0;
+const API_TOKEN_ACTOR_NAME = 'API Token';
+
 export class ActionBL {
 	constructor(
 		private actionRepo: ActionRepository,
+		private auditBL: AuditBL,
 		private alertHistoryRepo?: AlertHistoryRepository
 	) {}
 
@@ -53,12 +70,13 @@ export class ActionBL {
 		return result;
 	}
 
-	async create(data: CreateActionInput): Promise<Action> {
+	async create(data: CreateActionInput, actor?: User | null): Promise<Action> {
 		const { lastID } = await this.actionRepo.createAction(data);
 		const created = await this.actionRepo.getActionById(lastID);
 		if (!created) {
 			throw new Error('Failed to retrieve created action');
 		}
+		await this.recordAuditAction(AuditActionType.CREATE, created, actor);
 		return created;
 	}
 
@@ -70,12 +88,50 @@ export class ActionBL {
 		return this.actionRepo.getActionById(id);
 	}
 
-	async update(id: number, data: UpdateActionInput): Promise<Action | undefined> {
+	async update(id: number, data: UpdateActionInput, actor?: User | null): Promise<Action | undefined> {
 		await this.actionRepo.updateAction(id, data);
-		return this.actionRepo.getActionById(id);
+		const updated = await this.actionRepo.getActionById(id);
+		if (updated) {
+			await this.recordAuditAction(AuditActionType.UPDATE, updated, actor, JSON.stringify(data));
+		}
+		return updated;
 	}
 
-	async delete(id: number): Promise<void> {
+	async delete(id: number, actor?: User | null): Promise<void> {
+		const existing = await this.actionRepo.getActionById(id);
 		await this.actionRepo.deleteAction(id);
+		if (existing) {
+			await this.recordAuditAction(AuditActionType.DELETE, existing, actor);
+		}
+	}
+
+	private getAuditActor(actor?: User | null): { userId: number; userName: string } {
+		const parsedUserId = actor?.id !== undefined ? Number(actor.id) : NaN;
+		return {
+			userId: Number.isFinite(parsedUserId) ? parsedUserId : API_TOKEN_ACTOR_ID,
+			userName: actor?.fullName ?? API_TOKEN_ACTOR_NAME,
+		};
+	}
+
+	private async recordAuditAction(
+		actionType: AuditActionType,
+		action: Action,
+		actor?: User | null,
+		details?: string
+	): Promise<void> {
+		try {
+			const auditActor = this.getAuditActor(actor);
+			await this.auditBL.logAction({
+				actionType,
+				resourceType: AuditResourceType.ACTION,
+				resourceId: String(action.id),
+				userId: auditActor.userId,
+				userName: auditActor.userName,
+				resourceName: action.name,
+				details,
+			});
+		} catch (error) {
+			logger.error(`Failed to record action audit event (${actionType}) for ${action.id}`, error);
+		}
 	}
 }

--- a/apps/server/tests/action-audit.test.ts
+++ b/apps/server/tests/action-audit.test.ts
@@ -1,0 +1,103 @@
+import { SuperTest, Test } from 'supertest';
+import { AuditActionType, AuditResourceType, AuditLog } from '@OpsiMate/shared';
+import Database from 'better-sqlite3';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup.ts';
+
+let app: SuperTest<Test>;
+let db: Database.Database;
+let jwtToken: string;
+let testUserId: number;
+
+const slackAction = {
+	name: 'Audit Slack Action',
+	type: 'slack',
+	config: { webhookUrl: 'https://hooks.slack.com/services/T000/B000/xyz' },
+};
+
+beforeAll(async () => {
+	db = await setupDB();
+	app = await setupExpressApp(db);
+	jwtToken = await setupUserWithToken(app);
+	const testUser = db.prepare('SELECT id FROM users WHERE email = ?').get('provideruser@example.com') as
+		| { id: number }
+		| undefined;
+	if (!testUser) {
+		throw new Error('Expected test user provideruser@example.com to exist');
+	}
+	testUserId = testUser.id;
+});
+
+beforeEach(() => {
+	db.exec('DELETE FROM audit_logs');
+});
+
+afterAll(() => {
+	db.close();
+});
+
+describe('Action Audit Logs', () => {
+	test('should log action creation and retrieve audit log', async () => {
+		const createRes = await app
+			.post('/api/v1/actions')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send(slackAction);
+
+		expect(createRes.status).toBe(201);
+		expect(createRes.body.success).toBe(true);
+
+		const auditRes = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
+		expect(auditRes.status).toBe(200);
+		expect(Array.isArray(auditRes.body.logs)).toBe(true);
+		expect(auditRes.body.logs.length).toBe(1);
+
+		const log: AuditLog = auditRes.body.logs[0];
+		expect(log.actionType).toBe(AuditActionType.CREATE);
+		expect(log.resourceType).toBe(AuditResourceType.ACTION);
+		expect(log.resourceId).toBe(String(createRes.body.data.id));
+		expect(log.resourceName).toBe(slackAction.name);
+		expect(log.userId).toBe(testUserId);
+		expect(log.userName).toBe('Provider User');
+		expect(log.timestamp).toBeDefined();
+	});
+
+	test('should log action create, update and delete audit entries', async () => {
+		const createRes = await app
+			.post('/api/v1/actions')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send(slackAction);
+
+		expect(createRes.status).toBe(201);
+		const resourceId = String(createRes.body.data.id);
+
+		const updateRes = await app
+			.put(`/api/v1/actions/${resourceId}`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...slackAction, name: 'Audit Slack Action Updated' });
+		expect(updateRes.status).toBe(200);
+
+		const deleteRes = await app
+			.delete(`/api/v1/actions/${resourceId}`)
+			.set('Authorization', `Bearer ${jwtToken}`);
+		expect(deleteRes.status).toBe(200);
+
+		const auditRes = await app.get('/api/v1/audit?page=1&pageSize=10').set('Authorization', `Bearer ${jwtToken}`);
+		expect(auditRes.status).toBe(200);
+
+		const logs = auditRes.body.logs as AuditLog[];
+		const actionLogs = logs.filter(
+			(log) => log.resourceType === AuditResourceType.ACTION && log.resourceId === resourceId
+		);
+
+		expect(actionLogs).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ actionType: AuditActionType.CREATE }),
+				expect.objectContaining({ actionType: AuditActionType.UPDATE }),
+				expect.objectContaining({ actionType: AuditActionType.DELETE }),
+			])
+		);
+		for (const log of actionLogs) {
+			expect(log.userId).toBe(testUserId);
+			expect(log.userName).toBe('Provider User');
+		}
+	});
+});

--- a/apps/server/tests/action-audit.test.ts
+++ b/apps/server/tests/action-audit.test.ts
@@ -75,9 +75,7 @@ describe('Action Audit Logs', () => {
 			.send({ ...slackAction, name: 'Audit Slack Action Updated' });
 		expect(updateRes.status).toBe(200);
 
-		const deleteRes = await app
-			.delete(`/api/v1/actions/${resourceId}`)
-			.set('Authorization', `Bearer ${jwtToken}`);
+		const deleteRes = await app.delete(`/api/v1/actions/${resourceId}`).set('Authorization', `Bearer ${jwtToken}`);
 		expect(deleteRes.status).toBe(200);
 
 		const auditRes = await app.get('/api/v1/audit?page=1&pageSize=10').set('Authorization', `Bearer ${jwtToken}`);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -256,6 +256,7 @@ export enum AuditResourceType {
 	DASHBOARD = 'DASHBOARD',
 	SECRET = 'SECRET',
 	ENRICHMENT = 'ENRICHMENT',
+	ACTION = 'ACTION',
 	// Add more as needed
 }
 


### PR DESCRIPTION
## Issue Reference

Closes #651

---

## What Was Changed

Custom actions are now recorded in the audit log on create, update, and delete.

- `packages/shared/src/types.ts` — added `ACTION` to the `AuditResourceType` enum.
- `apps/server/src/bl/actions/action.bl.ts` — injected `AuditBL` into `ActionBL` and added best-effort `recordAuditAction` calls to `create`/`update`/`delete`, mirroring the existing `EnrichmentBL` implementation.
- `apps/server/src/api/v1/actions/controller.ts` — typed the create/update/delete handlers as `AuthenticatedRequest` and passed `req.user` through as the acting user (the run handler already did this).
- `apps/server/src/app.ts` — wired the existing `auditBL` into the `ActionBL` constructor.
- `apps/server/tests/action-audit.test.ts` — new server test asserting the audit row on create, plus create/update/delete coverage, following `audit.test.ts`.

---

## Why Was It Changed

Creating, updating, or deleting an action left no trace in the audit log, while every other mutable resource (providers, users, dashboards, secrets, enrichments) already writes audit rows. Actions were therefore a blind spot on the Audit page.

The fix mirrors the enrichment audit pattern (PR #663) exactly, so it stays consistent with the rest of the codebase:

- Audit writes are best-effort — wrapped in try/catch and logged on failure — so a failing audit insert never fails the mutation itself.
- API-token requests that carry no `req.user` do not crash; the actor falls back to id `0` / `API Token`.

---

## Screenshots

N/A - server-only change (audit-log record writes); no UI or visual diff. Behavior is covered by the new `action-audit` server test.

---

## Additional Context (Optional)

Verified with `pnpm --filter @OpsiMate/server test` (115 tests pass, including the new `action-audit` file) and a `tsc --noEmit` typecheck with no new errors.
