### PR TITLE
chore: Vercel config for the zero-backend playground sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ infrastructure/terraform/.terraform/
 infrastructure/terraform/.terraform.lock.hcl
 # Local server config (contains api_token, secrets) — never commit
 apps/server/local-config.yml
+.vercel
+.env*

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 <p align="center">
   <a href="https://docs.opsimate.dev/docs/getting-started/deploy">Get Started</a> ·
   <a href="https://docs.opsimate.dev/">Docs</a> ·
-  <a href="https://opsimate.goprosite.net">Demo</a> ·
+  <a href="https://demo.opsimate.dev/">Demo</a> ·
   <a href="https://www.opsimate.dev/">Website</a> ·
   <a href="https://github.com/OpsiMate/OpsiMate/issues/new?labels=bug&template=bug_report.md">Report Bug</a>
 </p>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm --filter @OpsiMate/shared build && VITE_PLAYGROUND_MODE=true pnpm --filter @OpsiMate/client build",
+  "outputDirectory": "apps/client/dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Issue Reference

N/A — sandbox deployment.

---

## What Was Changed

Adds a root `vercel.json` that turns a Vercel static deploy of this repo into the playground sandbox:

- `buildCommand` builds `@OpsiMate/shared` then the client with `VITE_PLAYGROUND_MODE=true`, baking playground mode into the bundle — MSW intercepts every `/api/v1/*` call in the browser and serves it from the seeded mock state.
- `outputDirectory` points at `apps/client/dist` (which already ships `mockServiceWorker.js`).
- A SPA rewrite (`/(.*) → /index.html`) keeps client-side routes working on refresh/deep link.

No server, no database — every visitor gets a fresh, fully-seeded sandbox as the demo admin, and state resets on reload.

---

## Why Was It Changed

Lets the public demo run as static files on Vercel (e.g. demo.opsimate.dev) instead of a hosted server.

---

## Screenshots

N/A — config only.

---

## Additional Context (Optional)

Verified locally end-to-end: built with the exact `buildCommand`, served `dist` statically, and drove it with Playwright in a cold browser (no query param, no token) — lands straight in the app, alerts table renders 27 mock rows, `/oncall` deep link works with mock teams, and no API request escapes MSW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Deployment**
  * Added Vercel configuration for monorepo deployments, including the OpenAPI schema URL, install/build commands, and SPA-style routing.
  * Enabled a client “playground” mode for deployed builds and set static output for the client app.
* **Chores**
  * Updated `.gitignore` to ignore Vercel artifacts and local environment files.
* **Documentation**
  * Updated the README “Demo” link to the new destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->