### PR TITLE
feat(alerts): rework silence durations + org-wide daily silence reset

### DIFF
--- a/apps/client/src/components/Alerts/ConfirmAlertActionDialog/ConfirmAlertActionDialog.tsx
+++ b/apps/client/src/components/Alerts/ConfirmAlertActionDialog/ConfirmAlertActionDialog.tsx
@@ -13,40 +13,44 @@ import { Textarea } from '@/components/ui/textarea';
 import { useEffect, useState } from 'react';
 
 // How long a silence lasts. The expiry timestamp is computed at confirm time, so
-// re-silencing an alert always restarts the timer from "now".
-export type SilenceDuration = 'midnight' | '1h' | '4h' | '8h' | 'forever';
+// re-silencing an alert always restarts the timer from "now". Every choice expires —
+// an indefinite "forever" option existed once and was removed on purpose.
+export type SilenceDuration = 'midnight' | '5m' | '15m' | '30m' | '1h' | '2h' | '6h';
+
+// Minutes from now for each fixed-length duration; 'midnight' is computed from the clock.
+const DURATION_MINUTES: Record<Exclude<SilenceDuration, 'midnight'>, number> = {
+	'5m': 5,
+	'15m': 15,
+	'30m': 30,
+	'1h': 60,
+	'2h': 120,
+	'6h': 360,
+};
 
 const SILENCE_DURATION_OPTIONS: { value: SilenceDuration; label: string }[] = [
 	{ value: 'midnight', label: 'Until midnight' },
+	{ value: '5m', label: '5 minutes' },
+	{ value: '15m', label: '15 minutes' },
+	{ value: '30m', label: '30 minutes' },
 	{ value: '1h', label: '1 hour' },
-	{ value: '4h', label: '4 hours' },
-	{ value: '8h', label: '8 hours' },
-	{ value: 'forever', label: 'Forever (until unsilenced)' },
+	{ value: '2h', label: '2 hours' },
+	{ value: '6h', label: '6 hours' },
 ];
 
