### PR TITLE
fix(client): eliminate all console errors and warnings across pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ config.yml
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/tailwind.css-data.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	// Tailwind CSS IntelliSense understands the v4 CSS-first config natively and adds
+	// class completion/hover previews on top of the at-rule support in settings.json.
+	"recommendations": ["bradlc.vscode-tailwindcss"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	// Teach the built-in CSS language server Tailwind 4's at-rules (@theme, @plugin,
+	// @custom-variant, @utility, @apply, …) so index.css doesn't light up with
+	// "Unknown at rule" warnings. Genuinely unknown at-rules are still flagged.
+	"css.customData": [".vscode/tailwind.css-data.json"]
+}

--- a/.vscode/tailwind.css-data.json
+++ b/.vscode/tailwind.css-data.json
@@ -1,0 +1,50 @@
+{
+	"version": 1.1,
+	"atDirectives": [
+		{
+			"name": "@theme",
+			"description": "Tailwind CSS 4: declares design tokens (colors, fonts, breakpoints, …) as CSS variables that also generate utilities.",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/theme" }]
+		},
+		{
+			"name": "@plugin",
+			"description": "Tailwind CSS 4: loads a JavaScript plugin (replaces the `plugins` array of the v3 config file).",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#plugin-directive" }]
+		},
+		{
+			"name": "@custom-variant",
+			"description": "Tailwind CSS 4: defines a custom variant (e.g. the class-based `dark:` variant).",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#custom-variant-directive" }]
+		},
+		{
+			"name": "@variant",
+			"description": "Tailwind CSS 4: applies a variant's rules inside plain CSS.",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#variant-directive" }]
+		},
+		{
+			"name": "@utility",
+			"description": "Tailwind CSS 4: registers a custom utility that works with variants (replaces v3 `@layer utilities` additions).",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#utility-directive" }]
+		},
+		{
+			"name": "@apply",
+			"description": "Tailwind CSS: inlines utility classes into custom CSS rules.",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#apply-directive" }]
+		},
+		{
+			"name": "@source",
+			"description": "Tailwind CSS 4: registers extra source files to scan for class names.",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#source-directive" }]
+		},
+		{
+			"name": "@reference",
+			"description": "Tailwind CSS 4: imports a stylesheet for @apply/@variant resolution without emitting its CSS.",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#reference-directive" }]
+		},
+		{
+			"name": "@config",
+			"description": "Tailwind CSS 4: loads a legacy JavaScript config file.",
+			"references": [{ "name": "Tailwind docs", "url": "https://tailwindcss.com/docs/functions-and-directives#config-directive" }]
+		}
+	]
+}

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -47,6 +47,9 @@ const App: React.FC = () => {
 	// Tailwind 4's `@layer utilities` regardless of specificity — that wiped out every border and
 	// button background (reset) and forced `border-color` to Chakra's gray.200 (global styles).
 	// Tailwind's preflight is this app's reset; Chakra is only here for the actions modal.
+	// BrowserRouter opts in to the v7 behaviors: silences the future-flag console warnings and
+	// makes the eventual React Router 7 upgrade a no-op. Safe here — state updates tolerate
+	// startTransition, and the only splat route (NotFound) has no relative router links.
 	return (
 		<ChakraProvider resetCSS={false} disableGlobalStyle>
 			<ThemeProvider
@@ -64,10 +67,6 @@ const App: React.FC = () => {
 							<Sonner />
 							<UnsavedChangesDialogWrapper />
 
-							{/* Opt in to the v7 behaviors now: silences the future-flag console warnings
-							    and makes the eventual React Router 7 upgrade a no-op. Safe here — state
-							    updates tolerate startTransition, and the only splat route (NotFound)
-							    contains no relative router links. */}
 							<BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
 								<AuthGuard>
 									<Routes>

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -64,7 +64,11 @@ const App: React.FC = () => {
 							<Sonner />
 							<UnsavedChangesDialogWrapper />
 
-							<BrowserRouter>
+							{/* Opt in to the v7 behaviors now: silences the future-flag console warnings
+							    and makes the eventual React Router 7 upgrade a no-op. Safe here — state
+							    updates tolerate startTransition, and the only splat route (NotFound)
+							    contains no relative router links. */}
+							<BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
 								<AuthGuard>
 									<Routes>
 										<Route path="/" element={<Alerts />} />

--- a/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
@@ -1,4 +1,3 @@
-import { Table, TableBody } from '@/components/ui/table';
 import { Alert } from '@OpsiMate/shared';
 import { Virtualizer } from '@tanstack/react-virtual';
 import { useEffect } from 'react';
@@ -71,74 +70,81 @@ export const VirtualizedAlertList = ({
 		};
 	}, [onDragEnd]);
 
+	// Each virtual row is absolutely positioned, so it never participated in a shared
+	// table layout — a row was already its own `display: table` box. Rendering each one
+	// as a real single-row <table> keeps that layout identical while producing valid
+	// HTML (React 19 logs <div>-in-<tbody> / <tr>-in-<div> nesting as console errors).
+	// `text-sm` replaces the removed ui/Table wrapper; the `[&_tr:last-child]:border-0`
+	// rule replaces the ui/TableBody one (every row's <tr> is the last child of its own
+	// table, which is what kept the rows border-free before, too).
 	return (
-		<div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative', width: '100%' }}>
-			<Table className="w-full table-fixed">
-				<TableBody>
-					{virtualItems.map((virtualRow) => {
-						const item = flatRows[virtualRow.index];
+		<div
+			className="text-sm [&_tr:last-child]:border-0"
+			style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative', width: '100%' }}
+		>
+			{virtualItems.map((virtualRow) => {
+				const item = flatRows[virtualRow.index];
 
-						if (item.type === 'group') {
-							return (
-								<div
-									key={virtualRow.key}
-									data-index={virtualRow.index}
-									ref={virtualizer.measureElement}
-									style={{
-										position: 'absolute',
-										top: 0,
-										left: 0,
-										width: '100%',
-										transform: `translateY(${virtualRow.start}px)`,
-									}}
-								>
-									<GroupHeader item={item} onToggle={onToggleGroup} columnLabels={columnLabels} />
-								</div>
-							);
-						}
+				if (item.type === 'group') {
+					return (
+						<div
+							key={virtualRow.key}
+							data-index={virtualRow.index}
+							ref={virtualizer.measureElement}
+							style={{
+								position: 'absolute',
+								top: 0,
+								left: 0,
+								width: '100%',
+								transform: `translateY(${virtualRow.start}px)`,
+							}}
+						>
+							<GroupHeader item={item} onToggle={onToggleGroup} columnLabels={columnLabels} />
+						</div>
+					);
+				}
 
-						const alert = item.alert;
-						const isSelected = selectedAlerts.some((a) => a.id === alert.id);
-						return (
-							<div
-								key={virtualRow.key}
-								data-index={virtualRow.index}
-								ref={virtualizer.measureElement}
-								style={{
-									position: 'absolute',
-									top: 0,
-									left: 0,
-									width: '100%',
-									transform: `translateY(${virtualRow.start}px)`,
-									display: 'table',
-									tableLayout: 'fixed',
-								}}
-							>
-								<AlertRow
-									alert={alert}
-									isSelected={isSelected}
-									orderedColumns={orderedColumns}
-									onSelectAlert={onSelectAlert}
-									onAlertClick={onAlertClick}
-									isActiveRow={alert.id === activeAlertId}
-									onSilenceAlert={onSilenceAlert}
-									onUnsilenceAlert={onUnsilenceAlert}
-									onDeleteAlert={onDeleteAlert}
-									onUnresolveAlert={onUnresolveAlert}
-									onSelectAlerts={onSelectAlerts}
-									isResolved={isResolved}
-									severityColors={severityColors}
-									expandRows={expandRows}
-									isDragging={isDragging}
-									onDragStart={onDragStart}
-									onDragEnter={onDragEnter}
-									onDragEnd={onDragEnd}
-								/>
-							</div>
-						);
-					})}
-				</TableBody>
-			</Table>
+				const alert = item.alert;
+				const isSelected = selectedAlerts.some((a) => a.id === alert.id);
+				return (
+					<table
+						key={virtualRow.key}
+						data-index={virtualRow.index}
+						ref={virtualizer.measureElement}
+						className="w-full table-fixed"
+						style={{
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							width: '100%',
+							transform: `translateY(${virtualRow.start}px)`,
+						}}
+					>
+						<tbody>
+							<AlertRow
+								alert={alert}
+								isSelected={isSelected}
+								orderedColumns={orderedColumns}
+								onSelectAlert={onSelectAlert}
+								onAlertClick={onAlertClick}
+								isActiveRow={alert.id === activeAlertId}
+								onSilenceAlert={onSilenceAlert}
+								onUnsilenceAlert={onUnsilenceAlert}
+								onDeleteAlert={onDeleteAlert}
+								onUnresolveAlert={onUnresolveAlert}
+								onSelectAlerts={onSelectAlerts}
+								isResolved={isResolved}
+								severityColors={severityColors}
+								expandRows={expandRows}
+								isDragging={isDragging}
+								onDragStart={onDragStart}
+								onDragEnter={onDragEnter}
+								onDragEnd={onDragEnd}
+							/>
+						</tbody>
+					</table>
+				);
+			})}
 		</div>
 	);
 };

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -1,10 +1,8 @@
-/* Nunito Sans is self-hosted (bundled from @fontsource) so the app renders correctly in
-   air-gapped deployments — a remote Google Fonts import blocks first paint when the CDN
-   is unreachable. */
-@import '@fontsource/nunito-sans/400.css' layer(base);
-@import '@fontsource/nunito-sans/600.css' layer(base);
-@import '@fontsource/nunito-sans/700.css' layer(base);
-
+/* Nunito Sans (self-hosted via @fontsource) is imported from main.tsx, NOT here:
+   @tailwindcss/postcss inlines @import rules itself, which copies the @fontsource CSS
+   verbatim but never routes its url(./files/*.woff2) references through Vite's asset
+   pipeline — the production build then ships no font binaries at all and every page
+   logs OTS "Failed to decode" font warnings while falling back to system fonts. */
 @import 'tailwindcss';
 
 @plugin 'tailwindcss-animate';

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,6 +1,13 @@
 import { Logger } from '@OpsiMate/shared';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+// Nunito Sans is self-hosted (bundled from @fontsource) so the app renders correctly in
+// air-gapped deployments — a remote Google Fonts import blocks first paint when the CDN
+// is unreachable. Imported here rather than in index.css so Vite's asset pipeline emits
+// the font binaries; @tailwindcss/postcss would inline the CSS without them (see index.css).
+import '@fontsource/nunito-sans/400.css';
+import '@fontsource/nunito-sans/600.css';
+import '@fontsource/nunito-sans/700.css';
 import './index.css';
 
 const logger = new Logger('main');


### PR DESCRIPTION
## What

A Playwright console audit — fresh loads of all 11 routes, SPA navigation between pages, and row/dialog interactions, run against both the dev server and the production build — found three distinct issues. After this PR the same audit reports **zero console errors and zero warnings** in both dev and prod.

### 1. React Router future-flag warnings (2 warnings × every page)

`BrowserRouter` now opts in to `v7_startTransition` and `v7_relativeSplatPath`. Both verified safe: state updates tolerate `startTransition` (React 19), and the only splat route (`NotFound`) contains no relative router links — it uses a plain `<a href="/">`. Bonus: the eventual React Router 7 upgrade becomes a no-op for these behaviors.

### 2. Invalid DOM nesting in the virtualized alerts table (React 19 logs these as errors)

`VirtualizedAlertList` rendered absolutely-positioned `<div>`s inside `<tbody>`, each containing a bare `<tr>`. Key insight: each virtual row was already its own `display: table` CSS box, so the surrounding `<Table><TableBody>` never contributed layout — only `text-sm` inheritance and (accidentally) the `[&_tr:last-child]:border-0` rule that keeps rows border-free. Each alert row is now a real single-row `<table><tbody>` (the same pattern `DashboardsTable` already uses), with those two style contributions moved onto the container so appearance is preserved.

**Verified**: pixel diff of the alerts page against `main` is **0.000%** — literally identical rendering. Row click → details, checkbox + drag selection → bulk bar, group-by severity (headers render, expand shows the 4 critical rows), and the expand-rows toggle all exercised headlessly with zero console output.

### 3. Production builds have shipped no fonts since the Tailwind 4 migration (#697)

The `OTS parsing error: invalid sfntVersion: 1008821359` warnings in the prod build decode to ASCII `"<!DO"` — the font URLs were returning `index.html`. Root cause: `@tailwindcss/postcss` inlines the `@fontsource` imports in `index.css` itself, so their `url(./files/*.woff2)` references never went through Vite's asset pipeline and **zero font binaries were emitted** — production silently fell back to system fonts (dev was unaffected, which is why it went unnoticed). The imports moved to `main.tsx`, where Vite bundles them properly: `dist/` again contains 30 hashed font assets, no stale `./files/` references remain in the CSS, and `document.fonts` confirms 3 Nunito Sans faces load in both dev and production.

## Verification

- Console audit (11 routes × load + SPA nav + interactions): **0 issues** in dev, **0 issues** in prod (was 6 unique issues in dev, 7 in prod)
- `pnpm build` 4/4 · client tests 37/37 · server tests 115/115 · all lints (`--max-warnings=0` where CI enforces it) and prettier clean · client `tsc` unchanged at 81 pre-existing errors
- Nunito Sans: `document.fonts.check('16px "Nunito Sans"')` → `true` on both :8080 (dev) and :4173 (prod preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved alert list rendering for smoother scrolling and more consistent row display.
  - Updated alert group and item HTML/layout to maintain alignment for long virtualized lists.
  - Nunito Sans font styles now load more reliably, including when external font services are unavailable.
  - Updated router setup to opt into upcoming React Router v7 behaviors while keeping the same navigation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->