### PR TITLE
fix(alerts): summary column crushed to zero width, headers painting over each other

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -45,8 +45,10 @@ export const COLUMN_MIN_WIDTHS: Record<string, number> = {
 	type: 48,
 	severity: 48,
 	status: 48,
-	alertName: 180,
-	summary: 160,
+	// The two flexible (w-auto) columns split leftover space equally, so they share
+	// one minimum — declaring different ones would be unenforceable.
+	alertName: 170,
+	summary: 170,
 	owner: 120,
 	startsAt: 150,
 	// Rendered at ACTIONS_COLUMN_WIDTH (inline style), not COLUMN_WIDTHS.

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -18,17 +18,38 @@ export const COLUMN_LABELS: Record<string, string> = {
 	startsAt: 'Started At',
 };
 
+// Every column except alertName and summary has a fixed width; those two share the
+// leftover space equally (the table is layout-fixed). Percentage widths are deliberately
+// avoided: with enough columns visible their sum exceeded the table's width and the
+// auto-width summary column silently collapsed to 0px, letting neighbors paint over it.
 export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
 	// Type, severity and status are icon-only columns (icon-only headers too, names in
 	// tooltips).
 	type: 'w-12 min-w-12 max-w-12',
-	alertName: 'w-[26%]',
+	alertName: 'w-auto',
 	severity: 'w-12 min-w-12 max-w-12',
 	status: 'w-12 min-w-12 max-w-12',
 	summary: 'w-auto',
-	owner: 'w-[12%]',
-	startsAt: 'w-[15%]',
+	owner: 'w-[120px]',
+	startsAt: 'w-[150px]',
 	[ACTIONS_COLUMN]: 'w-14 min-w-14 max-w-14',
-	default: 'w-[10%]',
+	default: 'w-[110px]',
+};
+
+// Per-column minimums (px) summed into the table's floor width: the table never renders
+// narrower than its visible columns' minimums — below that the whole table (header and
+// body together) scrolls horizontally instead of crushing a column.
+export const COLUMN_MIN_WIDTHS: Record<string, number> = {
+	select: 40,
+	type: 48,
+	severity: 48,
+	status: 48,
+	alertName: 180,
+	summary: 160,
+	owner: 120,
+	startsAt: 150,
+	// Rendered at ACTIONS_COLUMN_WIDTH (inline style), not COLUMN_WIDTHS.
+	[ACTIONS_COLUMN]: 80,
+	default: 110,
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -138,7 +138,13 @@ export const AlertsTable = ({
 					    auto-width summary column silently collapsing to zero. */}
 					<div className="flex-1 min-h-0 overflow-x-auto">
 						<div className="flex h-full flex-col" style={{ minWidth: tableMinWidth }}>
-							<div className="border-b flex-shrink-0">
+							{/* overflow-hidden + stable gutter mirrors the body scrollport's reserved
+							    scrollbar gutter (see below) so header and body columns stay aligned on
+							    classic-scrollbar systems. */}
+							<div
+								className="border-b flex-shrink-0 overflow-hidden"
+								style={{ scrollbarGutter: 'stable' }}
+							>
 								<Table className="table-fixed w-full">
 									<TableHeader>
 										<TableRow className="h-8">
@@ -255,7 +261,13 @@ export const AlertsTable = ({
 									))}
 								</div>
 
-								<div ref={parentRef} className="overflow-y-auto h-full w-full relative">
+								{/* Stable gutter: non-overlay scrollbars otherwise shrink the rows relative
+							    to the header, drifting the auto-width columns by the scrollbar width. */}
+								<div
+									ref={parentRef}
+									className="overflow-y-auto h-full w-full relative"
+									style={{ scrollbarGutter: 'stable' }}
+								>
 									{isLoading ? (
 										<div className="flex items-center justify-center py-8 text-sm text-foreground">
 											Loading alerts...

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -136,7 +136,7 @@ export const AlertsTable = ({
 					{/* Header and body share this horizontal scroller: when the pane is narrower
 					    than the table's minimum width they scroll sideways together, instead of the
 					    auto-width summary column silently collapsing to zero. */}
-					<div className="flex-1 min-h-0 overflow-x-auto">
+					<div className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden">
 						<div className="flex h-full flex-col" style={{ minWidth: tableMinWidth }}>
 							{/* overflow-hidden + stable gutter mirrors the body scrollport's reserved
 							    scrollbar gutter (see below) so header and body columns stay aligned on
@@ -265,7 +265,7 @@ export const AlertsTable = ({
 							    to the header, drifting the auto-width columns by the scrollbar width. */}
 								<div
 									ref={parentRef}
-									className="overflow-y-auto h-full w-full relative"
+									className="overflow-y-auto overflow-x-hidden h-full w-full relative"
 									style={{ scrollbarGutter: 'stable' }}
 								>
 									{isLoading ? (

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -10,6 +10,7 @@ import {
 	ACTIONS_COLUMN,
 	ACTIONS_COLUMN_WIDTH,
 	COLUMN_LABELS,
+	COLUMN_MIN_WIDTHS,
 	COLUMN_WIDTHS,
 	DEFAULT_COLUMN_ORDER,
 	DEFAULT_VISIBLE_COLUMNS,
@@ -101,6 +102,13 @@ export const AlertsTable = ({
 		return [...filtered, ACTIONS_COLUMN];
 	}, [columnOrder, visibleColumns]);
 
+	// Floor width for the table: the sum of the visible columns' minimums. Narrower
+	// panes get a horizontal scrollbar instead of columns crushing each other.
+	const tableMinWidth = useMemo(() => {
+		const columns = onSelectAlerts ? ['select', ...orderedColumns] : orderedColumns;
+		return columns.reduce((sum, col) => sum + (COLUMN_MIN_WIDTHS[col] ?? COLUMN_MIN_WIDTHS.default), 0);
+	}, [orderedColumns, onSelectAlerts]);
+
 	const hasActiveTimeFilter = timeRange && !isTimeRangeEmpty(timeRange);
 
 	return (
@@ -125,156 +133,163 @@ export const AlertsTable = ({
 							{heading}
 						</div>
 					)}
-					<div className="border-b flex-shrink-0">
-						<Table className="table-fixed w-full">
-							<TableHeader>
-								<TableRow className="h-8">
-									{onSelectAlerts && (
-										<TableHead
-											className={TABLE_HEAD_CLASSES}
-											style={{
-												width: SELECT_COLUMN_WIDTH,
-												minWidth: SELECT_COLUMN_WIDTH,
-												maxWidth: SELECT_COLUMN_WIDTH,
-											}}
-										>
-											<div className="flex items-center justify-center">
-												<Checkbox
-													checked={
-														sortedAlerts.length > 0 &&
-														selectedAlerts.length === sortedAlerts.length
-													}
-													onCheckedChange={handleSelectAll}
-													className="h-3 w-3 border-2 data-[state=checked]:bg-primary data-[state=checked]:border-primary"
-												/>
-											</div>
-										</TableHead>
-									)}
-									{orderedColumns.map((column) => {
-										if (column === ACTIONS_COLUMN) {
-											return (
+					{/* Header and body share this horizontal scroller: when the pane is narrower
+					    than the table's minimum width they scroll sideways together, instead of the
+					    auto-width summary column silently collapsing to zero. */}
+					<div className="flex-1 min-h-0 overflow-x-auto">
+						<div className="flex h-full flex-col" style={{ minWidth: tableMinWidth }}>
+							<div className="border-b flex-shrink-0">
+								<Table className="table-fixed w-full">
+									<TableHeader>
+										<TableRow className="h-8">
+											{onSelectAlerts && (
 												<TableHead
-													key={column}
-													className={`${TABLE_HEAD_CLASSES} text-xs`}
+													className={TABLE_HEAD_CLASSES}
 													style={{
-														width: ACTIONS_COLUMN_WIDTH,
-														minWidth: ACTIONS_COLUMN_WIDTH,
-														maxWidth: ACTIONS_COLUMN_WIDTH,
+														width: SELECT_COLUMN_WIDTH,
+														minWidth: SELECT_COLUMN_WIDTH,
+														maxWidth: SELECT_COLUMN_WIDTH,
 													}}
 												>
-													<div className="flex items-center justify-end gap-2 min-w-0">
-														<GroupByControls
-															groupByColumns={groupByColumns}
-															onGroupByChange={setGroupByColumns}
-															availableColumns={visibleColumns}
-															columnLabels={allColumnLabels}
-															onExpandAll={expandAll}
-															onCollapseAll={collapseAll}
+													<div className="flex items-center justify-center">
+														<Checkbox
+															checked={
+																sortedAlerts.length > 0 &&
+																selectedAlerts.length === sortedAlerts.length
+															}
+															onCheckedChange={handleSelectAll}
+															className="h-3 w-3 border-2 data-[state=checked]:bg-primary data-[state=checked]:border-primary"
 														/>
-														{onColumnToggle && (
-															<ColumnSettingsDropdown
-																visibleColumns={visibleColumns}
-																onColumnToggle={onColumnToggle}
-																columnLabels={COLUMN_LABELS}
-																excludeColumns={[ACTIONS_COLUMN]}
-																tagKeys={tagKeys}
-															/>
-														)}
 													</div>
 												</TableHead>
-											);
-										}
-										if (isTagKeyColumn(column)) {
-											const tagKey = extractTagKeyFromColumnId(column);
-											const label = allColumnLabels[column] || tagKey || column;
-											return (
-												<SortableHeader
-													key={column}
-													column={column as AlertSortField}
-													label={label}
-													sortField={sortField}
-													sortDirection={sortDirection}
-													onSort={handleSort}
-													className={COLUMN_WIDTHS.default}
-												/>
-											);
-										}
-										if (
-											[
-												'alertName',
-												'severity',
-												'status',
-												'startsAt',
-												'summary',
-												'type',
-												'owner',
-											].includes(column)
-										) {
-											return (
-												<SortableHeader
-													key={column}
-													column={column as AlertSortField}
-													label={allColumnLabels[column]}
-													labelIcon={HEADER_ICONS[column]}
-													sortField={sortField}
-													sortDirection={sortDirection}
-													onSort={handleSort}
-													className={COLUMN_WIDTHS[column]}
-												/>
-											);
-										}
-										return null;
-									})}
-								</TableRow>
-							</TableHeader>
-						</Table>
-					</div>
+											)}
+											{orderedColumns.map((column) => {
+												if (column === ACTIONS_COLUMN) {
+													return (
+														<TableHead
+															key={column}
+															className={`${TABLE_HEAD_CLASSES} text-xs`}
+															style={{
+																width: ACTIONS_COLUMN_WIDTH,
+																minWidth: ACTIONS_COLUMN_WIDTH,
+																maxWidth: ACTIONS_COLUMN_WIDTH,
+															}}
+														>
+															<div className="flex items-center justify-end gap-2 min-w-0">
+																<GroupByControls
+																	groupByColumns={groupByColumns}
+																	onGroupByChange={setGroupByColumns}
+																	availableColumns={visibleColumns}
+																	columnLabels={allColumnLabels}
+																	onExpandAll={expandAll}
+																	onCollapseAll={collapseAll}
+																/>
+																{onColumnToggle && (
+																	<ColumnSettingsDropdown
+																		visibleColumns={visibleColumns}
+																		onColumnToggle={onColumnToggle}
+																		columnLabels={COLUMN_LABELS}
+																		excludeColumns={[ACTIONS_COLUMN]}
+																		tagKeys={tagKeys}
+																	/>
+																)}
+															</div>
+														</TableHead>
+													);
+												}
+												if (isTagKeyColumn(column)) {
+													const tagKey = extractTagKeyFromColumnId(column);
+													const label = allColumnLabels[column] || tagKey || column;
+													return (
+														<SortableHeader
+															key={column}
+															column={column as AlertSortField}
+															label={label}
+															sortField={sortField}
+															sortDirection={sortDirection}
+															onSort={handleSort}
+															className={COLUMN_WIDTHS.default}
+														/>
+													);
+												}
+												if (
+													[
+														'alertName',
+														'severity',
+														'status',
+														'startsAt',
+														'summary',
+														'type',
+														'owner',
+													].includes(column)
+												) {
+													return (
+														<SortableHeader
+															key={column}
+															column={column as AlertSortField}
+															label={allColumnLabels[column]}
+															labelIcon={HEADER_ICONS[column]}
+															sortField={sortField}
+															sortDirection={sortDirection}
+															onSort={handleSort}
+															className={COLUMN_WIDTHS[column]}
+														/>
+													);
+												}
+												return null;
+											})}
+										</TableRow>
+									</TableHeader>
+								</Table>
+							</div>
 
-					<div className="flex-1 min-h-0 relative">
-						<div className="absolute top-0 left-0 right-0 z-20">
-							{activeStickyHeaders.map((item) => (
-								<StickyGroupHeader
-									key={`sticky-${item.type === 'group' ? item.key : ''}`}
-									item={item}
-									onToggle={toggleGroup}
-									columnLabels={allColumnLabels}
-								/>
-							))}
-						</div>
+							<div className="flex-1 min-h-0 relative">
+								<div className="absolute top-0 left-0 right-0 z-20">
+									{activeStickyHeaders.map((item) => (
+										<StickyGroupHeader
+											key={`sticky-${item.type === 'group' ? item.key : ''}`}
+											item={item}
+											onToggle={toggleGroup}
+											columnLabels={allColumnLabels}
+										/>
+									))}
+								</div>
 
-						<div ref={parentRef} className="overflow-auto h-full w-full relative">
-							{isLoading ? (
-								<div className="flex items-center justify-center py-8 text-sm text-foreground">
-									Loading alerts...
+								<div ref={parentRef} className="overflow-y-auto h-full w-full relative">
+									{isLoading ? (
+										<div className="flex items-center justify-center py-8 text-sm text-foreground">
+											Loading alerts...
+										</div>
+									) : flatRows.length === 0 ? (
+										<div className="flex items-center justify-center py-8 text-sm text-foreground">
+											{searchTerm ? 'No alerts found matching your search.' : 'No alerts found.'}
+										</div>
+									) : (
+										<VirtualizedAlertList
+											virtualizer={virtualizer}
+											flatRows={flatRows}
+											selectedAlerts={selectedAlerts}
+											orderedColumns={orderedColumns}
+											onToggleGroup={toggleGroup}
+											onSelectAlert={handleSelectAlert}
+											onAlertClick={onAlertClick}
+											activeAlertId={activeAlertId}
+											onSilenceAlert={onSilenceAlert}
+											onUnsilenceAlert={onUnsilenceAlert}
+											onDeleteAlert={onDeleteAlert}
+											onUnresolveAlert={onUnresolveAlert}
+											onSelectAlerts={onSelectAlerts}
+											columnLabels={allColumnLabels}
+											isResolved={isResolved}
+											severityColors={severityColors}
+											isDragging={isDragging}
+											onDragStart={handleDragStart}
+											onDragEnter={handleDragEnter}
+											onDragEnd={() => handleDragEnd(handleSelectAlert)}
+										/>
+									)}
 								</div>
-							) : flatRows.length === 0 ? (
-								<div className="flex items-center justify-center py-8 text-sm text-foreground">
-									{searchTerm ? 'No alerts found matching your search.' : 'No alerts found.'}
-								</div>
-							) : (
-								<VirtualizedAlertList
-									virtualizer={virtualizer}
-									flatRows={flatRows}
-									selectedAlerts={selectedAlerts}
-									orderedColumns={orderedColumns}
-									onToggleGroup={toggleGroup}
-									onSelectAlert={handleSelectAlert}
-									onAlertClick={onAlertClick}
-									activeAlertId={activeAlertId}
-									onSilenceAlert={onSilenceAlert}
-									onUnsilenceAlert={onUnsilenceAlert}
-									onDeleteAlert={onDeleteAlert}
-									onUnresolveAlert={onUnresolveAlert}
-									onSelectAlerts={onSelectAlerts}
-									columnLabels={allColumnLabels}
-									isResolved={isResolved}
-									severityColors={severityColors}
-									isDragging={isDragging}
-									onDragStart={handleDragStart}
-									onDragEnter={handleDragEnter}
-									onDragEnd={() => handleDragEnd(handleSelectAlert)}
-								/>
-							)}
+							</div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Issue Reference

N/A — reported directly: the Summary column looked broken at some resolutions, with the Owner header showing overlapping glyphs (a sort arrow from the crushed Summary header painting over it).

---

## What Was Changed

The alerts-table width system is reworked to survive any visible-column combination:

- **owner / startsAt / tag columns**: fixed px widths (120 / 150 / 110) instead of percentages.
- **alertName + summary**: the two flexible columns, sharing leftover space equally.
- **Computed floor width**: the table never renders narrower than the sum of its visible columns' minimums (`COLUMN_MIN_WIDTHS`). Below that, the header and body scroll horizontally **together** (one shared scroller) instead of crushing a column. Vertical scrolling is unchanged.

---

## Why Was It Changed

Summary was the only `w-auto` column in a percentage-based fixed layout, so it absorbed the entire width deficit before any other column shrank. Measured with the details panel open:

| Scenario | Summary width before | after |
|---|---|---|
| 1440px viewport | 50px | 170px |
| 1280px viewport | **0px** | 170px |
| 1280px + 3 tag columns | **0px** | 170px |

At 0px the Summary column vanished and its header's sort arrow painted over the "Owner" header — the reported artifact. Percentages made this unfixable with a static floor: every extra visible column (tags) grew the percent total past the table's budget.

---

## Screenshots

Verified visually: at 1280px with details open the Summary shows real text and the Owner header renders clean; at 1920px full-width, Alert Name and Summary each grow to ~477px with fully readable summaries.

---

## Additional Context (Optional)

Verified with Playwright against a running instance: header/body worst column drift is 0px before and after horizontal scrolling; alignment probes pass at 1100–1920px with the details panel open and closed, with and without tag columns, on the All tab, split-by-owner, and zoom 0.8–1.25. Client tsc at the 82-error baseline; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Alerts table layout and column sizing for more consistent readability.
  * Prevented columns from becoming too narrow in smaller panes.
  * Synchronized horizontal scrolling between the table header and its contents.
  * Maintained vertical scrolling without creating separate horizontal scroll areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->