### PR TITLE
feat(dashboards): persist time filter as part of the dashboard

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -3,6 +3,7 @@ import { FilterSidebar } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useDashboard } from '@/context/DashboardContext';
+import { deserializeTimeRange, serializeTimeRange } from '@/context/DashboardContext.utils';
 import { useAlerts, useResolvedAlerts, useDeleteResolvedAlert, useMarkAlertRead } from '@/hooks/queries/alerts';
 import {
 	useCreateDashboard,
@@ -141,6 +142,7 @@ const Alerts = () => {
 			visibleColumns: dashboardState.visibleColumns.filter((col) => col !== ACTIONS_COLUMN),
 			query: dashboardState.query,
 			groupBy: dashboardState.groupBy,
+			timeRange: serializeTimeRange(dashboardState.timeRange),
 		};
 
 		try {
@@ -371,7 +373,7 @@ const Alerts = () => {
 				columnOrder: [],
 				groupBy: dashboard.groupBy || [],
 				query: dashboard.query || '',
-				timeRange: { from: null, to: null, preset: null },
+				timeRange: deserializeTimeRange(dashboard.timeRange),
 			});
 		};
 

--- a/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
+++ b/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
@@ -8,6 +8,7 @@ import { getAlertSeverity } from '@/components/Alerts/utils/severity.utils';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useDashboard } from '@/context/DashboardContext';
+import { deserializeTimeRange, serializeTimeRange } from '@/context/DashboardContext.utils';
 import { useAlerts, useSilenceAlert, useUnsilenceAlert } from '@/hooks/queries/alerts';
 import {
 	useCreateDashboard,
@@ -147,6 +148,7 @@ const AlertsTVMode = () => {
 			visibleColumns: dashboardState.visibleColumns,
 			query: dashboardState.query,
 			groupBy: dashboardState.groupBy,
+			timeRange: serializeTimeRange(dashboardState.timeRange),
 		};
 
 		try {
@@ -202,6 +204,7 @@ const AlertsTVMode = () => {
 					columnOrder: [],
 					groupBy: dashboard.groupBy || [],
 					query: dashboard.query || '',
+					timeRange: deserializeTimeRange(dashboard.timeRange),
 				});
 			};
 

--- a/apps/client/src/context/DashboardContext.tsx
+++ b/apps/client/src/context/DashboardContext.tsx
@@ -83,8 +83,11 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 	}, [dashboardState]);
 
 	const setInitialState = useCallback((state: DashboardState) => {
-		setInitialStateState(JSON.parse(JSON.stringify(state)));
-		setDashboardState(JSON.parse(JSON.stringify(state)));
+		// structuredClone (not JSON round-trip) so timeRange's Date objects survive
+		// the deep copy — JSON.stringify would turn them into strings and break the
+		// time filter comparisons in useAlertsFiltering.
+		setInitialStateState(structuredClone(state));
+		setDashboardState(structuredClone(state));
 		setHasUserMadeChanges(false);
 	}, []);
 
@@ -104,6 +107,9 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 		const initialVisibleColumns = JSON.stringify(initialState.visibleColumns);
 		const currentQuery = dashboardState.query;
 		const initialQuery = initialState.query;
+		// Dates serialize to ISO strings, so JSON.stringify gives a stable comparison.
+		const currentTimeRange = JSON.stringify(dashboardState.timeRange);
+		const initialTimeRange = JSON.stringify(initialState.timeRange);
 
 		return (
 			currentName !== initialName ||
@@ -111,7 +117,8 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 			currentGroupBy !== initialGroupBy ||
 			currentFilters !== initialFilters ||
 			currentVisibleColumns !== initialVisibleColumns ||
-			currentQuery !== initialQuery
+			currentQuery !== initialQuery ||
+			currentTimeRange !== initialTimeRange
 		);
 	}, [dashboardState, initialState, hasUserMadeChanges]);
 
@@ -123,6 +130,7 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 			'filters',
 			'visibleColumns',
 			'query',
+			'timeRange',
 		];
 		if (userEditableFields.includes(field)) {
 			setHasUserMadeChanges(true);
@@ -138,7 +146,7 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 	}, []);
 
 	const markAsClean = useCallback(() => {
-		setInitialStateState(JSON.parse(JSON.stringify(dashboardState)));
+		setInitialStateState(structuredClone(dashboardState));
 		setHasUserMadeChanges(false);
 	}, [dashboardState]);
 

--- a/apps/client/src/context/DashboardContext.tsx
+++ b/apps/client/src/context/DashboardContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { clearStorage, loadFromStorage, saveToStorage } from './DashboardContext.utils';
+import { clearStorage, loadFromStorage, saveToStorage, serializeTimeRange } from './DashboardContext.utils';
 
 export type DashboardType = 'services' | 'alerts';
 
