### PR TITLE
feat(alerts): silences take a duration and an optional comment

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
@@ -18,6 +18,14 @@ const formatFullDate = (dateStr: string) =>
 		minute: '2-digit',
 	});
 
+// Descriptions may embed machine ISO timestamps (e.g. "Alert silenced until
+// 2026-07-19T09:23:39.487Z"); show them as short datetimes in the viewer's timezone.
+const ISO_TIMESTAMP_RE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})/g;
+const humanizeTimestamps = (text: string): string =>
+	text.replace(ISO_TIMESTAMP_RE, (iso) =>
+		new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+	);
+
 interface EventStyle {
 	label: string;
 	dotClass: string;
@@ -126,7 +134,9 @@ export const AlertHistoryTimeline = ({ data, isFiltered }: AlertHistoryTimelineP
 									<span>{style.label}</span>
 								</div>
 								{item.description && (
-									<div className="text-xs text-foreground/80">{item.description}</div>
+									<div className="text-xs text-foreground/80">
+										{humanizeTimestamps(item.description)}
+									</div>
 								)}
 								<div className="text-xs text-muted-foreground">
 									{formatFullDate(item.date)}

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -213,8 +213,8 @@ const Alerts = () => {
 	const deleteResolvedAlertMutation = useDeleteResolvedAlert();
 	const markAlertReadMutation = useMarkAlertRead();
 
-	const handleSilenceAllSelected = async () => {
-		await handleSilenceAll(selectedAlerts, () => setSelectedAlerts([]));
+	const handleSilenceAllSelected = async (silencedUntil?: string | null, comment?: string) => {
+		await handleSilenceAll(selectedAlerts, () => setSelectedAlerts([]), silencedUntil, comment);
 	};
 
 	const handleAssignOwnerAllSelected = async (ownerId: string | null) => {
@@ -249,9 +249,14 @@ const Alerts = () => {
 	const confirmSilenceAlert = (alertId: string) =>
 		setPendingAction({
 			title: 'Silence this alert?',
-			description: 'The alert stays in the list but stops notifying. You can unsilence it at any time.',
+			description:
+				'The alert stays in the list but stops notifying for the chosen duration. You can unsilence it at any time, and silencing again restarts the timer.',
 			confirmLabel: 'Silence',
-			run: () => void handleSilenceAlert(alertId),
+			withSilenceDuration: true,
+			withComment: true,
+			commentLabel: 'Silence comment',
+			commentPlaceholder: 'Why is this silenced?',
+			run: (comment, silencedUntil) => void handleSilenceAlert(alertId, silencedUntil, comment),
 		});
 
 	const confirmResolveAlert = (alertId: string) =>
@@ -260,6 +265,8 @@ const Alerts = () => {
 			description: 'The alert moves to the Resolved list. You can unresolve it later if it is still an issue.',
 			confirmLabel: 'Resolve',
 			withComment: true,
+			commentLabel: 'Resolve comment',
+			commentPlaceholder: 'What fixed it / why is this resolved?',
 			run: (comment) => void handleDeleteAlert(alertId, comment),
 		});
 
@@ -286,9 +293,14 @@ const Alerts = () => {
 	const confirmSilenceAllSelected = () =>
 		setPendingAction({
 			title: `Silence ${selectedAlerts.length} alert${selectedAlerts.length !== 1 ? 's' : ''}?`,
-			description: 'The selected alerts stay in the list but stop notifying. You can unsilence them at any time.',
+			description:
+				'The selected alerts stay in the list but stop notifying for the chosen duration. You can unsilence them at any time, and silencing again restarts the timer.',
 			confirmLabel: 'Silence all',
-			run: () => void handleSilenceAllSelected(),
+			withSilenceDuration: true,
+			withComment: true,
+			commentLabel: 'Silence comment',
+			commentPlaceholder: 'Why are these silenced?',
+			run: (comment, silencedUntil) => void handleSilenceAllSelected(silencedUntil, comment),
 		});
 
 	const confirmResolveAllSelected = () =>
@@ -298,6 +310,8 @@ const Alerts = () => {
 				'The selected alerts move to the Resolved list. You can unresolve them later if needed. An optional comment will be added to every resolved alert.',
 			confirmLabel: 'Resolve',
 			withComment: true,
+			commentLabel: 'Resolve comment',
+			commentPlaceholder: 'What fixed it / why is this resolved?',
 			run: (comment) => void handleResolveAllSelected(comment),
 		});
 

--- a/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
+++ b/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
@@ -233,7 +233,8 @@ const AlertsTVMode = () => {
 
 	const handleSilenceAlert = async (alertId: string) => {
 		try {
-			await silenceAlertMutation.mutateAsync(alertId);
+			// TV mode has no duration picker — silence stays until manually lifted.
+			await silenceAlertMutation.mutateAsync({ alertId });
 			toast({
 				title: 'Alert silenced',
 				description: 'The alert has been marked as silenced.',

--- a/apps/client/src/components/Alerts/ConfirmAlertActionDialog/ConfirmAlertActionDialog.tsx
+++ b/apps/client/src/components/Alerts/ConfirmAlertActionDialog/ConfirmAlertActionDialog.tsx
@@ -8,20 +8,58 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useEffect, useState } from 'react';
 
+// How long a silence lasts. The expiry timestamp is computed at confirm time, so
+// re-silencing an alert always restarts the timer from "now".
+export type SilenceDuration = 'midnight' | '1h' | '4h' | '8h' | 'forever';
+
+const SILENCE_DURATION_OPTIONS: { value: SilenceDuration; label: string }[] = [
+	{ value: 'midnight', label: 'Until midnight' },
+	{ value: '1h', label: '1 hour' },
+	{ value: '4h', label: '4 hours' },
+	{ value: '8h', label: '8 hours' },
+	{ value: 'forever', label: 'Forever (until unsilenced)' },
+];
+
+// null = no expiry (silenced until manually unsilenced).
+const silencedUntilFor = (duration: SilenceDuration): string | null => {
+	switch (duration) {
+		case 'forever':
+			return null;
+		case 'midnight': {
+			// Local midnight — the user thinks in their own day boundary, not UTC's.
+			const endOfDay = new Date();
+			endOfDay.setHours(24, 0, 0, 0);
+			return endOfDay.toISOString();
+		}
+		case '1h':
+			return new Date(Date.now() + 1 * 60 * 60 * 1000).toISOString();
+		case '4h':
+			return new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
+		case '8h':
+			return new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString();
+	}
+};
+
 // A state-changing alert action awaiting the user's go-ahead. `run` executes it; for
-// resolve actions it receives the optional resolve note the user typed.
+// resolve/silence actions it receives the optional note the user typed, and for silence
+// actions the computed expiry of the chosen duration (null = forever).
 export interface PendingAlertAction {
 	title: string;
 	description: string;
 	confirmLabel: string;
 	// Destructive actions (permanent delete) get the red confirm button.
 	destructive?: boolean;
-	// Resolve actions offer an optional note, stored as a comment on the resolved alert(s).
+	// Resolve/silence actions offer an optional note, stored as a comment on the alert(s).
 	withComment?: boolean;
-	run: (comment?: string) => void;
+	commentLabel?: string;
+	commentPlaceholder?: string;
+	// Silence actions pick a duration (defaults to "until midnight").
+	withSilenceDuration?: boolean;
+	run: (comment?: string, silencedUntil?: string | null) => void;
 }
 
 interface ConfirmAlertActionDialogProps {
@@ -33,15 +71,18 @@ interface ConfirmAlertActionDialogProps {
 // fed by whichever entry point (row menu, details footer, bulk bar) requested the action.
 export const ConfirmAlertActionDialog = ({ pending, onClose }: ConfirmAlertActionDialogProps) => {
 	const [comment, setComment] = useState('');
+	const [duration, setDuration] = useState<SilenceDuration>('midnight');
 
-	// Fresh state per confirmation — a note typed for one resolve must not leak into the next.
+	// Fresh state per confirmation — a note or duration chosen for one action must not
+	// leak into the next.
 	useEffect(() => {
 		if (pending) {
 			setComment('');
+			setDuration('midnight');
 		}
 	}, [pending]);
 
-	const resolveNote = comment.trim() || undefined;
+	const note = comment.trim() || undefined;
 
 	return (
 		<AlertDialog open={!!pending} onOpenChange={(open) => !open && onClose()}>
@@ -51,16 +92,37 @@ export const ConfirmAlertActionDialog = ({ pending, onClose }: ConfirmAlertActio
 					<AlertDialogDescription>{pending?.description}</AlertDialogDescription>
 				</AlertDialogHeader>
 
+				{pending?.withSilenceDuration && (
+					<div className="space-y-1.5">
+						<label htmlFor="silence-duration" className="text-sm font-medium">
+							Silence for
+						</label>
+						<Select value={duration} onValueChange={(value) => setDuration(value as SilenceDuration)}>
+							<SelectTrigger id="silence-duration">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{SILENCE_DURATION_OPTIONS.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+
 				{pending?.withComment && (
 					<div className="space-y-1.5">
-						<label htmlFor="resolve-comment" className="text-sm font-medium">
-							Resolve comment <span className="font-normal text-muted-foreground">(optional)</span>
+						<label htmlFor="action-comment" className="text-sm font-medium">
+							{pending.commentLabel ?? 'Comment'}{' '}
+							<span className="font-normal text-muted-foreground">(optional)</span>
 						</label>
 						<Textarea
-							id="resolve-comment"
+							id="action-comment"
 							value={comment}
 							onChange={(e) => setComment(e.target.value)}
-							placeholder="What fixed it / why is this resolved?"
+							placeholder={pending.commentPlaceholder ?? 'Add a note for your team'}
 							rows={3}
 							maxLength={5000}
 						/>
@@ -71,7 +133,7 @@ export const ConfirmAlertActionDialog = ({ pending, onClose }: ConfirmAlertActio
 					<AlertDialogCancel>Cancel</AlertDialogCancel>
 					<AlertDialogAction
 						onClick={() => {
-							pending?.run(resolveNote);
+							pending?.run(note, pending.withSilenceDuration ? silencedUntilFor(duration) : undefined);
 							onClose();
 						}}
 						className={

--- a/apps/client/src/components/Alerts/StatusBadge/StatusBadge.tsx
+++ b/apps/client/src/components/Alerts/StatusBadge/StatusBadge.tsx
@@ -12,8 +12,17 @@ interface StatusIndicator {
 
 // Precedence mirrors the old status badge: silenced wins over muted, which wins over
 // the firing/resolved lifecycle state.
+// "Jul 19, 14:30" in the viewer's locale/timezone — enough to know when the silence lifts.
+const formatSilencedUntil = (iso: string): string =>
+	new Date(iso).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+
 const getStatusIndicator = (alert: Alert): StatusIndicator => {
-	if (alert.isSilenced) return { Icon: BellOff, label: 'Silenced', className: 'text-muted-foreground' };
+	if (alert.isSilenced)
+		return {
+			Icon: BellOff,
+			label: alert.silencedUntil ? `Silenced until ${formatSilencedUntil(alert.silencedUntil)}` : 'Silenced',
+			className: 'text-muted-foreground',
+		};
 	if (alert.isMuted)
 		return { Icon: VolumeX, label: 'Muted', className: 'text-amber-500', testId: 'alert-status-muted' };
 	if (alert.status === AlertStatus.FIRING) return { Icon: Flame, label: 'Firing', className: 'text-red-500' };

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -18,9 +18,9 @@ export const useAlertActions = () => {
 	const unresolveAlertMutation = useUnresolveAlert();
 	const { toast } = useToast();
 
-	const handleSilenceAlert = async (alertId: string) => {
+	const handleSilenceAlert = async (alertId: string, silencedUntil?: string | null, comment?: string) => {
 		try {
-			await silenceAlertMutation.mutateAsync(alertId);
+			await silenceAlertMutation.mutateAsync({ alertId, silencedUntil, comment });
 		} catch (error) {
 			toast({
 				title: 'Error silencing alert',
@@ -76,8 +76,13 @@ export const useAlertActions = () => {
 		}
 	};
 
-	const handleSilenceAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
-		const silencePromises = selectedAlerts.map((alert) => handleSilenceAlert(alert.id));
+	const handleSilenceAll = async (
+		selectedAlerts: Alert[],
+		onComplete: () => void,
+		silencedUntil?: string | null,
+		comment?: string
+	) => {
+		const silencePromises = selectedAlerts.map((alert) => handleSilenceAlert(alert.id, silencedUntil, comment));
 		const results = await Promise.allSettled(silencePromises);
 
 		results.forEach((result, index) => {

--- a/apps/client/src/components/Dashboard/Dashboard.tsx
+++ b/apps/client/src/components/Dashboard/Dashboard.tsx
@@ -111,7 +111,8 @@ export const Dashboard = () => {
 
 	const handleAlertSilence = async (alertId: string) => {
 		try {
-			await silenceAlertMutation.mutateAsync(alertId);
+			// The dashboard has no duration picker — silence stays until manually lifted.
+			await silenceAlertMutation.mutateAsync({ alertId });
 		} catch (error) {
 			logger.error('Error silencing alert:', error);
 			toast({

--- a/apps/client/src/hooks/queries/alerts/useSilenceAlert.ts
+++ b/apps/client/src/hooks/queries/alerts/useSilenceAlert.ts
@@ -2,22 +2,31 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { alertsApi } from '@/lib/api';
 import { queryKeys } from '../queryKeys';
 
+interface SilenceAlertVariables {
+	alertId: string;
+	// ISO expiry of the silence; null silences until manually unsilenced.
+	silencedUntil?: string | null;
+	comment?: string;
+}
+
 export const useSilenceAlert = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: async (alertId: string) => {
-			const response = await alertsApi.silenceAlert(alertId);
+		mutationFn: async ({ alertId, silencedUntil, comment }: SilenceAlertVariables) => {
+			const response = await alertsApi.silenceAlert(alertId, { silencedUntil, comment });
 			if (!response.success) {
 				throw new Error(response.error || 'Failed to silence alert');
 			}
 			return response.data;
 		},
-		onSuccess: () => {
+		onSuccess: (_data, { alertId }) => {
 			// Invalidate and refetch alerts
 			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
 			// Refresh any open alert-history panel (this records a history event server-side).
 			queryClient.invalidateQueries({ queryKey: ['alertHistory'] });
+			// A silence note is stored as a regular comment, so refresh the comment thread too.
+			queryClient.invalidateQueries({ queryKey: [...queryKeys.alertComments, alertId] });
 		},
 	});
 };

--- a/apps/client/src/hooks/queries/alerts/useSilenceAlert.ts
+++ b/apps/client/src/hooks/queries/alerts/useSilenceAlert.ts
@@ -23,8 +23,8 @@ export const useSilenceAlert = () => {
 		onSuccess: (_data, { alertId }) => {
 			// Invalidate and refetch alerts
 			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
-			// Refresh any open alert-history panel (this records a history event server-side).
-			queryClient.invalidateQueries({ queryKey: ['alertHistory'] });
+			// Refresh any open alert-history panel (this records history events server-side).
+			queryClient.invalidateQueries({ queryKey: queryKeys.alertHistory(alertId) });
 			// A silence note is stored as a regular comment, so refresh the comment thread too.
 			queryClient.invalidateQueries({ queryKey: [...queryKeys.alertComments, alertId] });
 		},

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -547,9 +547,16 @@ export const alertsApi = {
 		return await apiRequest<{ alerts: SharedAlert[] }>('/alerts');
 	},
 
-	// Silence an alert
-	async silenceAlert(alertId: string): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/silence`, 'PATCH');
+	// Silence an alert until `silencedUntil` (ISO; null = forever). Re-silencing overwrites
+	// the expiry, restarting the timer. An optional note is stored as a comment.
+	async silenceAlert(
+		alertId: string,
+		options?: { silencedUntil?: string | null; comment?: string }
+	): Promise<ApiResponse<{ alert: SharedAlert }>> {
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/silence`, 'PATCH', {
+			silencedUntil: options?.silencedUntil ?? null,
+			comment: options?.comment,
+		});
 	},
 
 	// Unsilence an alert

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -198,6 +198,14 @@ export const handlers = [
 			actorName: PLAYGROUND_ACTOR,
 			description: alert.silencedUntil ? `Alert silenced until ${alert.silencedUntil}` : 'Alert silenced',
 		});
+		// The silencer takes ownership of the alert (mirrors the server).
+		alert.ownerId = getPlaygroundUser().id;
+		pushAlertEvent(alertId, {
+			date: nowIso(),
+			eventType: AlertHistoryEventType.OWNER_ASSIGNED,
+			actorName: PLAYGROUND_ACTOR,
+			description: `Assigned to ${PLAYGROUND_ACTOR}`,
+		});
 		if (silenceComment) {
 			playgroundState.alertComments.push({
 				id: `comment-${randomId()}`,

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -147,6 +147,19 @@ const toOncallTeam = (team: OncallTeamState): OncallTeam => {
 export const handlers = [
 	// ==================== ALERTS ====================
 	http.get(`${API_BASE}/alerts`, () => {
+		// Timed silences expire lazily on read (mirrors the server sweep).
+		const now = nowIso();
+		for (const alert of playgroundState.alerts) {
+			if (alert.isSilenced && alert.silencedUntil && alert.silencedUntil <= now) {
+				alert.isSilenced = false;
+				alert.silencedUntil = null;
+				pushAlertEvent(alert.id, {
+					date: now,
+					eventType: AlertHistoryEventType.UNSILENCED,
+					description: 'Silence expired',
+				});
+			}
+		}
 		return HttpResponse.json({
 			success: true,
 			data: { alerts: playgroundState.alerts.map(withAppliedEnrichments) },
@@ -160,7 +173,7 @@ export const handlers = [
 		});
 	}),
 
-	http.patch(`${API_BASE}/alerts/:alertId/silence`, ({ params }) => {
+	http.patch(`${API_BASE}/alerts/:alertId/silence`, async ({ params, request }) => {
 		const alertId = params.alertId as string;
 		const alert = playgroundState.alerts.find((a) => a.id === alertId);
 
@@ -168,14 +181,33 @@ export const handlers = [
 			return HttpResponse.json({ success: false, error: 'Alert not found' }, { status: 404 });
 		}
 
+		// Optional duration + note in the body (mirrors the server): silencedUntil is
+		// always overwritten so re-silencing restarts the timer; the note becomes a comment.
+		const body = (await request.json().catch(() => null)) as {
+			silencedUntil?: string | null;
+			comment?: string;
+		} | null;
+		const silenceComment = typeof body?.comment === 'string' ? body.comment.trim() : '';
+
 		alert.isSilenced = true;
+		alert.silencedUntil = body?.silencedUntil ?? null;
 		alert.updatedAt = nowIso();
 		pushAlertEvent(alertId, {
 			date: nowIso(),
 			eventType: AlertHistoryEventType.SILENCED,
 			actorName: PLAYGROUND_ACTOR,
-			description: 'Alert silenced',
+			description: alert.silencedUntil ? `Alert silenced until ${alert.silencedUntil}` : 'Alert silenced',
 		});
+		if (silenceComment) {
+			playgroundState.alertComments.push({
+				id: `comment-${randomId()}`,
+				alertId,
+				userId: getPlaygroundUser().id,
+				comment: silenceComment,
+				createdAt: nowIso(),
+				updatedAt: nowIso(),
+			});
+		}
 
 		return HttpResponse.json({ success: true, data: { alert } });
 	}),
@@ -189,6 +221,7 @@ export const handlers = [
 		}
 
 		alert.isSilenced = false;
+		alert.silencedUntil = null;
 		alert.updatedAt = nowIso();
 		pushAlertEvent(alertId, {
 			date: nowIso(),
@@ -259,6 +292,7 @@ export const handlers = [
 		// resolved, never both.
 		alert.status = AlertStatus.RESOLVED;
 		alert.isSilenced = false;
+		alert.silencedUntil = null;
 		alert.updatedAt = nowIso();
 		// The resolver takes ownership of the alert (mirrors the server).
 		alert.ownerId = getPlaygroundUser().id;
@@ -297,6 +331,7 @@ export const handlers = [
 		const alert = { ...playgroundState.resolvedAlerts[alertIndex] };
 		alert.status = AlertStatus.FIRING;
 		alert.isSilenced = false;
+		alert.silencedUntil = null;
 		alert.isRead = false;
 		alert.updatedAt = nowIso();
 

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -8,6 +8,7 @@ import {
 	HttpAlertWebhookSchema,
 	SetAlertOwnerSchema,
 	ResolveAlertBodySchema,
+	SilenceAlertBodySchema,
 	UptimeKumaWebhookPayload,
 	ZabbixWebhookPayload,
 } from './models';
@@ -37,12 +38,22 @@ export class AlertController {
 			if (!id) {
 				return res.status(400).json({ success: false, error: 'Alert id is required' });
 			}
-			const alert = await this.alertBL.silenceAlert(id, req.user?.fullName);
+			const { silencedUntil, comment } = SilenceAlertBodySchema.parse(req.body ?? {});
+			const alert = await this.alertBL.silenceAlert(
+				id,
+				// String() — the JWT carries the id as a number; comments store it as TEXT.
+				{ id: req.user != null ? String(req.user.id) : null, name: req.user?.fullName ?? null },
+				silencedUntil ?? null,
+				comment
+			);
 			if (!alert) {
 				return res.status(404).json({ success: false, error: 'Alert not found' });
 			}
 			return res.json({ success: true, data: { alert } });
 		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
 			logger.error('Error silencing alert:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -53,6 +53,15 @@ export const ResolveAlertBodySchema = z.object({
 	comment: z.string().trim().max(5000).optional(),
 });
 
+// Optional body of the silence request (PATCH /alerts/:id/silence).
+export const SilenceAlertBodySchema = z.object({
+	// ISO time when the silence auto-expires; null or absent silences until manually
+	// unsilenced. Always overwritten on re-silence, so the timer restarts each time.
+	silencedUntil: isoDateString.nullable().optional(),
+	// Optional note, stored as a regular alert comment by the acting user.
+	comment: z.string().trim().max(5000).optional(),
+});
+
 /**
  * Datadog alerts webhook payload.
  *

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -101,9 +101,19 @@ export class AlertBL {
 		}
 	}
 
+	// Timed silences expire lazily: every listing first sweeps alerts whose silence window
+	// has passed back to unsilenced, with a history entry so the timeline explains the flip.
+	private async expireSilences(): Promise<void> {
+		const expiredIds = await this.alertRepo.clearExpiredSilences(new Date().toISOString());
+		for (const id of expiredIds) {
+			await this.recordHistoryEvent(id, AlertHistoryEventType.UNSILENCED, 'Silence expired', null);
+		}
+	}
+
 	async getAllAlerts(): Promise<Alert[]> {
 		try {
 			logger.info('Fetching all alerts');
+			await this.expireSilences();
 			let alerts = await this.alertRepo.getAllAlerts();
 			// Enrich before muting so mute policy rules can match enrichment-added tags.
 			if (this.enrichmentBL) {
@@ -119,12 +129,25 @@ export class AlertBL {
 		}
 	}
 
-	async silenceAlert(id: string, actorName?: string | null): Promise<Alert | null> {
+	// silencedUntil (ISO) bounds the silence; null means until manually unsilenced. An
+	// optional note is stored as a regular comment by the acting user, mirroring resolve.
+	async silenceAlert(
+		id: string,
+		actor: { id: string | null; name: string | null },
+		silencedUntil: string | null,
+		comment?: string
+	): Promise<Alert | null> {
 		try {
 			logger.info(`Silencing alert with id: ${id}`);
-			const alert = await this.alertRepo.silenceAlert(id);
+			const alert = await this.alertRepo.silenceAlert(id, silencedUntil);
 			if (alert) {
-				await this.recordHistoryEvent(id, AlertHistoryEventType.SILENCED, 'Alert silenced', actorName);
+				const description = silencedUntil
+					? `Alert silenced until ${toIsoUtc(silencedUntil)}`
+					: 'Alert silenced';
+				await this.recordHistoryEvent(id, AlertHistoryEventType.SILENCED, description, actor.name);
+				if (comment && actor.id != null) {
+					await this.createComment({ alertId: id, userId: actor.id, comment });
+				}
 			}
 			return alert;
 		} catch (error) {

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -105,9 +105,11 @@ export class AlertBL {
 	// has passed back to unsilenced, with a history entry so the timeline explains the flip.
 	private async expireSilences(): Promise<void> {
 		const expiredIds = await this.alertRepo.clearExpiredSilences(new Date().toISOString());
-		for (const id of expiredIds) {
-			await this.recordHistoryEvent(id, AlertHistoryEventType.UNSILENCED, 'Silence expired', null);
-		}
+		await Promise.all(
+			expiredIds.map((id) =>
+				this.recordHistoryEvent(id, AlertHistoryEventType.UNSILENCED, 'Silence expired', null)
+			)
+		);
 	}
 
 	async getAllAlerts(): Promise<Alert[]> {
@@ -140,10 +142,13 @@ export class AlertBL {
 	): Promise<Alert | null> {
 		try {
 			logger.info(`Silencing alert with id: ${id}`);
-			let alert = await this.alertRepo.silenceAlert(id, silencedUntil);
+			// Normalize to UTC before persisting: expiry uses lexicographic string comparison,
+			// which is only correct when every stored value shares the same ISO-UTC format.
+			const normalizedSilencedUntil = silencedUntil ? toIsoUtc(silencedUntil) : null;
+			let alert = await this.alertRepo.silenceAlert(id, normalizedSilencedUntil);
 			if (alert) {
-				const description = silencedUntil
-					? `Alert silenced until ${toIsoUtc(silencedUntil)}`
+				const description = normalizedSilencedUntil
+					? `Alert silenced until ${normalizedSilencedUntil}`
 					: 'Alert silenced';
 				await this.recordHistoryEvent(id, AlertHistoryEventType.SILENCED, description, actor.name);
 				if (actor.id != null && Number.isFinite(Number(actor.id))) {

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -130,7 +130,8 @@ export class AlertBL {
 	}
 
 	// silencedUntil (ISO) bounds the silence; null means until manually unsilenced. An
-	// optional note is stored as a regular comment by the acting user, mirroring resolve.
+	// optional note is stored as a regular comment by the acting user, and — mirroring
+	// resolve — whoever silences the alert takes ownership of it.
 	async silenceAlert(
 		id: string,
 		actor: { id: string | null; name: string | null },
@@ -139,12 +140,16 @@ export class AlertBL {
 	): Promise<Alert | null> {
 		try {
 			logger.info(`Silencing alert with id: ${id}`);
-			const alert = await this.alertRepo.silenceAlert(id, silencedUntil);
+			let alert = await this.alertRepo.silenceAlert(id, silencedUntil);
 			if (alert) {
 				const description = silencedUntil
 					? `Alert silenced until ${toIsoUtc(silencedUntil)}`
 					: 'Alert silenced';
 				await this.recordHistoryEvent(id, AlertHistoryEventType.SILENCED, description, actor.name);
+				if (actor.id != null && Number.isFinite(Number(actor.id))) {
+					// setAlertOwner also records the "Assigned to …" history event.
+					alert = (await this.setAlertOwner(id, actor.id, false, actor.name)) ?? alert;
+				}
 				if (comment && actor.id != null) {
 					await this.createComment({ alertId: id, userId: actor.id, comment });
 				}

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -160,6 +160,13 @@ export class AlertRepository {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN team TEXT`).run();
 			}
 
+			// Backward compatibility: ensure silenced_until column exists (ISO expiry of a
+			// timed silence; NULL while silenced means silenced forever)
+			const hasSilencedUntil = columns.some((col: TableInfoRow) => col.name === 'silenced_until');
+			if (!hasSilencedUntil) {
+				this.db.prepare(`ALTER TABLE alerts ADD COLUMN silenced_until TEXT`).run();
+			}
+
 			// Repair: an alert id must never exist as both active and resolved. Ingestion used
 			// to re-insert a previously-resolved alert into the active table without dropping
 			// its resolved copy, so it showed up twice in the UI. The active row wins — the
@@ -198,6 +205,7 @@ export class AlertRepository {
 			runbookUrl: row.runbook_url,
 			createdAt: row.created_at,
 			isSilenced: row.is_dismissed ? true : false,
+			silencedUntil: row.is_dismissed ? (row.silenced_until ?? null) : null,
 			isRead: row.is_read ? true : false,
 			ownerId: row.owner_id != null ? String(row.owner_id) : null,
 		};
@@ -211,11 +219,40 @@ export class AlertRepository {
 		});
 	}
 
-	async silenceAlert(id: string): Promise<SharedAlert | null> {
+	// silencedUntil is written unconditionally — re-silencing an already-silenced alert
+	// restarts the timer with the newly chosen duration (null = forever).
+	async silenceAlert(id: string, silencedUntil: string | null): Promise<SharedAlert | null> {
 		return runAsync(() => {
-			this.db.prepare('UPDATE alerts SET is_dismissed = 1 WHERE id = ?').run(id);
+			this.db
+				.prepare('UPDATE alerts SET is_dismissed = 1, silenced_until = ? WHERE id = ?')
+				.run(silencedUntil, id);
 			const row = this.db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow | undefined;
 			return row ? this.toSharedAlert(row) : null;
+		});
+	}
+
+	// Un-silences every alert whose timed silence has passed and returns their ids so the
+	// caller can record history events. ISO-8601 strings compare lexicographically, so plain
+	// string comparison against "now" is correct.
+	async clearExpiredSilences(nowIso: string): Promise<string[]> {
+		return runAsync(() => {
+			const sweep = this.db.transaction(() => {
+				const rows = this.db
+					.prepare(
+						`SELECT id FROM alerts WHERE is_dismissed = 1 AND silenced_until IS NOT NULL AND silenced_until <= ?`
+					)
+					.all(nowIso) as { id: string }[];
+				if (rows.length > 0) {
+					this.db
+						.prepare(
+							`UPDATE alerts SET is_dismissed = 0, silenced_until = NULL
+							 WHERE is_dismissed = 1 AND silenced_until IS NOT NULL AND silenced_until <= ?`
+						)
+						.run(nowIso);
+				}
+				return rows.map((r) => r.id);
+			});
+			return sweep();
 		});
 	}
 
@@ -229,7 +266,7 @@ export class AlertRepository {
 
 	async unsilenceAlert(id: string): Promise<SharedAlert | null> {
 		return runAsync(() => {
-			this.db.prepare('UPDATE alerts SET is_dismissed = 0 WHERE id = ?').run(id);
+			this.db.prepare('UPDATE alerts SET is_dismissed = 0, silenced_until = NULL WHERE id = ?').run(id);
 			const row = this.db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow | undefined;
 			return row ? this.toSharedAlert(row) : null;
 		});

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -66,6 +66,7 @@ export type AlertRow = {
 	runbook_url?: string;
 	created_at: string;
 	is_dismissed: boolean;
+	silenced_until?: string | null;
 	is_read?: boolean | number | null;
 	owner_id?: number | null;
 };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -212,6 +212,9 @@ export interface Alert {
 	runbookUrl?: string;
 	createdAt: string;
 	isSilenced: boolean;
+	// When the silence auto-expires (ISO); null while silenced means silenced forever.
+	// Re-silencing always overwrites this, so the timer restarts on every silence.
+	silencedUntil?: string | null;
 	// False until someone opens the alert; unread alerts render bold in the table.
 	isRead?: boolean;
 	// Transient: set at fetch time when an active mute policy rule matches this alert. Not persisted.


### PR DESCRIPTION
## What

Silencing an alert — from the row three-dots menu, the details sidebar, or the multi-select bar — now opens a dialog where the user picks **how long** the silence lasts and can leave an **optional comment**:

- **Duration**: Until midnight (default), 1 hour, 4 hours, 8 hours, or Forever (until unsilenced)
- **Comment**: optional, stored as a regular alert comment (same pattern as the resolve note); on bulk silence it is added to every selected alert

## Timer restart

`silenced_until` is overwritten unconditionally on every silence, so unsilencing and silencing again always restarts the timer with the newly chosen duration.

## Expiry

Timed silences expire lazily: every alert listing first sweeps alerts whose window passed back to unsilenced and records a **"Silence expired"** history entry. The status badge tooltip shows *Silenced until \<local time\>*.

## Implementation

- New `alerts.silenced_until` TEXT column (guarded `ALTER TABLE` migration); `NULL` while silenced = forever
- `PATCH /alerts/:id/silence` accepts a zod-validated `{ silencedUntil, comment }` body; invalid input returns 400
- `ConfirmAlertActionDialog` gains a duration select (`withSilenceDuration`) and per-action comment label/placeholder; the expiry is computed at confirm time in the user's local timezone (midnight = local midnight)
- TV mode / dashboard quick-silence (no dialog) keep the previous behavior: silence forever
- Playground mocks mirror everything (duration, comment, lazy expiry)

## Verification (against the running dev app)

- API: silence with expiry + comment, re-silence overwrite (timer restart), auto-expiry sweep + history entry, unsilence clears both flags, invalid date → 400 — all pass
- UI (Playwright): sidebar silence with "1 hour" + comment → silenced ~1h with comment stored; bulk silence 2 alerts with "Forever" + comment → both silenced with the comment; duration select defaults to "Until midnight"
- Server tests 115/115, client tsc at baseline, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alerts can now be silenced for a selected duration or indefinitely.
  * You can add optional comments when silencing or resolving alerts (single and bulk actions).
  * Silenced alerts show “Silenced until” with a localized date/time; indefinite silences remain unchanged.
  * Expired silences are automatically lifted.
  * Alert history timestamps are now shown in a localized, human-readable format.
* **Bug Fixes**
  * Silence and resolution details (including comments) now refresh consistently across the interface, including after TV-mode silencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->