### PR TITLE
feat(alerts): single view-picker dropdown + fix actions-header overflow

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -432,8 +432,6 @@ const Alerts = () => {
 		[AlertTab.Resolved]: filteredResolvedAlerts.length,
 		[AlertTab.All]: filteredAllAlerts.length,
 	};
-	const currentTabOption = ALERT_TAB_OPTIONS.find((option) => option.value === activeTab) ?? ALERT_TAB_OPTIONS[0];
-
 	return (
 		<DashboardLayout>
 			<div className="flex h-full">
@@ -484,10 +482,26 @@ const Alerts = () => {
 											className="gap-1.5 shrink-0"
 											aria-label="Choose which alerts to show"
 										>
-											<currentTabOption.Icon className="h-4 w-4" />
-											<span>{currentTabOption.label}</span>
-											<span className="text-xs text-muted-foreground tabular-nums">
-												{tabCounts[activeTab]}
+											{/* All options render stacked in one grid cell (hidden except the
+											    current one) so the button keeps the width of the widest option
+											    and nothing shifts when switching views. */}
+											<span className="grid">
+												{ALERT_TAB_OPTIONS.map(({ value, label, Icon }) => (
+													<span
+														key={value}
+														aria-hidden={value !== activeTab}
+														className={cn(
+															'col-start-1 row-start-1 flex items-center gap-1.5 whitespace-nowrap',
+															value !== activeTab && 'invisible'
+														)}
+													>
+														<Icon className="h-4 w-4" />
+														<span>{label}</span>
+														<span className="text-xs text-muted-foreground tabular-nums">
+															{tabCounts[value]}
+														</span>
+													</span>
+												))}
 											</span>
 											<ChevronDown className="h-3.5 w-3.5 opacity-60" />
 										</Button>

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -486,7 +486,12 @@ const Alerts = () => {
 											variant="outline"
 											size="sm"
 											className="gap-1.5 shrink-0"
-											aria-label="Choose which alerts to show"
+											// Dynamic name: a static label would override the visible text and
+											// hide the current view + count from screen readers.
+											aria-label={`Choose which alerts to show — currently ${
+												ALERT_TAB_OPTIONS.find((option) => option.value === activeTab)?.label ??
+												'Active'
+											}, ${tabCounts[activeTab]} alerts`}
 										>
 											{/* All options render stacked in one grid cell (hidden except the
 											    current one) so the button keeps the width of the widest option

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -1,7 +1,13 @@
 import { DashboardLayout } from '@/components/DashboardLayout';
 import { FilterSidebar } from '@/components/shared';
 import { Button } from '@/components/ui/button';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useDashboard } from '@/context/DashboardContext';
 import { deserializeTimeRange, serializeTimeRange } from '@/context/DashboardContext.utils';
 import { useAlerts, useResolvedAlerts, useDeleteResolvedAlert, useMarkAlertRead } from '@/hooks/queries/alerts';
@@ -16,7 +22,7 @@ import { useServices } from '@/hooks/queries/services';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
-import { Bell, CheckCircle2, Columns2, LayoutList, Palette } from 'lucide-react';
+import { Bell, CheckCircle2, ChevronDown, Columns2, LayoutList, Palette } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertsFilterPanel } from '.';
@@ -41,6 +47,14 @@ import {
 	useColumnManagement,
 	useSeverityColors,
 } from './hooks';
+
+// Options for the alert-list picker (one dropdown instead of three toggle buttons);
+// per-tab counts come from the filtered lists at render time.
+const ALERT_TAB_OPTIONS = [
+	{ value: AlertTab.Active, label: 'Active', Icon: Bell },
+	{ value: AlertTab.Resolved, label: 'Resolved', Icon: CheckCircle2 },
+	{ value: AlertTab.All, label: 'All', Icon: LayoutList },
+] as const;
 
 const Alerts = () => {
 	const navigate = useNavigate();
@@ -411,6 +425,15 @@ const Alerts = () => {
 		setSelectedAlert((prev) => (prev?.id === alert.id ? null : alert));
 	};
 
+	// Per-tab counts for the alert-list picker; the dropdown shows every tab's count so
+	// switching isn't needed just to see how many resolved/all alerts there are.
+	const tabCounts: Record<AlertTab, number> = {
+		[AlertTab.Active]: filteredAlerts.length,
+		[AlertTab.Resolved]: filteredResolvedAlerts.length,
+		[AlertTab.All]: filteredAllAlerts.length,
+	};
+	const currentTabOption = ALERT_TAB_OPTIONS.find((option) => option.value === activeTab) ?? ALERT_TAB_OPTIONS[0];
+
 	return (
 		<DashboardLayout>
 			<div className="flex h-full">
@@ -453,58 +476,43 @@ const Alerts = () => {
 							/>
 
 							<div className="mt-3 flex items-center gap-4">
-								<ToggleGroup
-									type="single"
-									value={activeTab}
-									onValueChange={(value) => {
-										if (value) {
-											const newTab = value as AlertTab;
-											setActiveTab(newTab);
-											setSelectedAlert(null);
-											setSelectedAlerts([]);
-										}
-									}}
-									className="justify-start"
-								>
-									<ToggleGroupItem
-										value={AlertTab.Active}
-										aria-label="Active alerts"
-										size="sm"
-										className="gap-1.5 bg-transparent text-foreground hover:bg-muted hover:text-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground [&_svg]:text-current [&_svg]:data-[state=on]:text-primary-foreground"
-									>
-										<Bell className="h-4 w-4" />
-										<span>Active</span>
-									</ToggleGroupItem>
-									<ToggleGroupItem
-										value={AlertTab.Resolved}
-										aria-label="Resolved alerts"
-										size="sm"
-										className="gap-1.5 bg-transparent text-foreground hover:bg-muted hover:text-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground [&_svg]:text-current [&_svg]:data-[state=on]:text-primary-foreground"
-									>
-										<CheckCircle2 className="h-4 w-4" />
-										<span>Resolved</span>
-									</ToggleGroupItem>
-									<ToggleGroupItem
-										value={AlertTab.All}
-										aria-label="All alerts"
-										size="sm"
-										className="gap-1.5 bg-transparent text-foreground hover:bg-muted hover:text-foreground data-[state=on]:bg-primary data-[state=on]:text-primary-foreground [&_svg]:text-current [&_svg]:data-[state=on]:text-primary-foreground"
-									>
-										<LayoutList className="h-4 w-4" />
-										<span>All</span>
-									</ToggleGroupItem>
-								</ToggleGroup>
-								<span className="text-sm text-muted-foreground whitespace-nowrap">
-									{(() => {
-										const count =
-											activeTab === AlertTab.Active
-												? filteredAlerts.length
-												: activeTab === AlertTab.Resolved
-													? filteredResolvedAlerts.length
-													: filteredAllAlerts.length;
-										return `${count} Alert${count !== 1 ? 's' : ''}`;
-									})()}
-								</span>
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											variant="outline"
+											size="sm"
+											className="gap-1.5 shrink-0"
+											aria-label="Choose which alerts to show"
+										>
+											<currentTabOption.Icon className="h-4 w-4" />
+											<span>{currentTabOption.label}</span>
+											<span className="text-xs text-muted-foreground tabular-nums">
+												{tabCounts[activeTab]}
+											</span>
+											<ChevronDown className="h-3.5 w-3.5 opacity-60" />
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start" className="w-44">
+										<DropdownMenuRadioGroup
+											value={activeTab}
+											onValueChange={(value) => {
+												setActiveTab(value as AlertTab);
+												setSelectedAlert(null);
+												setSelectedAlerts([]);
+											}}
+										>
+											{ALERT_TAB_OPTIONS.map(({ value, label, Icon }) => (
+												<DropdownMenuRadioItem key={value} value={value} className="gap-1.5">
+													<Icon className="h-4 w-4" />
+													<span>{label}</span>
+													<span className="ml-auto pl-4 text-xs text-muted-foreground tabular-nums">
+														{tabCounts[value]}
+													</span>
+												</DropdownMenuRadioItem>
+											))}
+										</DropdownMenuRadioGroup>
+									</DropdownMenuContent>
+								</DropdownMenu>
 
 								<div className="flex-1 min-w-0">
 									<SearchBar

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -33,6 +33,7 @@ import { AlertsTable } from './AlertsTable';
 import { AssignmentPane } from './AssignmentPane';
 import { VerticalSplit } from './VerticalSplit';
 import { ACTIONS_COLUMN } from './AlertsTable/AlertsTable.constants';
+import { filterAlerts } from './AlertsTable/AlertsTable.utils';
 import { AlertTab } from './AlertsTable/AlertsTable.types';
 import { SearchBar } from './AlertsTable/SearchBar';
 import { TimeFilter, createEmptyTimeRange } from './AlertsTable/TimeFilter';
@@ -426,12 +427,17 @@ const Alerts = () => {
 	};
 
 	// Per-tab counts for the alert-list picker; the dropdown shows every tab's count so
-	// switching isn't needed just to see how many resolved/all alerts there are.
-	const tabCounts: Record<AlertTab, number> = {
-		[AlertTab.Active]: filteredAlerts.length,
-		[AlertTab.Resolved]: filteredResolvedAlerts.length,
-		[AlertTab.All]: filteredAllAlerts.length,
-	};
+	// switching isn't needed just to see how many resolved/all alerts there are. The
+	// search term is applied too — AlertsTable filters by it after the sidebar/time
+	// filters, and the counts must agree with the rows actually shown.
+	const tabCounts: Record<AlertTab, number> = useMemo(
+		() => ({
+			[AlertTab.Active]: filterAlerts(filteredAlerts, dashboardState.query).length,
+			[AlertTab.Resolved]: filterAlerts(filteredResolvedAlerts, dashboardState.query).length,
+			[AlertTab.All]: filterAlerts(filteredAllAlerts, dashboardState.query).length,
+		}),
+		[filteredAlerts, filteredResolvedAlerts, filteredAllAlerts, dashboardState.query]
+	);
 	return (
 		<DashboardLayout>
 			<div className="flex h-full">

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -35,6 +35,8 @@ export interface AlertRowProps {
 	severityColors?: boolean;
 	// Wrap cell content onto new lines instead of truncating (the "expand rows" toggle).
 	expandRows?: boolean;
+	// Width of the trailing actions column; must match the header's or columns drift.
+	actionsColumnWidth?: string;
 	onDragStart?: (alert: Alert, e: React.MouseEvent) => void;
 	onDragEnter?: (alert: Alert) => void;
 	onDragEnd?: () => void;
@@ -56,6 +58,7 @@ export const AlertRow = ({
 	isDragging = false,
 	severityColors = false,
 	expandRows = false,
+	actionsColumnWidth,
 	onDragStart,
 	onDragEnter,
 	onDragEnd,
@@ -167,6 +170,7 @@ export const AlertRow = ({
 							<AlertActionsColumn
 								key={column}
 								alert={alert}
+								width={actionsColumnWidth}
 								onSilenceAlert={onSilenceAlert}
 								onUnsilenceAlert={onUnsilenceAlert}
 								onDeleteAlert={onDeleteAlert}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertActionsColumn/AlertActionsColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertActionsColumn/AlertActionsColumn.tsx
@@ -6,6 +6,8 @@ import { RowActions } from '../../RowActions';
 
 export interface AlertActionsColumnProps {
 	alert: Alert;
+	// Must match the header's actions-column width or the fixed-layout columns drift.
+	width?: string;
 	onSilenceAlert?: (alertId: string) => void;
 	onUnsilenceAlert?: (alertId: string) => void;
 	onDeleteAlert?: (alertId: string) => void;
@@ -14,16 +16,14 @@ export interface AlertActionsColumnProps {
 
 export const AlertActionsColumn = ({
 	alert,
+	width = ACTIONS_COLUMN_WIDTH,
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
 	onUnresolveAlert,
 }: AlertActionsColumnProps) => {
 	return (
-		<TableCell
-			className={ACTIONS_COLUMN_PADDING}
-			style={{ width: ACTIONS_COLUMN_WIDTH, minWidth: ACTIONS_COLUMN_WIDTH, maxWidth: ACTIONS_COLUMN_WIDTH }}
-		>
+		<TableCell className={ACTIONS_COLUMN_PADDING} style={{ width, minWidth: width, maxWidth: width }}>
 			<RowActions
 				alert={alert}
 				onSilenceAlert={onSilenceAlert}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -1,7 +1,12 @@
 export const ACTIONS_COLUMN = 'actions';
 
 export const SELECT_COLUMN_WIDTH = '40px';
+// Sized for the two header buttons (expand rows + group by): 2×28px + 8px gap + 16px cell
+// padding. When the column-settings button is also shown the header needs a third button,
+// so the table switches to the wider constant — with only 80px the buttons overflow the
+// fixed <th> and sit on top of the neighboring column's header text.
 export const ACTIONS_COLUMN_WIDTH = '80px';
+export const ACTIONS_COLUMN_WIDTH_WITH_SETTINGS = '116px';
 export const TABLE_HEAD_CLASSES = 'h-8 py-1 px-2';
 
 export const DEFAULT_VISIBLE_COLUMNS = ['type', 'severity', 'status', 'alertName', 'summary', 'owner', 'startsAt'];

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -11,6 +11,7 @@ import { AlertsEmptyState } from './AlertsEmptyState';
 import {
 	ACTIONS_COLUMN,
 	ACTIONS_COLUMN_WIDTH,
+	ACTIONS_COLUMN_WIDTH_WITH_SETTINGS,
 	COLUMN_LABELS,
 	COLUMN_MIN_WIDTHS,
 	COLUMN_WIDTHS,
@@ -113,12 +114,24 @@ export const AlertsTable = ({
 		return [...filtered, ACTIONS_COLUMN];
 	}, [columnOrder, visibleColumns]);
 
+	// The actions header holds two buttons (expand rows + group by), or three when column
+	// settings are enabled — the column must widen with it or the extra button overflows
+	// the fixed <th> onto the neighboring column's header text.
+	const actionsColumnWidth = onColumnToggle ? ACTIONS_COLUMN_WIDTH_WITH_SETTINGS : ACTIONS_COLUMN_WIDTH;
+
 	// Floor width for the table: the sum of the visible columns' minimums. Narrower
 	// panes get a horizontal scrollbar instead of columns crushing each other.
 	const tableMinWidth = useMemo(() => {
 		const columns = onSelectAlerts ? ['select', ...orderedColumns] : orderedColumns;
-		return columns.reduce((sum, col) => sum + (COLUMN_MIN_WIDTHS[col] ?? COLUMN_MIN_WIDTHS.default), 0);
-	}, [orderedColumns, onSelectAlerts]);
+		return columns.reduce(
+			(sum, col) =>
+				sum +
+				(col === ACTIONS_COLUMN
+					? parseInt(actionsColumnWidth, 10)
+					: (COLUMN_MIN_WIDTHS[col] ?? COLUMN_MIN_WIDTHS.default)),
+			0
+		);
+	}, [orderedColumns, onSelectAlerts, actionsColumnWidth]);
 
 	const hasActiveTimeFilter = timeRange && !isTimeRangeEmpty(timeRange);
 
@@ -184,9 +197,9 @@ export const AlertsTable = ({
 															key={column}
 															className={`${TABLE_HEAD_CLASSES} text-xs`}
 															style={{
-																width: ACTIONS_COLUMN_WIDTH,
-																minWidth: ACTIONS_COLUMN_WIDTH,
-																maxWidth: ACTIONS_COLUMN_WIDTH,
+																width: actionsColumnWidth,
+																minWidth: actionsColumnWidth,
+																maxWidth: actionsColumnWidth,
 															}}
 														>
 															<div className="flex items-center justify-end gap-2 min-w-0">
@@ -332,6 +345,7 @@ export const AlertsTable = ({
 											columnLabels={allColumnLabels}
 											isResolved={isResolved}
 											severityColors={severityColors}
+											actionsColumnWidth={actionsColumnWidth}
 											isDragging={isDragging}
 											onDragStart={handleDragStart}
 											onDragEnter={handleDragEnter}

--- a/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
@@ -25,6 +25,8 @@ interface VirtualizedAlertListProps {
 	severityColors?: boolean;
 	// Wrap cell content onto new lines instead of truncating (the "expand rows" toggle).
 	expandRows?: boolean;
+	// Width of the trailing actions column; must match the header's or columns drift.
+	actionsColumnWidth?: string;
 	isDragging?: boolean;
 	onDragStart?: (alert: Alert, e: React.MouseEvent) => void;
 	onDragEnter?: (alert: Alert) => void;
@@ -49,6 +51,7 @@ export const VirtualizedAlertList = ({
 	isResolved = false,
 	severityColors = false,
 	expandRows = false,
+	actionsColumnWidth,
 	isDragging = false,
 	onDragStart,
 	onDragEnter,
@@ -136,6 +139,7 @@ export const VirtualizedAlertList = ({
 								isResolved={isResolved}
 								severityColors={severityColors}
 								expandRows={expandRows}
+								actionsColumnWidth={actionsColumnWidth}
 								isDragging={isDragging}
 								onDragStart={onDragStart}
 								onDragEnter={onDragEnter}

--- a/apps/client/src/components/shared/FilterPanel.tsx
+++ b/apps/client/src/components/shared/FilterPanel.tsx
@@ -247,7 +247,10 @@ export const FilterPanel = ({
 
 							return (
 								<AccordionItem key={field} value={field} className="border-b">
-									<AccordionTrigger className="px-2 py-1.5 hover:no-underline hover:bg-muted/50 text-foreground">
+									{/* pr-3 (not px-2): the chevron's right edge then sits 20px from the panel
+								    edge — same inset as the option rows' count badges (px-2 + px-1 + badge),
+								    so the chevron and the counts form one aligned column. */}
+									<AccordionTrigger className="pl-2 pr-3 py-1.5 hover:no-underline hover:bg-muted/50 text-foreground">
 										<div className="flex items-center justify-between w-full pr-2">
 											<span className="text-xs font-medium text-foreground">
 												{config.fieldLabels[field] || field}


### PR DESCRIPTION
## What

Two alerts-toolbar/table changes:

### 1. One dropdown instead of the Active/Resolved/All buttons

The three toggle buttons plus the separate "N Alerts" label are now a single compact picker with the search directly next to it.

- Trigger shows the current view: icon + label + live count.
- The dropdown lists all three views as radio items, **each with its own alert count** — no switching needed just to see how many resolved alerts exist.
- Counts use the same filtered lists as before (sidebar filters / time range / search still apply).
- Switching keeps the old behavior (clears selection + closes the details panel).
- **Constant width**: all three options render stacked (hidden) inside the trigger, so the button always has the widest option's width — measured 140px in all three views, search field position pixel-identical (no layout shift on switch). Hidden copies are `aria-hidden`.

### 2. Fix: header action buttons overflowed onto the last column

`ACTIONS_COLUMN_WIDTH` (80px) fits the two original header buttons (expand rows + group by); the column-settings button made the content ~116px, overflowing the fixed `<th>` and painting over the neighboring header. Invisible while short labels left that corner empty — a long tag-key column ("Kubernetes Node Pool") rendered up to the boundary and collided with the expand-rows button (repro: 30px overhang measured before the fix).

The actions column now uses 116px when `onColumnToggle` is provided (settings button present), 80px otherwise, with the width threaded to body cells and the table's min-width floor so header and body stay aligned.

## Verification (live app, Playwright)

- Dropdown: options + counts render, switching works, light/dark checked, no layout shift (button 140px in all views).
- Overlap: expand-rows button fully inside its column, zero overlap with the long tag header, header/body actions cells at identical x/width (116px), both split-by-owner panes consistent.
- Console audit across all routes + interactions: 0 errors / 0 warnings.
- Gates: build 4/4, client tests 37/37, lint identical to main (no new warnings), prettier clean, tsc unchanged at 81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced alert status tabs with a dropdown (Active, Resolved, All) that supports radio-style selection and displays per-status counts that update with the current search term.
  * Alert table action column width now adapts automatically when column settings are available.
* **Bug Fixes**
  * Switching alert views now clears any previously selected alerts.
  * Improved header/row alignment after action column width changes.
* **Style**
  * Tweaked filter panel accordion trigger spacing for cleaner chevron and count badge alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->