### PR TITLE
chore: migrate links to the opsimate.dev domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@
 </p>
 
 <p align="center">
-  <a href="https://opsimate.vercel.app/docs/getting-started/deploy">Get Started</a> ·
-  <a href="https://opsimate.vercel.app/">Docs</a> ·
+  <a href="https://docs.opsimate.dev/docs/getting-started/deploy">Get Started</a> ·
+  <a href="https://docs.opsimate.dev/">Docs</a> ·
   <a href="https://opsimate.goprosite.net">Demo</a> ·
-  <a href="https://www.opsimate.com/">Website</a> ·
+  <a href="https://www.opsimate.dev/">Website</a> ·
   <a href="https://github.com/OpsiMate/OpsiMate/issues/new?labels=bug&template=bug_report.md">Report Bug</a>
 </p>
 
@@ -176,10 +176,10 @@ We welcome contributions to OpsiMate! Here's how you can help:
 
 ## Support
 
-- **[Documentation](https://opsimate.vercel.app/)** - Comprehensive guides and API reference
+- **[Documentation](https://docs.opsimate.dev/)** - Comprehensive guides and API reference
 - **[GitHub Issues](https://github.com/opsimate/opsimate/issues)** - Bug reports and feature requests
 - **[Slack Community](https://join.slack.com/t/opsimate/shared_invite/zt-39bq3x6et-NrVCZzH7xuBGIXmOjJM7gA)** - Join our discussions and get help
-- **[Website](https://www.opsimate.com/)** - Learn more about OpsiMate
+- **[Website](https://www.opsimate.dev/)** - Learn more about OpsiMate
 
 ---
 

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -44,7 +44,7 @@
 		/>
 
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://opsimate.com/" />
+		<meta property="og:url" content="https://opsimate.dev/" />
 		<meta property="og:title" content="OpsiMate - Real-Time Infrastructure Monitoring Dashboard" />
 		<meta
 			property="og:description"
@@ -56,7 +56,7 @@
 		<meta property="og:site_name" content="OpsiMate" />
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:url" content="https://opsimate.com/" />
+		<meta name="twitter:url" content="https://opsimate.dev/" />
 		<meta name="twitter:title" content="OpsiMate - Real-Time Infrastructure Monitoring Dashboard" />
 		<meta
 			name="twitter:description"

--- a/apps/client/src/components/ForgotPasswordSuccess.tsx
+++ b/apps/client/src/components/ForgotPasswordSuccess.tsx
@@ -13,7 +13,7 @@ const ForgotPasswordSuccess: React.FC = () => {
 					<br />
 					See{' '}
 					<a
-						href="https://opsimate.vercel.app/docs/getting-started/configuration"
+						href="https://docs.opsimate.dev/docs/getting-started/configuration"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="text-primary underline"

--- a/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
+++ b/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
@@ -439,7 +439,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 						<Button
 							variant="outline"
 							onClick={() =>
-								window.open('https://opsimate.vercel.app/docs/integrations/custom-alerts', '_blank')
+								window.open('https://docs.opsimate.dev/docs/integrations/custom-alerts', '_blank')
 							}
 							className="gap-2"
 						>

--- a/apps/client/src/pages/Integrations.tsx
+++ b/apps/client/src/pages/Integrations.tsx
@@ -93,7 +93,7 @@ const INTEGRATIONS: Integration[] = [
 		description: 'Receive monitoring alerts from Google Cloud Platform via webhook.',
 		logo: GCPIcon,
 		tags: ['Monitoring', 'Alerts', 'Cloud'],
-		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/gcp',
+		documentationUrl: 'https://docs.opsimate.dev/docs/integrations/gcp',
 		configFields: [],
 		enabled: true, // GCP integration is enabled by default
 	},
@@ -104,7 +104,7 @@ const INTEGRATIONS: Integration[] = [
 		description: 'Receive alerts from Uptime Kuma monitoring via webhook.',
 		logo: UptimeKumaIcon,
 		tags: ['Monitoring', 'Alerts', 'Uptime'],
-		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/uptime-kuma',
+		documentationUrl: 'https://docs.opsimate.dev/docs/integrations/uptime-kuma',
 		configFields: [],
 		enabled: true, // integration is enabled by default
 	},
@@ -115,7 +115,7 @@ const INTEGRATIONS: Integration[] = [
 		description: 'Receive alerts from Grafana via a Webhook contact point (push).',
 		logo: GrafanaIcon,
 		tags: ['Monitoring', 'Visualization', 'Alerts'],
-		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/grafana',
+		documentationUrl: 'https://docs.opsimate.dev/docs/integrations/grafana',
 		configFields: [],
 		enabled: true, // Grafana alerts are received via webhook (no credentials stored)
 	},
@@ -126,7 +126,7 @@ const INTEGRATIONS: Integration[] = [
 		description: 'Cloud monitoring and analytics platform for infrastructure, applications, and logs.',
 		logo: DatadogIcon,
 		tags: ['Monitoring', 'APM', 'Logs', 'Metrics', 'Alerts'],
-		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/datadog',
+		documentationUrl: 'https://docs.opsimate.dev/docs/integrations/datadog',
 		// Datadog alert webhooks are supported by default (via /alerts/custom/datadog)
 		enabled: true,
 		configFields: [
@@ -148,7 +148,7 @@ const INTEGRATIONS: Integration[] = [
 		description: 'Enterprise-class open source monitoring solution for networks and applications.',
 		logo: ZabbixIcon,
 		tags: ['Monitoring', 'Alerts', 'Infrastructure'],
-		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/zabbix',
+		documentationUrl: 'https://docs.opsimate.dev/docs/integrations/zabbix',
 		configFields: [],
 		enabled: true,
 	},
@@ -159,7 +159,7 @@ const INTEGRATIONS: Integration[] = [
 		description: 'Log analytics platform powered by machine learning.',
 		logo: CoralogixIcon,
 		tags: ['Logging', 'Analytics', 'Monitoring'],
-		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/overview',
+		documentationUrl: 'https://docs.opsimate.dev/docs/integrations/overview',
 		configFields: [
 			{ name: 'apiKey', label: 'API Key', type: 'password', required: true },
 			{ name: 'applicationName', label: 'Application Name', type: 'text', required: true },
@@ -173,7 +173,7 @@ const INTEGRATIONS: Integration[] = [
 		description: 'Send alerts from any source via HTTP POST requests. Perfect for custom scripts and tools.',
 		logo: ({ className }: { className?: string }) => <Webhook className={className} />,
 		tags: ['Alerts', 'Monitoring'],
-		documentationUrl: 'https://opsimate.vercel.app/docs/integrations/custom-alerts',
+		documentationUrl: 'https://docs.opsimate.dev/docs/integrations/custom-alerts',
 		configFields: [],
 		enabled: true,
 	},

--- a/apps/server/src/dal/external-client/mail-client.ts
+++ b/apps/server/src/dal/external-client/mail-client.ts
@@ -185,7 +185,7 @@ export class MailClient {
 			}
 
 			await this.transporter.sendMail({
-				from: this.mailerConfig?.from || '"OpsiMate" <no-reply@opsimate.com>',
+				from: this.mailerConfig?.from || '"OpsiMate" <no-reply@opsimate.dev>',
 				to: options.to,
 				subject: this.getMailSubject(options),
 				html,

--- a/apps/server/src/utils/mailTemplate.ts
+++ b/apps/server/src/utils/mailTemplate.ts
@@ -66,7 +66,7 @@ export function welcomeTemplate(customBody?: string, userName?: string) {
       <div style="display: block;">
         <div style="margin-bottom: 20px; text-align: left;">
             <div style="font-weight: bold; color: #2563eb; margin-bottom: 2px;">Documentation</div>
-            <a href="https://opsimate.vercel.app/" style="color:#2563eb;font-weight:bold;text-decoration:underline;font-size:16px;">Explore Docs</a>
+            <a href="https://docs.opsimate.dev/" style="color:#2563eb;font-weight:bold;text-decoration:underline;font-size:16px;">Explore Docs</a>
             <div style="font-size: 13px; color: #4a5568; margin-top: 4px;">You can start exploring here: get started, find guides, and explore features.</div>
         </div>
         <div style="margin-bottom: 20px; text-align: left;">
@@ -81,7 +81,7 @@ export function welcomeTemplate(customBody?: string, userName?: string) {
         </div>
         <div style="margin-bottom: 20px; text-align: left;">
           <div style="font-weight: bold; color: #2563eb; margin-bottom: 2px;">OpsiMate Website</div>
-          <a href="https://www.opsimate.com/" style="color:#2563eb;font-weight:bold;text-decoration:underline;font-size:16px;">Visit Website</a>
+          <a href="https://www.opsimate.dev/" style="color:#2563eb;font-weight:bold;text-decoration:underline;font-size:16px;">Visit Website</a>
           <div style="font-size: 13px; color: #4a5568; margin-top: 4px;">Learn more about us.</div>
         </div>
       </div>

--- a/infrastructure/helm/README.md
+++ b/infrastructure/helm/README.md
@@ -21,7 +21,7 @@ The frontend is a browser app (JavaScript). When you open `localhost:8080`, the 
 
 **Why is backend private in production?**
 
-In production, Ingress acts as a single entry point. All traffic goes through one URL (e.g., `opsimate.com`), and Ingress routes `/api/*` to the backend internally. The backend is never exposed to the internet.
+In production, Ingress acts as a single entry point. All traffic goes through one URL (e.g., `opsimate.dev`), and Ingress routes `/api/*` to the backend internally. The backend is never exposed to the internet.
 
 ## Architecture
 
@@ -49,7 +49,7 @@ Internet
     ▼
 ┌─────────────────┐
 │     Ingress     │  ← Single public entry point
-│ opsimate.com    │
+│ opsimate.dev    │
 └────────┬────────┘
          │
     ┌────┴────┐


### PR DESCRIPTION
## Issue Reference

N/A — domain migration.

---

## What Was Changed

Every reference to the old domains now points at the new ones:

- `opsimate.vercel.app` → `docs.opsimate.dev` (docs links in the README, integrations page, custom-alerts modal, forgot-password screen, and the welcome mail template)
- `opsimate.com` / `www.opsimate.com` → `opsimate.dev` (README website links, OG/Twitter meta tags in `index.html`, mail template website link, default mail from-address, Helm README example)

---

## Why Was It Changed

The project moved to the `opsimate.dev` domain; in-app and repo links should land on the live docs and website.

---

## Screenshots

N/A — link/string changes only.

---

## Additional Context (Optional)

Swept the whole repo for remaining `opsimate.vercel.app` / `opsimate.com` references — none left in source (only in the untracked `dist/` build artifact). Prettier clean; client tsc at its 82-error baseline; server tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation, support, navigation, and infrastructure examples to use the new Opsimate website and documentation domains.
  * Refreshed integration, configuration, and custom alerts links to point to the current documentation site.

* **Bug Fixes**
  * Updated social sharing metadata and welcome email links to use the current website.
  * Updated the default outgoing email sender address to the `.dev` domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->