@@ -107,9 +107,10 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 		const initialVisibleColumns = JSON.stringify(initialState.visibleColumns);
 		const currentQuery = dashboardState.query;
 		const initialQuery = initialState.query;
-		// Dates serialize to ISO strings, so JSON.stringify gives a stable comparison.
-		const currentTimeRange = JSON.stringify(dashboardState.timeRange);
-		const initialTimeRange = JSON.stringify(initialState.timeRange);
+		// serializeTimeRange fixes the property order (and turns Dates into ISO
+		// strings), so the stringified comparison is stable.
+		const currentTimeRange = JSON.stringify(serializeTimeRange(dashboardState.timeRange));
+		const initialTimeRange = JSON.stringify(serializeTimeRange(initialState.timeRange));
 
 		return (
 			currentName !== initialName ||

--- a/apps/client/src/context/DashboardContext.utils.ts
+++ b/apps/client/src/context/DashboardContext.utils.ts
@@ -1,30 +1,24 @@
-import { Logger } from '@OpsiMate/shared';
+import { DashboardTimeRange, Logger } from '@OpsiMate/shared';
 import { DashboardState, TimeRange } from './DashboardContext';
 
 const logger = new Logger('DashboardContext.utils');
 
 export const DASHBOARD_STORAGE_KEY = 'OpsiMate-active-dashboard';
 
-interface SerializedTimeRange {
-	from: string | null;
-	to: string | null;
-	preset: TimeRange['preset'];
-}
-
-const serializeTimeRange = (timeRange: TimeRange): SerializedTimeRange => ({
+export const serializeTimeRange = (timeRange: TimeRange): DashboardTimeRange => ({
 	from: timeRange.from?.toISOString() ?? null,
 	to: timeRange.to?.toISOString() ?? null,
 	preset: timeRange.preset,
 });
 
-const deserializeTimeRange = (stored: SerializedTimeRange | undefined): TimeRange => {
+export const deserializeTimeRange = (stored: DashboardTimeRange | undefined): TimeRange => {
 	if (!stored) {
 		return { from: null, to: null, preset: null };
 	}
 	return {
 		from: stored.from ? new Date(stored.from) : null,
 		to: stored.to ? new Date(stored.to) : null,
-		preset: stored.preset,
+		preset: stored.preset as TimeRange['preset'],
 	};
 };
 

--- a/apps/client/src/hooks/queries/dashboards/dashboards.types.ts
+++ b/apps/client/src/hooks/queries/dashboards/dashboards.types.ts
@@ -1,3 +1,5 @@
+import { DashboardTimeRange, Tag } from '@OpsiMate/shared';
+
 export interface Dashboard {
 	id: string;
 	name: string;
@@ -7,6 +9,7 @@ export interface Dashboard {
 	visibleColumns: string[];
 	query: string;
 	groupBy: string[];
+	timeRange?: DashboardTimeRange;
 	createdAt?: string;
 }
 
@@ -18,13 +21,12 @@ export interface CreateDashboardInput {
 	visibleColumns: string[];
 	query: string;
 	groupBy: string[];
+	timeRange?: DashboardTimeRange;
 }
 
 export interface UpdateDashboardInput extends CreateDashboardInput {
 	id: string;
 }
-
-import { Tag } from '@OpsiMate/shared';
 
 export interface DashboardTagsResponse {
 	dashboardId: number;

--- a/apps/server/src/dal/dashboardRepository.ts
+++ b/apps/server/src/dal/dashboardRepository.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
-import { DashboardRow } from './models';
-import { Dashboard } from '@OpsiMate/shared';
+import { DashboardRow, TableInfoRow } from './models';
+import { Dashboard, DashboardTimeRange } from '@OpsiMate/shared';
 
 export class DashboardRepository {
 	constructor(private db: Database.Database) {}
@@ -16,6 +16,9 @@ export class DashboardRepository {
 			visibleColumns: JSON.parse(dashboardRow.visible_columns) as string[],
 			query: dashboardRow.query,
 			groupBy: JSON.parse(dashboardRow.group_by) as string[],
+			timeRange: dashboardRow.time_range
+				? (JSON.parse(dashboardRow.time_range) as DashboardTimeRange)
+				: undefined,
 			createdAt: dashboardRow.created_at,
 		};
 	};
@@ -37,8 +40,8 @@ export class DashboardRepository {
 	async createDashboard(dashboard: Omit<Dashboard, 'createdAt' | 'id'>): Promise<number> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
-                INSERT INTO dashboards (name, type, description, filters, visible_columns, query, group_by)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO dashboards (name, type, description, filters, visible_columns, query, group_by, time_range)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             `);
 			const result = stmt.run(
 				dashboard.name,
@@ -47,7 +50,8 @@ export class DashboardRepository {
 				JSON.stringify(dashboard.filters),
 				JSON.stringify(dashboard.visibleColumns),
 				dashboard.query,
-				JSON.stringify(dashboard.groupBy)
+				JSON.stringify(dashboard.groupBy),
+				dashboard.timeRange ? JSON.stringify(dashboard.timeRange) : null
 			);
 			return result.lastInsertRowid as number;
 		});
@@ -75,11 +79,18 @@ export class DashboardRepository {
 							filters         TEXT NOT NULL,
 							visible_columns TEXT NOT NULL,
 							query           TEXT,
-							group_by        TEXT NOT NULL
+							group_by        TEXT NOT NULL,
+							time_range      TEXT
 						)
 					`
 				)
 				.run();
+
+			// Backward compatibility: ensure time_range column exists on older DBs
+			const columns = this.db.prepare(`PRAGMA table_info(dashboards)`).all() as TableInfoRow[];
+			if (!columns.some((col) => col.name === 'time_range')) {
+				this.db.prepare(`ALTER TABLE dashboards ADD COLUMN time_range TEXT`).run();
+			}
 		});
 	}
 
@@ -94,7 +105,8 @@ export class DashboardRepository {
                 filters = ?,
                 visible_columns = ?,
                 query = ?,
-                group_by = ?
+                group_by = ?,
+                time_range = ?
             WHERE id = ?
         `);
 
@@ -106,6 +118,7 @@ export class DashboardRepository {
 				JSON.stringify(dashboard.visibleColumns),
 				dashboard.query,
 				JSON.stringify(dashboard.groupBy),
+				dashboard.timeRange ? JSON.stringify(dashboard.timeRange) : null,
 				dashboardId
 			);
 

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -49,6 +49,7 @@ export interface DashboardRow {
 	visible_columns: string; // string[]
 	query: string;
 	group_by: string; // string[]
+	time_range?: string | null; // DashboardTimeRange
 }
 
 export type AlertRow = {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -264,6 +264,13 @@ export const CreateDashboardSchema = z.object({
 	visibleColumns: z.array(z.string()),
 	query: z.string(),
 	groupBy: z.array(z.string()),
+	timeRange: z
+		.object({
+			from: z.string().nullable(),
+			to: z.string().nullable(),
+			preset: z.string().nullable(),
+		})
+		.optional(),
 });
 
 export const DashboardIdSchema = z.object({

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -339,6 +339,15 @@ export interface ResetPasswordType {
 	expiresAt: Date;
 }
 
+// Serialized time filter persisted with a dashboard. Dates are stored as ISO
+// strings so the range survives the wire and the DB; `preset` mirrors the
+// client TimeRange preset ('last1h', 'custom', ...).
+export interface DashboardTimeRange {
+	from: string | null;
+	to: string | null;
+	preset: string | null;
+}
+
 export interface Dashboard {
 	id: string;
 	type: 'services' | 'alerts';
@@ -348,6 +357,7 @@ export interface Dashboard {
 	visibleColumns: string[];
 	query: string;
 	groupBy: string[];
+	timeRange?: DashboardTimeRange;
 	createdAt?: string;
 }
 


### PR DESCRIPTION
Saving a dashboard now stores the active time filter (from/to/preset, dates as ISO strings) and selecting the dashboard restores it, in both the alerts view and TV mode.

- shared: add DashboardTimeRange, optional timeRange on Dashboard, and the matching field on CreateDashboardSchema so Zod keeps it
- server: nullable time_range TEXT column with a PRAGMA-guarded ALTER TABLE migration for existing DBs
- client: deep-clone dashboard state with structuredClone instead of a JSON round-trip so restored Date objects survive (a JSON clone turned them into strings, making the time filter comparisons NaN and hiding every alert), and include timeRange in the dirty check so changing the filter shows the save button

## Issue Reference

<!-- Link to the related issue or ticket, e.g. Closes #123 -->

---

## What Was Changed

<!-- Brief summary of the changes introduced in this PR -->

---

## Why Was It Changed

<!-- Explain the reasoning or motivation behind the change -->

---

## Screenshots

<!-- If UI changes or visual diffs were made, include screenshots here -->

---

## Additional Context (Optional)

<!-- Any extra information that helps reviewers understand the PR, like edge cases, limitations, or TODOs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dashboards now save and restore selected time ranges (custom dates and presets), including in TV mode.
  - Dashboard creation and updates support optional time-range configuration.
  - Time-range edits are now included in change tracking (dirty state).

- **Bug Fixes**
  - Preserves date values correctly when saving, loading, and comparing dashboards.
  - Added backward-compatible storage support for existing installations (new time-range column is added when missing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->