-// null = no expiry (silenced until manually unsilenced).
-const silencedUntilFor = (duration: SilenceDuration): string | null => {
-	switch (duration) {
-		case 'forever':
-			return null;
-		case 'midnight': {
-			// Local midnight — the user thinks in their own day boundary, not UTC's.
-			const endOfDay = new Date();
-			endOfDay.setHours(24, 0, 0, 0);
-			return endOfDay.toISOString();
-		}
-		case '1h':
-			return new Date(Date.now() + 1 * 60 * 60 * 1000).toISOString();
-		case '4h':
-			return new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
-		case '8h':
-			return new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString();
+const silencedUntilFor = (duration: SilenceDuration): string => {
+	if (duration === 'midnight') {
+		// Local midnight — the user thinks in their own day boundary, not UTC's.
+		const endOfDay = new Date();
+		endOfDay.setHours(24, 0, 0, 0);
+		return endOfDay.toISOString();
 	}
+	return new Date(Date.now() + DURATION_MINUTES[duration] * 60 * 1000).toISOString();
 };
 
 // A state-changing alert action awaiting the user's go-ahead. `run` executes it; for
 // resolve/silence actions it receives the optional note the user typed, and for silence
-// actions the computed expiry of the chosen duration (null = forever).
+// actions the computed expiry of the chosen duration (always an ISO timestamp here —
+// the API still accepts null for no-expiry, used by quick-silence paths elsewhere).
 export interface PendingAlertAction {
 	title: string;
 	description: string;

--- a/apps/client/src/components/Settings/SilenceResetSettings.tsx
+++ b/apps/client/src/components/Settings/SilenceResetSettings.tsx
@@ -1,0 +1,94 @@
+import { Card } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import { useSilenceResetSettings, useUpdateSilenceResetSettings } from '@/hooks/queries/alerts/useSilenceReset';
+import { Loader2 } from 'lucide-react';
+
+// 0..23 rendered as "00:00" … "23:00".
+const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
+const formatHour = (hour: number) => `${String(hour).padStart(2, '0')}:00`;
+
+// Org-wide daily silence reset: at the configured hour every silenced alert flips back to
+// alerting, regardless of the duration each silence was given. Made for teams (e.g. algo
+// trading) that want a clean, fully-alerting board at a fixed time every day.
+export const SilenceResetSettings = () => {
+	const { data, isLoading, error } = useSilenceResetSettings();
+	const { mutate: updateSettings, isPending } = useUpdateSilenceResetSettings();
+	const { toast } = useToast();
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center gap-2 text-muted-foreground">
+				<Loader2 className="h-4 w-4 animate-spin" /> Loading silence settings…
+			</div>
+		);
+	}
+
+	if (error || !data) {
+		return (
+			<div className="text-sm text-muted-foreground">
+				Failed to load silence settings{error ? ` — ${(error as Error).message}` : ''}. Admin access is required
+				for this section.
+			</div>
+		);
+	}
+
+	const save = (updates: { enabled?: boolean; hour?: number }) => {
+		updateSettings(updates, {
+			onError: (e) =>
+				toast({ title: 'Failed to save', description: (e as Error).message, variant: 'destructive' }),
+		});
+	};
+
+	return (
+		<div className="space-y-4">
+			<div>
+				<h2 className="text-lg font-semibold text-foreground">Daily silence reset</h2>
+				<p className="text-sm text-muted-foreground">
+					Clear every silence at a fixed hour each day so all alerts notify again — whatever duration each
+					silence was given. Useful when the whole board must be live again at the end of the day.
+				</p>
+			</div>
+
+			<Card className="p-4 flex items-center justify-between gap-4">
+				<div className="min-w-0">
+					<div className="font-medium text-foreground">Clear all silences daily</div>
+					<div className="text-sm text-muted-foreground">
+						{data.enabled
+							? `Every day at ${formatHour(data.hour)} (server time), all silenced alerts go back to alerting.`
+							: 'Disabled — silences only expire on their own schedule.'}
+					</div>
+				</div>
+				<div className="flex items-center gap-4 shrink-0">
+					<div className="flex items-center gap-2">
+						<span className="text-sm text-muted-foreground">at</span>
+						<Select
+							value={String(data.hour)}
+							disabled={!data.enabled || isPending}
+							onValueChange={(value) => save({ hour: Number(value) })}
+						>
+							<SelectTrigger className="w-24 h-8 text-sm" aria-label="Reset hour (server time)">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{HOURS.map((hour) => (
+									<SelectItem key={hour} value={String(hour)}>
+										{formatHour(hour)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<span className="text-sm text-muted-foreground">server time</span>
+					</div>
+					<Switch
+						checked={data.enabled}
+						disabled={isPending}
+						onCheckedChange={(enabled) => save({ enabled })}
+						aria-label="Enable daily silence reset"
+					/>
+				</div>
+			</Card>
+		</div>
+	);
+};

--- a/apps/client/src/components/Settings/SilenceResetSettings/SilenceResetSettings.tsx
+++ b/apps/client/src/components/Settings/SilenceResetSettings/SilenceResetSettings.tsx
@@ -3,6 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/use-toast';
 import { useSilenceResetSettings, useUpdateSilenceResetSettings } from '@/hooks/queries/alerts/useSilenceReset';
+import { UpdateSilenceResetSettings } from '@OpsiMate/shared';
 import { Loader2 } from 'lucide-react';
 
 // 0..23 rendered as "00:00" … "23:00".
@@ -34,7 +35,7 @@ export const SilenceResetSettings = () => {
 		);
 	}
 
-	const save = (updates: { enabled?: boolean; hour?: number }) => {
+	const save = (updates: UpdateSilenceResetSettings) => {
 		updateSettings(updates, {
 			onError: (e) =>
 				toast({ title: 'Failed to save', description: (e as Error).message, variant: 'destructive' }),

--- a/apps/client/src/components/Settings/SilenceResetSettings/index.ts
+++ b/apps/client/src/components/Settings/SilenceResetSettings/index.ts
@@ -1,0 +1,1 @@
+export { SilenceResetSettings } from './SilenceResetSettings';

--- a/apps/client/src/hooks/queries/alerts/index.ts
+++ b/apps/client/src/hooks/queries/alerts/index.ts
@@ -8,3 +8,4 @@ export { useMarkAlertRead } from './useMarkAlertRead';
 export { useUnsilenceAlert } from './useUnsilenceAlert';
 export { useSetAlertOwner } from './useSetAlertOwner';
 export { useSetResolvedAlertOwner } from './useSetResolvedAlertOwner';
+export { useSilenceResetSettings, useUpdateSilenceResetSettings } from './useSilenceReset';

--- a/apps/client/src/hooks/queries/alerts/useSilenceReset.ts
+++ b/apps/client/src/hooks/queries/alerts/useSilenceReset.ts
@@ -1,5 +1,5 @@
 import { silenceResetApi } from '@/lib/api';
-import { SilenceResetSettings } from '@OpsiMate/shared';
+import { SilenceResetSettings, UpdateSilenceResetSettings } from '@OpsiMate/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../queryKeys';
 
@@ -19,7 +19,7 @@ export const useSilenceResetSettings = () => {
 export const useUpdateSilenceResetSettings = () => {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: async (updates: { enabled?: boolean; hour?: number }) => {
+		mutationFn: async (updates: UpdateSilenceResetSettings) => {
 			const response = await silenceResetApi.updateSettings(updates);
 			if (!response.success || !response.data) {
 				throw new Error(response.error || 'Failed to update silence reset settings');

--- a/apps/client/src/hooks/queries/alerts/useSilenceReset.ts
+++ b/apps/client/src/hooks/queries/alerts/useSilenceReset.ts
@@ -1,0 +1,31 @@
+import { silenceResetApi } from '@/lib/api';
+import { SilenceResetSettings } from '@OpsiMate/shared';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+export const useSilenceResetSettings = () => {
+	return useQuery({
+		queryKey: queryKeys.silenceReset,
+		queryFn: async (): Promise<SilenceResetSettings> => {
+			const response = await silenceResetApi.getSettings();
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to fetch silence reset settings');
+			}
+			return response.data;
+		},
+	});
+};
+
+export const useUpdateSilenceResetSettings = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (updates: { enabled?: boolean; hour?: number }) => {
+			const response = await silenceResetApi.updateSettings(updates);
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to update silence reset settings');
+			}
+			return response.data;
+		},
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.silenceReset }),
+	});
+};

--- a/apps/client/src/hooks/queries/queryKeys.ts
+++ b/apps/client/src/hooks/queries/queryKeys.ts
@@ -25,4 +25,5 @@ export const queryKeys = {
 	enrichments: ['enrichments'] as const,
 	actions: ['actions'] as const,
 	retention: ['retention'] as const,
+	silenceReset: ['silenceReset'] as const,
 };

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -21,6 +21,7 @@ import {
 	RetentionResource,
 	RetentionRunResult,
 	RetentionSettings,
+	SilenceResetSettings,
 	Service,
 	ServiceWithProvider,
 	Alert as SharedAlert,
@@ -724,6 +725,13 @@ export const retentionApi = {
 	updatePolicy: (resourceType: RetentionResource, updates: { enabled?: boolean; retentionDays?: number }) =>
 		apiRequest<RetentionPolicy>(`/retention/policies/${resourceType}`, 'PUT', updates),
 	runNow: () => apiRequest<RetentionRunResult>('/retention/run', 'POST'),
+};
+
+// Org-wide daily silence reset (admin-only endpoints).
+export const silenceResetApi = {
+	getSettings: () => apiRequest<SilenceResetSettings>('/alerts/silence-reset'),
+	updateSettings: (updates: { enabled?: boolean; hour?: number }) =>
+		apiRequest<SilenceResetSettings>('/alerts/silence-reset', 'PUT', updates),
 };
 
 /**

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -22,6 +22,7 @@ import {
 	RetentionRunResult,
 	RetentionSettings,
 	SilenceResetSettings,
+	UpdateSilenceResetSettings,
 	Service,
 	ServiceWithProvider,
 	Alert as SharedAlert,
@@ -730,7 +731,7 @@ export const retentionApi = {
 // Org-wide daily silence reset (admin-only endpoints).
 export const silenceResetApi = {
 	getSettings: () => apiRequest<SilenceResetSettings>('/alerts/silence-reset'),
-	updateSettings: (updates: { enabled?: boolean; hour?: number }) =>
+	updateSettings: (updates: UpdateSilenceResetSettings) =>
 		apiRequest<SilenceResetSettings>('/alerts/silence-reset', 'PUT', updates),
 };
 

--- a/apps/client/src/pages/Settings.tsx
+++ b/apps/client/src/pages/Settings.tsx
@@ -14,8 +14,9 @@ import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { createSecretOnServer, deleteSecretOnServer, getSecretsFromServer } from '@/lib/sslKeys';
 import { AuditLog, Logger, SecretMetadata } from '@OpsiMate/shared';
-import { Check, DatabaseBackup, Edit, FileText, KeyRound, Plus, Trash2, Users, X } from 'lucide-react';
+import { BellOff, Check, DatabaseBackup, Edit, FileText, KeyRound, Plus, Trash2, Users, X } from 'lucide-react';
 import { RetentionSettings } from '../components/Settings/RetentionSettings';
+import { SilenceResetSettings } from '../components/Settings/SilenceResetSettings';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { AddUserModal } from '../components/AddUserModal';
 import { CustomFieldsTable } from '../components/CustomFieldsTable';
@@ -219,6 +220,7 @@ const Settings: React.FC = () => {
 								if (h === 'Users') return 'users';
 								if (h === 'Audit_Log') return 'audit';
 								if (h === 'retention') return 'retention';
+								if (h === 'silences') return 'silences';
 								if (h === 'secrets') return 'secrets';
 								if (h === 'custom-fields') return 'custom-fields';
 								return 'users';
@@ -228,6 +230,7 @@ const Settings: React.FC = () => {
 									users: 'Users',
 									audit: 'Audit_Log',
 									retention: 'retention',
+									silences: 'silences',
 									secrets: 'secrets',
 									'custom-fields': 'custom-fields',
 								};
@@ -250,6 +253,10 @@ const Settings: React.FC = () => {
 										<TabsTrigger value="retention" className="justify-start gap-2">
 											<DatabaseBackup className="h-4 w-4" />
 											Data Retention
+										</TabsTrigger>
+										<TabsTrigger value="silences" className="justify-start gap-2">
+											<BellOff className="h-4 w-4" />
+											Alert Silences
 										</TabsTrigger>
 									</TabsList>
 								</div>
@@ -552,6 +559,10 @@ const Settings: React.FC = () => {
 
 									<TabsContent value="retention" className="space-y-6">
 										<RetentionSettings />
+									</TabsContent>
+
+									<TabsContent value="silences" className="space-y-6">
+										<SilenceResetSettings />
 									</TabsContent>
 
 									<TabsContent value="secrets" className="space-y-6">

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -1,5 +1,13 @@
 import { Request, Response } from 'express';
-import { AlertHistory, AlertStatus, CreateCommentSchema, Logger, UpdateCommentSchema } from '@OpsiMate/shared';
+import {
+	AlertHistory,
+	AlertStatus,
+	CreateCommentSchema,
+	Logger,
+	Role,
+	UpdateCommentSchema,
+	UpdateSilenceResetSettingsSchema,
+} from '@OpsiMate/shared';
 import { AlertBL } from '../../../bl/alerts/alert.bl';
 import {
 	DatadogAlertWebhookSchema,
@@ -28,6 +36,42 @@ export class AlertController {
 			return res.json({ success: true, data: { alerts } });
 		} catch (error) {
 			logger.error('Error getting alerts:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
+	// Both silence-reset endpoints are admin-only: this is org-wide configuration, same
+	// gate the retention settings use.
+	private requireAdmin(req: AuthenticatedRequest, res: Response): boolean {
+		if (!req.user || req.user.role !== Role.Admin) {
+			res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
+			return false;
+		}
+		return true;
+	}
+
+	async getSilenceResetSettings(req: AuthenticatedRequest, res: Response) {
+		if (!this.requireAdmin(req, res)) return;
+		try {
+			const settings = await this.alertBL.getSilenceResetSettings();
+			return res.json({ success: true, data: settings });
+		} catch (error) {
+			logger.error('Error getting silence reset settings:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
+	async updateSilenceResetSettings(req: AuthenticatedRequest, res: Response) {
+		if (!this.requireAdmin(req, res)) return;
+		try {
+			const updates = UpdateSilenceResetSettingsSchema.parse(req.body ?? {});
+			const settings = await this.alertBL.updateSilenceResetSettings(updates);
+			return res.json({ success: true, data: settings });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+			}
+			logger.error('Error updating silence reset settings:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
 	}

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -7,6 +7,10 @@ export default function createAlertRouter(controller: AlertController) {
 	// CRUD
 	router.get('/', controller.getAlerts.bind(controller));
 
+	// Daily silence reset settings (admin; must be before /:alertId to avoid route conflicts)
+	router.get('/silence-reset', controller.getSilenceResetSettings.bind(controller));
+	router.put('/silence-reset', controller.updateSilenceResetSettings.bind(controller));
+
 	// Resolved alerts (must be before /:alertId to avoid route conflicts)
 	router.get('/resolved', controller.getResolvedAlerts.bind(controller));
 	router.delete('/resolved/:alertId', controller.deleteResolvedAlert.bind(controller));

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -10,6 +10,7 @@ import {
 	AlertType,
 	Logger,
 	normalizeAlertSeverity,
+	SilenceResetSettings,
 } from '@OpsiMate/shared';
 import { AlertCommentsRepository } from '../../dal/alertCommentsRepository.ts';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
@@ -110,6 +111,49 @@ export class AlertBL {
 				this.recordHistoryEvent(id, AlertHistoryEventType.UNSILENCED, 'Silence expired', null)
 			)
 		);
+		await this.runDailySilenceReset();
+	}
+
+	// Org-wide daily reset (opt-in): once the configured hour passes, every silence clears —
+	// whatever its remaining window — so the whole board alerts again. Piggybacks on the same
+	// lazy sweep as timed expiry, so it needs no scheduler; the marker records which daily
+	// occurrence was already applied, letting silences created after the hour survive until
+	// the next day's occurrence.
+	private async runDailySilenceReset(): Promise<void> {
+		const settings = await this.alertRepo.getSilenceResetSettings();
+		if (!settings.enabled) return;
+
+		// Latest occurrence of the configured hour that is not in the future (server-local).
+		const occurrence = new Date();
+		occurrence.setHours(settings.hour, 0, 0, 0);
+		if (occurrence.getTime() > Date.now()) {
+			occurrence.setDate(occurrence.getDate() - 1);
+		}
+
+		if (settings.lastClearedAt && new Date(settings.lastClearedAt).getTime() >= occurrence.getTime()) {
+			return;
+		}
+
+		// Mark first: if history writes fail the reset is not retried in a loop, and the sweep
+		// itself is transactional either way.
+		await this.alertRepo.markSilenceResetCleared(occurrence.toISOString());
+		const clearedIds = await this.alertRepo.clearAllSilences();
+		if (clearedIds.length > 0) {
+			logger.info(`Daily silence reset cleared ${clearedIds.length} silence(s)`);
+		}
+		await Promise.all(
+			clearedIds.map((id) =>
+				this.recordHistoryEvent(id, AlertHistoryEventType.UNSILENCED, 'Silence cleared by daily reset', null)
+			)
+		);
+	}
+
+	async getSilenceResetSettings(): Promise<SilenceResetSettings> {
+		return this.alertRepo.getSilenceResetSettings();
+	}
+
+	async updateSilenceResetSettings(updates: { enabled?: boolean; hour?: number }): Promise<SilenceResetSettings> {
+		return this.alertRepo.updateSilenceResetSettings(updates);
 	}
 
 	async getAllAlerts(): Promise<Alert[]> {

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -11,6 +11,7 @@ import {
 	Logger,
 	normalizeAlertSeverity,
 	SilenceResetSettings,
+	UpdateSilenceResetSettings,
 } from '@OpsiMate/shared';
 import { AlertCommentsRepository } from '../../dal/alertCommentsRepository.ts';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
@@ -135,9 +136,11 @@ export class AlertBL {
 		}
 
 		// Mark first: if history writes fail the reset is not retried in a loop, and the sweep
-		// itself is transactional either way.
+		// itself is transactional either way. The occurrence is also the clearing cutoff, so a
+		// late sweep (nothing listed alerts for a while) leaves silences created after the
+		// hour alone — they belong to the next day's reset.
 		await this.alertRepo.markSilenceResetCleared(occurrence.toISOString());
-		const clearedIds = await this.alertRepo.clearAllSilences();
+		const clearedIds = await this.alertRepo.clearSilencesEstablishedBy(occurrence.toISOString());
 		if (clearedIds.length > 0) {
 			logger.info(`Daily silence reset cleared ${clearedIds.length} silence(s)`);
 		}
@@ -152,7 +155,7 @@ export class AlertBL {
 		return this.alertRepo.getSilenceResetSettings();
 	}
 
-	async updateSilenceResetSettings(updates: { enabled?: boolean; hour?: number }): Promise<SilenceResetSettings> {
+	async updateSilenceResetSettings(updates: UpdateSilenceResetSettings): Promise<SilenceResetSettings> {
 		return this.alertRepo.updateSilenceResetSettings(updates);
 	}
 

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -4,6 +4,7 @@ import {
 	normalizeAlertSeverity,
 	Alert as SharedAlert,
 	SilenceResetSettings,
+	UpdateSilenceResetSettings,
 } from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
@@ -181,6 +182,14 @@ export class AlertRepository {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN silenced_until TEXT`).run();
 			}
 
+			// When the silence was established (ISO). The daily reset clears only silences
+			// created on or before the day's reset occurrence, so it needs this timestamp;
+			// NULL (pre-migration silences) is treated as old and swept.
+			const hasSilencedAt = columns.some((col: TableInfoRow) => col.name === 'silenced_at');
+			if (!hasSilencedAt) {
+				this.db.prepare(`ALTER TABLE alerts ADD COLUMN silenced_at TEXT`).run();
+			}
+
 			// Repair: an alert id must never exist as both active and resolved. Ingestion used
 			// to re-insert a previously-resolved alert into the active table without dropping
 			// its resolved copy, so it showed up twice in the UI. The active row wins — the
@@ -238,8 +247,8 @@ export class AlertRepository {
 	async silenceAlert(id: string, silencedUntil: string | null): Promise<SharedAlert | null> {
 		return runAsync(() => {
 			this.db
-				.prepare('UPDATE alerts SET is_dismissed = 1, silenced_until = ? WHERE id = ?')
-				.run(silencedUntil, id);
+				.prepare('UPDATE alerts SET is_dismissed = 1, silenced_until = ?, silenced_at = ? WHERE id = ?')
+				.run(silencedUntil, new Date().toISOString(), id);
 			const row = this.db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow | undefined;
 			return row ? this.toSharedAlert(row) : null;
 		});
@@ -259,7 +268,7 @@ export class AlertRepository {
 				if (rows.length > 0) {
 					this.db
 						.prepare(
-							`UPDATE alerts SET is_dismissed = 0, silenced_until = NULL
+							`UPDATE alerts SET is_dismissed = 0, silenced_until = NULL, silenced_at = NULL
 							 WHERE is_dismissed = 1 AND silenced_until IS NOT NULL AND silenced_until <= ?`
 						)
 						.run(nowIso);
@@ -270,18 +279,27 @@ export class AlertRepository {
 		});
 	}
 
-	// Daily reset sweep: unsilence every silenced alert, whatever its remaining window
-	// (including no-expiry quick-silences). Returns the affected ids for history entries.
-	async clearAllSilences(): Promise<string[]> {
+	// Daily reset sweep: unsilence every silence established on or before the reset
+	// occurrence, whatever its remaining window (including no-expiry quick-silences).
+	// Silences created after the occurrence survive until the next day's reset — even
+	// when the sweep runs late because nothing listed the alerts for a while. NULL
+	// silenced_at (silences from before the column existed) counts as old and is swept.
+	// Returns the affected ids for history entries.
+	async clearSilencesEstablishedBy(cutoffIso: string): Promise<string[]> {
 		return runAsync(() => {
 			const sweep = this.db.transaction(() => {
-				const rows = this.db.prepare(`SELECT id FROM alerts WHERE is_dismissed = 1`).all() as {
-					id: string;
-				}[];
+				const rows = this.db
+					.prepare(
+						`SELECT id FROM alerts WHERE is_dismissed = 1 AND (silenced_at IS NULL OR silenced_at <= ?)`
+					)
+					.all(cutoffIso) as { id: string }[];
 				if (rows.length > 0) {
 					this.db
-						.prepare(`UPDATE alerts SET is_dismissed = 0, silenced_until = NULL WHERE is_dismissed = 1`)
-						.run();
+						.prepare(
+							`UPDATE alerts SET is_dismissed = 0, silenced_until = NULL, silenced_at = NULL
+							 WHERE is_dismissed = 1 AND (silenced_at IS NULL OR silenced_at <= ?)`
+						)
+						.run(cutoffIso);
 				}
 				return rows.map((r) => r.id);
 			});
@@ -302,7 +320,7 @@ export class AlertRepository {
 		});
 	}
 
-	async updateSilenceResetSettings(updates: { enabled?: boolean; hour?: number }): Promise<SilenceResetSettings> {
+	async updateSilenceResetSettings(updates: UpdateSilenceResetSettings): Promise<SilenceResetSettings> {
 		await runAsync(() => {
 			this.db
 				.prepare(
@@ -345,7 +363,9 @@ export class AlertRepository {
 
 	async unsilenceAlert(id: string): Promise<SharedAlert | null> {
 		return runAsync(() => {
-			this.db.prepare('UPDATE alerts SET is_dismissed = 0, silenced_until = NULL WHERE id = ?').run(id);
+			this.db
+				.prepare('UPDATE alerts SET is_dismissed = 0, silenced_until = NULL, silenced_at = NULL WHERE id = ?')
+				.run(id);
 			const row = this.db.prepare('SELECT * FROM alerts WHERE id = ?').get(id) as AlertRow | undefined;
 			return row ? this.toSharedAlert(row) : null;
 		});

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -1,4 +1,10 @@
-import { AlertStatus, AlertType, normalizeAlertSeverity, Alert as SharedAlert } from '@OpsiMate/shared';
+import {
+	AlertStatus,
+	AlertType,
+	normalizeAlertSeverity,
+	Alert as SharedAlert,
+	SilenceResetSettings,
+} from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
 import { AlertRow, TableInfoRow } from './models';
@@ -122,6 +128,14 @@ export class AlertRepository {
 					created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 				);
 	
+				CREATE TABLE IF NOT EXISTS silence_reset_config (
+					id INTEGER PRIMARY KEY CHECK (id = 1),
+					enabled INTEGER NOT NULL DEFAULT 0,
+					hour INTEGER NOT NULL DEFAULT 0,
+					last_cleared_at TEXT,
+					updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+				);
+
 				CREATE TRIGGER IF NOT EXISTS archive_alert_on_insert
 					AFTER INSERT ON alerts
 					FOR EACH ROW
@@ -253,6 +267,71 @@ export class AlertRepository {
 				return rows.map((r) => r.id);
 			});
 			return sweep();
+		});
+	}
+
+	// Daily reset sweep: unsilence every silenced alert, whatever its remaining window
+	// (including no-expiry quick-silences). Returns the affected ids for history entries.
+	async clearAllSilences(): Promise<string[]> {
+		return runAsync(() => {
+			const sweep = this.db.transaction(() => {
+				const rows = this.db.prepare(`SELECT id FROM alerts WHERE is_dismissed = 1`).all() as {
+					id: string;
+				}[];
+				if (rows.length > 0) {
+					this.db
+						.prepare(`UPDATE alerts SET is_dismissed = 0, silenced_until = NULL WHERE is_dismissed = 1`)
+						.run();
+				}
+				return rows.map((r) => r.id);
+			});
+			return sweep();
+		});
+	}
+
+	async getSilenceResetSettings(): Promise<SilenceResetSettings> {
+		return runAsync(() => {
+			const row = this.db
+				.prepare(`SELECT enabled, hour, last_cleared_at FROM silence_reset_config WHERE id = 1`)
+				.get() as { enabled: number; hour: number; last_cleared_at: string | null } | undefined;
+			return {
+				enabled: row ? !!row.enabled : false,
+				hour: row?.hour ?? 0,
+				lastClearedAt: row?.last_cleared_at ?? null,
+			};
+		});
+	}
+
+	async updateSilenceResetSettings(updates: { enabled?: boolean; hour?: number }): Promise<SilenceResetSettings> {
+		await runAsync(() => {
+			this.db
+				.prepare(
+					`INSERT INTO silence_reset_config (id, enabled, hour)
+					 VALUES (1, COALESCE(?, 0), COALESCE(?, 0))
+					 ON CONFLICT (id) DO UPDATE SET
+						enabled = COALESCE(?, enabled),
+						hour = COALESCE(?, hour),
+						updated_at = CURRENT_TIMESTAMP`
+				)
+				.run(
+					updates.enabled === undefined ? null : updates.enabled ? 1 : 0,
+					updates.hour ?? null,
+					updates.enabled === undefined ? null : updates.enabled ? 1 : 0,
+					updates.hour ?? null
+				);
+		});
+		return this.getSilenceResetSettings();
+	}
+
+	async markSilenceResetCleared(occurrenceIso: string): Promise<void> {
+		return runAsync(() => {
+			this.db
+				.prepare(
+					`INSERT INTO silence_reset_config (id, enabled, hour, last_cleared_at)
+					 VALUES (1, 0, 0, ?)
+					 ON CONFLICT (id) DO UPDATE SET last_cleared_at = ?`
+				)
+				.run(occurrenceIso, occurrenceIso);
 		});
 	}
 

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -68,6 +68,7 @@ export type AlertRow = {
 	created_at: string;
 	is_dismissed: boolean;
 	silenced_until?: string | null;
+	silenced_at?: string | null;
 	is_read?: boolean | number | null;
 	owner_id?: number | null;
 };

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1302,3 +1302,104 @@ describe('Alerts API', () => {
 		});
 	});
 });
+
+describe('Silence reset settings API', () => {
+	// Each test starts from a clean config (the table survives seedAlerts, which only
+	// clears the alerts tables).
+	beforeEach(() => {
+		db.exec('DELETE FROM silence_reset_config');
+	});
+
+	test('GET returns disabled defaults', async () => {
+		const response = await app.get('/api/v1/alerts/silence-reset').set('Authorization', `Bearer ${jwtToken}`);
+
+		expect(response.status).toBe(200);
+		expect(response.body.data).toEqual({ enabled: false, hour: 0, lastClearedAt: null });
+	});
+
+	test('PUT updates enabled and hour', async () => {
+		const response = await app
+			.put('/api/v1/alerts/silence-reset')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ enabled: true, hour: 17 });
+
+		expect(response.status).toBe(200);
+		expect(response.body.data.enabled).toBe(true);
+		expect(response.body.data.hour).toBe(17);
+
+		// Partial update keeps the other field.
+		const partial = await app
+			.put('/api/v1/alerts/silence-reset')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ hour: 9 });
+		expect(partial.body.data).toMatchObject({ enabled: true, hour: 9 });
+	});
+
+	test('PUT rejects an invalid hour', async () => {
+		const response = await app
+			.put('/api/v1/alerts/silence-reset')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ hour: 24 });
+
+		expect(response.status).toBe(400);
+	});
+
+	test('endpoints reject non-admin users', async () => {
+		await app
+			.post('/api/v1/users')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ email: 'sr-viewer@example.com', fullName: 'SR Viewer', password: 'testpassword', role: 'viewer' });
+		const login = await app
+			.post('/api/v1/users/login')
+			.send({ email: 'sr-viewer@example.com', password: 'testpassword' });
+		const viewerToken = login.body.token as string;
+
+		const get = await app.get('/api/v1/alerts/silence-reset').set('Authorization', `Bearer ${viewerToken}`);
+		expect(get.status).toBe(403);
+		const put = await app
+			.put('/api/v1/alerts/silence-reset')
+			.set('Authorization', `Bearer ${viewerToken}`)
+			.send({ enabled: true });
+		expect(put.status).toBe(403);
+	});
+
+	test('listing alerts after the configured hour clears every silence once', async () => {
+		// Current hour: the day's occurrence is already in the past (or exactly now), so the
+		// first listing applies the reset deterministically.
+		const currentHour = new Date().getHours();
+		await app
+			.put('/api/v1/alerts/silence-reset')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ enabled: true, hour: currentHour });
+
+		// alert-3 is seeded silenced; silence alert-1 too, with a timed window.
+		await app
+			.patch(`/api/v1/alerts/${testAlerts[0].id}/silence`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ silencedUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString() });
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		expect(listing.status).toBe(200);
+		const silenced = (listing.body.data.alerts as { isSilenced: boolean }[]).filter((a) => a.isSilenced);
+		expect(silenced).toHaveLength(0);
+
+		// The reset is applied once per occurrence: a silence created afterwards survives
+		// subsequent listings until the next day's occurrence.
+		await app
+			.patch(`/api/v1/alerts/${testAlerts[0].id}/silence`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({});
+		const second = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const silencedAfter = (second.body.data.alerts as { id: string; isSilenced: boolean }[]).filter(
+			(a) => a.isSilenced
+		);
+		expect(silencedAfter.map((a) => a.id)).toEqual([testAlerts[0].id]);
+
+		// History explains the flip.
+		const history = await app
+			.get(`/api/v1/alerts/${testAlerts[0].id}/history`)
+			.set('Authorization', `Bearer ${jwtToken}`);
+		const descriptions = (history.body.data.data as { description: string }[]).map((h) => h.description);
+		expect(descriptions).toContain('Silence cleared by daily reset');
+	});
+});

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1363,7 +1363,7 @@ describe('Silence reset settings API', () => {
 		expect(put.status).toBe(403);
 	});
 
-	test('listing alerts after the configured hour clears every silence once', async () => {
+	test('listing after the configured hour clears silences from before it, once', async () => {
 		// Current hour: the day's occurrence is already in the past (or exactly now), so the
 		// first listing applies the reset deterministically.
 		const currentHour = new Date().getHours();
@@ -1372,30 +1372,39 @@ describe('Silence reset settings API', () => {
 			.set('Authorization', `Bearer ${jwtToken}`)
 			.send({ enabled: true, hour: currentHour });
 
-		// alert-3 is seeded silenced; silence alert-1 too, with a timed window.
+		// Silence alert-1 and backdate silenced_at to before the occurrence — the timeline
+		// CodeRabbit flagged: silence established before the hour, sweep arriving later.
 		await app
 			.patch(`/api/v1/alerts/${testAlerts[0].id}/silence`)
 			.set('Authorization', `Bearer ${jwtToken}`)
 			.send({ silencedUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString() });
+		db.prepare(`UPDATE alerts SET silenced_at = ? WHERE id = ?`).run(
+			new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+			testAlerts[0].id
+		);
+		// alert-2: silenced NOW — after the occurrence — so the (late) sweep must leave it.
+		await app
+			.patch(`/api/v1/alerts/${testAlerts[1].id}/silence`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({});
+		// alert-3 is seeded silenced with no silenced_at (pre-migration shape) — swept as old.
 
 		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
 		expect(listing.status).toBe(200);
-		const silenced = (listing.body.data.alerts as { isSilenced: boolean }[]).filter((a) => a.isSilenced);
-		expect(silenced).toHaveLength(0);
+		const silenced = (listing.body.data.alerts as { id: string; isSilenced: boolean }[]).filter(
+			(a) => a.isSilenced
+		);
+		expect(silenced.map((a) => a.id)).toEqual([testAlerts[1].id]);
 
-		// The reset is applied once per occurrence: a silence created afterwards survives
+		// The reset is applied once per occurrence: the surviving silence stays silenced on
 		// subsequent listings until the next day's occurrence.
-		await app
-			.patch(`/api/v1/alerts/${testAlerts[0].id}/silence`)
-			.set('Authorization', `Bearer ${jwtToken}`)
-			.send({});
 		const second = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
 		const silencedAfter = (second.body.data.alerts as { id: string; isSilenced: boolean }[]).filter(
 			(a) => a.isSilenced
 		);
-		expect(silencedAfter.map((a) => a.id)).toEqual([testAlerts[0].id]);
+		expect(silencedAfter.map((a) => a.id)).toEqual([testAlerts[1].id]);
 
-		// History explains the flip.
+		// History explains the flip on the cleared alert.
 		const history = await app
 			.get(`/api/v1/alerts/${testAlerts[0].id}/history`)
 			.set('Authorization', `Bearer ${jwtToken}`);

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -570,6 +570,7 @@ export const UpdateSilenceResetSettingsSchema = z
 		message: 'Provide enabled and/or hour',
 	});
 
+
 export const RetentionResourceParamSchema = z.object({
 	resourceType: z.nativeEnum(RetentionResource),
 });

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -570,7 +570,6 @@ export const UpdateSilenceResetSettingsSchema = z
 		message: 'Provide enabled and/or hour',
 	});
 
-
 export const RetentionResourceParamSchema = z.object({
 	resourceType: z.nativeEnum(RetentionResource),
 });

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -560,6 +560,16 @@ export const UpdateRetentionConfigSchema = z
 		message: 'Provide cleanupIntervalHours and/or vacuumAfterCleanup',
 	});
 
+export const UpdateSilenceResetSettingsSchema = z
+	.object({
+		enabled: z.boolean().optional(),
+		// Hour of day, server-local time.
+		hour: z.number().int().min(0).max(23).optional(),
+	})
+	.refine((v) => v.enabled !== undefined || v.hour !== undefined, {
+		message: 'Provide enabled and/or hour',
+	});
+
 export const RetentionResourceParamSchema = z.object({
 	resourceType: z.nativeEnum(RetentionResource),
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -544,6 +544,16 @@ export interface RetentionPolicy {
 	updatedAt: string;
 }
 
+// Org-wide daily silence reset: at `hour` (server-local time) every silenced alert flips
+// back to alerting, regardless of the duration originally chosen. Off by default.
+export interface SilenceResetSettings {
+	enabled: boolean;
+	// Hour of day (0-23, server-local time) at which all silences clear.
+	hour: number;
+	// ISO timestamp of the reset occurrence most recently applied (null if never).
+	lastClearedAt: string | null;
+}
+
 export interface RetentionConfig {
 	// How often the cleanup job runs.
 	cleanupIntervalHours: number;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -544,6 +544,14 @@ export interface RetentionPolicy {
 	updatedAt: string;
 }
 
+// The one update shape shared by the API layer, hooks and BL for silence-reset settings;
+// UpdateSilenceResetSettingsSchema (schemas.ts) is its validating counterpart.
+export interface UpdateSilenceResetSettings {
+	enabled?: boolean;
+	// Hour of day (0-23, server-local time).
+	hour?: number;
+}
+
 // Org-wide daily silence reset: at `hour` (server-local time) every silenced alert flips
 // back to alerting, regardless of the duration originally chosen. Off by default.
 export interface SilenceResetSettings {


### PR DESCRIPTION
## What

Two silence changes:

### 1. Reworked silence durations

The dialog's duration picker becomes: **Until midnight (default) · 5 min · 15 min · 30 min · 1 hour · 2 hours · 6 hours**. Removed: Forever, 4h, 8h — every dialog silence now expires on its own. Applies to all dialog entry points (row menu, details panel, bulk "Silence all"); re-silencing still restarts the timer, manual unsilence unchanged.

### 2. Daily silence reset (admin setting) — Settings → Alert Silences

Org-wide opt-in: at a configurable hour of the day, **every** silenced alert flips back to alerting — whatever duration each silence was given, *including* the no-expiry quick-silences from TV mode / the services dashboard. Built for orgs (e.g. algo trading) that want a fully-live board at a fixed time daily.

**Design**:
- No scheduler: the reset piggybacks on the existing lazy silence-expiry sweep that already runs on every alerts listing. If the configured hour's latest daily occurrence hasn't been applied yet, all silences clear in one transaction, each with a `Silence cleared by daily reset` history entry.
- An occurrence marker (`last_cleared_at`) makes the reset apply exactly once per day: silences created *after* the hour survive until the next day's occurrence.
- `GET`/`PUT /api/v1/alerts/silence-reset`, admin-only (same gate as retention settings). New `silence_reset_config` table, created idempotently alongside the alerts tables.
- The hour is evaluated in the **server's local timezone** (labeled "server time" in the UI) — flagging in case you want org-timezone handling later.
- This also resolves the earlier flag about quick-silence "forever": with the reset enabled, nothing can stay silenced past the daily hour.

## Verification

- **5 new API tests** (server suite now 120/120): defaults, full/partial update, hour validation (24 → 400), non-admin 403 on both endpoints, and the sweep semantics (clears once per occurrence, later silences survive, history entry written).
- **Live**: silenced one alert for 15 minutes and one with no expiry → simulated the hour arriving → one listing cleared both, history shows "Silence cleared by daily reset"; silences created after the occurrence survive subsequent listings. Settings UI exercised headlessly: enable, hour change (18:00 → 17:00), disable — every change persisted server-side, zero page errors.
- Gates: build 4/4, client tests 37/37, all lints (`--max-warnings=0` where CI uses it) + prettier clean, server tsc 0, client tsc 81 (baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an org-wide **Silences** settings tab with a **Daily silence reset** switch and hour selector.
  * Enabled admins to configure when all current alert silences are automatically cleared each day.

* **Bug Fixes**
  * Updated alert silence durations to **5m/15m/30m/1h/2h/6h** or **until midnight**.
  * Improved silence expiration handling to consistently compute an exact expiration timestamp for the selected duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->