### PR TITLE
fix(alerts): quick time presets are rolling windows, not click-time snapshots

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/alertHistory.utils.ts
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/alertHistory.utils.ts
@@ -1,14 +1,20 @@
 import { AlertHistoryData } from '@OpsiMate/shared';
 import { TimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.types';
+import { resolveTimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.utils';
 
 // Filters history entries to the active time range. An empty range ("All time") returns
-// everything. Mirrors how the alerts list itself is filtered by the time button.
+// everything. Mirrors how the alerts list itself is filtered by the time button —
+// including quick presets, which resolve to a fresh window at call time.
 export const filterHistoryByRange = (data: AlertHistoryData[], timeRange?: TimeRange | null): AlertHistoryData[] => {
-	if (!timeRange || (!timeRange.from && !timeRange.to)) {
+	if (!timeRange) {
 		return data;
 	}
-	const fromMs = timeRange.from ? timeRange.from.getTime() : null;
-	const toMs = timeRange.to ? timeRange.to.getTime() : null;
+	const resolved = resolveTimeRange(timeRange);
+	if (!resolved.from && !resolved.to) {
+		return data;
+	}
+	const fromMs = resolved.from ? resolved.from.getTime() : null;
+	const toMs = resolved.to ? resolved.to.getTime() : null;
 	return data.filter((item) => {
 		const t = new Date(item.date).getTime();
 		if (fromMs !== null && t < fromMs) return false;

--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/CustomTimeFilterTab/CustomTimeFilterTab.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/CustomTimeFilterTab/CustomTimeFilterTab.tsx
@@ -24,12 +24,16 @@ interface CustomTimeFilterTabProps {
 
 export const CustomTimeFilterTab = ({ value, onApply, onClear }: CustomTimeFilterTabProps) => {
 	// Prefill from the resolved window so switching from a quick preset (stored without
-	// dates) starts the pickers at the preset's current from/to instead of empty.
+	// dates) starts the pickers at the preset's current from/to instead of empty — the
+	// time inputs included, or applying "Custom" right after "Last 1 hour" would silently
+	// widen the range to the full day.
 	const initial = resolveTimeRange(value);
+	const toTimeInput = (date: Date): string =>
+		`${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
 	const [customFrom, setCustomFrom] = useState<Date | undefined>(initial.from ?? undefined);
 	const [customTo, setCustomTo] = useState<Date | undefined>(initial.to ?? undefined);
-	const [fromTime, setFromTime] = useState(DEFAULT_FROM_TIME);
-	const [toTime, setToTime] = useState(DEFAULT_TO_TIME);
+	const [fromTime, setFromTime] = useState(initial.from ? toTimeInput(initial.from) : DEFAULT_FROM_TIME);
+	const [toTime, setToTime] = useState(initial.to ? toTimeInput(initial.to) : DEFAULT_TO_TIME);
 	const [fromCalendarOpen, setFromCalendarOpen] = useState(false);
 	const [toCalendarOpen, setToCalendarOpen] = useState(false);
 

--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/CustomTimeFilterTab/CustomTimeFilterTab.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/CustomTimeFilterTab/CustomTimeFilterTab.tsx
@@ -14,6 +14,7 @@ import {
 	TO_LABEL,
 } from './CustomTimeFilterTab.constants';
 import { TimeRange } from '../TimeFilter.types';
+import { resolveTimeRange } from '../TimeFilter.utils';
 
 interface CustomTimeFilterTabProps {
 	value: TimeRange;
@@ -22,8 +23,11 @@ interface CustomTimeFilterTabProps {
 }
 
 export const CustomTimeFilterTab = ({ value, onApply, onClear }: CustomTimeFilterTabProps) => {
-	const [customFrom, setCustomFrom] = useState<Date | undefined>(value.from ?? undefined);
-	const [customTo, setCustomTo] = useState<Date | undefined>(value.to ?? undefined);
+	// Prefill from the resolved window so switching from a quick preset (stored without
+	// dates) starts the pickers at the preset's current from/to instead of empty.
+	const initial = resolveTimeRange(value);
+	const [customFrom, setCustomFrom] = useState<Date | undefined>(initial.from ?? undefined);
+	const [customTo, setCustomTo] = useState<Date | undefined>(initial.to ?? undefined);
 	const [fromTime, setFromTime] = useState(DEFAULT_FROM_TIME);
 	const [toTime, setToTime] = useState(DEFAULT_TO_TIME);
 	const [fromCalendarOpen, setFromCalendarOpen] = useState(false);

--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.tsx
@@ -7,7 +7,6 @@ import { Clock } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { CustomTimeFilterTab } from './CustomTimeFilterTab';
 import { QuickTimeFilterTab } from './QuickTimeFilterTab';
-import { getPresetConfig } from './TimeFilter.constants';
 import { QuickPreset, TimeFilterProps, TimeRange } from './TimeFilter.types';
 import { formatTimeRange, isTimeRangeEmpty } from './TimeFilter.utils';
 
@@ -16,12 +15,11 @@ export const TimeFilter = ({ value, onChange }: TimeFilterProps) => {
 
 	const handlePresetClick = useCallback(
 		(preset: QuickPreset) => {
-			const config = getPresetConfig(preset);
-			if (config) {
-				const { from, to } = config.getRange();
-				onChange({ from, to, preset });
-				setOpen(false);
-			}
+			// Store the preset alone — no materialized dates. Consumers resolve it to a
+			// fresh window at filter time (resolveTimeRange), so the range rolls with the
+			// clock instead of freezing at the moment of the click.
+			onChange({ from: null, to: null, preset });
+			setOpen(false);
 		},
 		[onChange]
 	);

--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.utils.ts
@@ -1,5 +1,16 @@
-import { getPresetLabel } from './TimeFilter.constants';
+import { getPresetConfig, getPresetLabel } from './TimeFilter.constants';
 import { TimeRange } from './TimeFilter.types';
+
+// Quick presets are stored as the preset alone (from/to null) and materialized here at
+// FILTER time, so "Last 1 hour" / "Today" are rolling windows anchored to now — not
+// snapshots of the moment the preset was clicked. Only 'custom' carries absolute dates.
+export const resolveTimeRange = (range: TimeRange): { from: Date | null; to: Date | null } => {
+	if (range.preset && range.preset !== 'custom') {
+		const config = getPresetConfig(range.preset);
+		if (config) return config.getRange();
+	}
+	return { from: range.from, to: range.to };
+};
 
 const formatDate = (date: Date): string => {
 	const month = (date.getMonth() + 1).toString().padStart(2, '0');

--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -2,9 +2,16 @@ import { TimeRange } from '@/context/DashboardContext';
 import { useUsers } from '@/hooks/queries/users';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { Alert } from '@OpsiMate/shared';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { resolveTimeRange } from '../AlertsTable/TimeFilter/TimeFilter.utils';
 import { getOwnerDisplayName } from '../utils/owner.utils';
 import { getAlertSeverity, SEVERITY_LABELS } from '../utils/severity.utils';
+
+// How often a quick-preset window re-anchors to "now". This is the roll cadence: alert
+// refetches keep the same array identity when data is unchanged (react-query structural
+// sharing), so without the tick the memo would never re-evaluate the window. 10s keeps
+// even the "Last 1 minute" preset reasonably fresh at negligible recompute cost.
+const ROLLING_WINDOW_TICK_MS = 10 * 1000;
 
 const getAlertType = (alert: Alert): string => {
 	return alert.type || 'Custom';
@@ -23,25 +30,40 @@ export const useAlertsFiltering = (
 ) => {
 	const { data: users = [] } = useUsers();
 
-	const { filters, timeRange } = useMemo(() => {
+	const { filters, timeRange } = useMemo((): { filters: Record<string, string[]>; timeRange?: TimeRange } => {
+		// 'filters' in x can't narrow the union on its own: the legacy shape is an open
+		// Record, so TS keeps both arms alive and unions every property access. The casts
+		// pin each branch to the shape the guard actually identified.
 		if ('filters' in filtersOrOptions) {
-			return {
-				filters: filtersOrOptions.filters,
-				timeRange: filtersOrOptions.timeRange,
-			};
+			const options = filtersOrOptions as UseAlertsFilteringOptions;
+			return { filters: options.filters, timeRange: options.timeRange };
 		}
-		return { filters: filtersOrOptions, timeRange: undefined };
+		return { filters: filtersOrOptions as Record<string, string[]>, timeRange: undefined };
 	}, [filtersOrOptions]);
 
+	// Quick presets ("Last 1 hour", "Today") are stored as the preset alone and resolved
+	// to concrete dates at filter time, so the window rolls with the clock. The tick
+	// guarantees a periodic re-anchor even when no refetch re-renders the page.
+	const isRollingPreset = !!timeRange?.preset && timeRange.preset !== 'custom';
+	const [tick, setTick] = useState(0);
+	useEffect(() => {
+		if (!isRollingPreset) return;
+		const interval = setInterval(() => setTick((t) => t + 1), ROLLING_WINDOW_TICK_MS);
+		return () => clearInterval(interval);
+	}, [isRollingPreset]);
+
 	const filteredAlerts = useMemo(() => {
+		// Reference the tick so a preset window re-anchors to "now" periodically.
+		void tick;
 		let result = alerts;
 
-		if (timeRange?.from || timeRange?.to) {
+		const resolved = timeRange ? resolveTimeRange(timeRange) : { from: null, to: null };
+		if (resolved.from || resolved.to) {
 			result = result.filter((alert) => {
 				const alertStartDate = new Date(alert.startsAt);
 				const alertEndDate = new Date(alert.updatedAt);
-				const filterStart = timeRange.from || new Date(0);
-				const filterEnd = timeRange.to || new Date();
+				const filterStart = resolved.from || new Date(0);
+				const filterEnd = resolved.to || new Date();
 
 				return alertStartDate <= filterEnd && alertEndDate >= filterStart;
 			});
@@ -95,7 +117,7 @@ export const useAlertsFiltering = (
 			}
 			return true;
 		});
-	}, [alerts, filters, timeRange, users]);
+	}, [alerts, filters, timeRange, users, tick]);
 
 	return filteredAlerts;
 };

--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -33,8 +33,10 @@ export const useAlertsFiltering = (
 	const { filters, timeRange } = useMemo((): { filters: Record<string, string[]>; timeRange?: TimeRange } => {
 		// 'filters' in x can't narrow the union on its own: the legacy shape is an open
 		// Record, so TS keeps both arms alive and unions every property access. The casts
-		// pin each branch to the shape the guard actually identified.
-		if ('filters' in filtersOrOptions) {
+		// pin each branch to the shape the guard actually identified. The Array check
+		// keeps a legacy record whose filter FIELD is named "filters" (value string[])
+		// from being mistaken for the options shape.
+		if ('filters' in filtersOrOptions && !Array.isArray(filtersOrOptions.filters)) {
 			const options = filtersOrOptions as UseAlertsFilteringOptions;
 			return { filters: options.filters, timeRange: options.timeRange };
 		}

--- a/apps/client/src/context/DashboardContext.utils.ts
+++ b/apps/client/src/context/DashboardContext.utils.ts
@@ -15,10 +15,17 @@ export const deserializeTimeRange = (stored: DashboardTimeRange | undefined): Ti
 	if (!stored) {
 		return { from: null, to: null, preset: null };
 	}
+	const preset = stored.preset as TimeRange['preset'];
+	// Quick presets are rolling windows resolved at filter time; drop any absolute dates
+	// that older versions froze in at click time (a saved "Today" from last week would
+	// otherwise keep filtering last week forever). Only 'custom' keeps its dates.
+	if (preset && preset !== 'custom') {
+		return { from: null, to: null, preset };
+	}
 	return {
 		from: stored.from ? new Date(stored.from) : null,
 		to: stored.to ? new Date(stored.to) : null,
-		preset: stored.preset as TimeRange['preset'],
+		preset,
 	};
 };
 

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -65,8 +65,9 @@ describe('useAlertsFiltering rolling time presets', () => {
 
 	test('"today" spans from local midnight regardless of when it was selected', () => {
 		const sinceMidnightMs = Date.now() - new Date().setHours(0, 0, 0, 0);
-		// Guard against the degenerate just-after-midnight case in CI.
-		const earlyToday = mkAlert('early-today', Math.min(sinceMidnightMs - 1_000, sinceMidnightMs));
+		// Clamp to now: less than a second after local midnight, "1s after midnight"
+		// would otherwise be a future timestamp the today-filter may exclude.
+		const earlyToday = mkAlert('early-today', Math.max(0, sinceMidnightMs - 1_000));
 		const yesterday = mkAlert('yesterday', sinceMidnightMs + 3_600_000);
 		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'today' as const } };
 		const { result } = renderHook(() => useAlertsFiltering([earlyToday, yesterday], options), { wrapper });

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -1,0 +1,75 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { useAlertsFiltering } from '@/components/Alerts/hooks/useAlertsFiltering';
+import { Alert } from '@OpsiMate/shared';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+	<QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+		{children}
+	</QueryClientProvider>
+);
+
+const mkAlert = (id: string, ageMs: number): Alert =>
+	({
+		id,
+		type: 'Grafana',
+		status: 'firing',
+		severity: 'info',
+		tags: {},
+		startsAt: new Date(Date.now() - ageMs).toISOString(),
+		updatedAt: new Date(Date.now() - ageMs).toISOString(),
+		alertUrl: '',
+		alertName: id,
+		createdAt: new Date().toISOString(),
+		isSilenced: false,
+	}) as unknown as Alert;
+
+// Quick presets are stored without dates and resolved to a fresh window at filter time —
+// these tests pin the rolling behavior that regressed when presets froze at click time.
+describe('useAlertsFiltering rolling time presets', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	test('a quick preset window rolls with the clock, without any prop change', () => {
+		const fresh = mkAlert('fresh', 5_000);
+		const stale = mkAlert('stale', 120_000);
+		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'last1m' as const } };
+		const { result } = renderHook(() => useAlertsFiltering([fresh, stale], options), { wrapper });
+
+		// Stale alert (2 min old) is outside "Last 1 minute" from the start.
+		expect(result.current.map((a) => a.id)).toEqual(['fresh']);
+
+		// 75s later the fresh alert has aged out too — the window moved, the props did not.
+		act(() => {
+			vi.advanceTimersByTime(75_000);
+		});
+		expect(result.current.map((a) => a.id)).toEqual([]);
+	});
+
+	test('a custom range stays absolute and does not roll', () => {
+		const alert = mkAlert('inside', 30_000);
+		const from = new Date(Date.now() - 60_000);
+		const to = new Date(Date.now() + 60_000);
+		const options = { filters: {}, timeRange: { from, to, preset: 'custom' as const } };
+		const { result } = renderHook(() => useAlertsFiltering([alert], options), { wrapper });
+		expect(result.current.map((a) => a.id)).toEqual(['inside']);
+
+		// Far beyond the custom "to": the absolute range must NOT re-anchor to now.
+		act(() => {
+			vi.advanceTimersByTime(10 * 60_000);
+		});
+		expect(result.current.map((a) => a.id)).toEqual(['inside']);
+	});
+
+	test('"today" spans from local midnight regardless of when it was selected', () => {
+		const sinceMidnightMs = Date.now() - new Date().setHours(0, 0, 0, 0);
+		// Guard against the degenerate just-after-midnight case in CI.
+		const earlyToday = mkAlert('early-today', Math.min(sinceMidnightMs - 1_000, sinceMidnightMs));
+		const yesterday = mkAlert('yesterday', sinceMidnightMs + 3_600_000);
+		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'today' as const } };
+		const { result } = renderHook(() => useAlertsFiltering([earlyToday, yesterday], options), { wrapper });
+		expect(result.current.map((a) => a.id)).toEqual(['early-today']);
+	});
+});


### PR DESCRIPTION
## The bug (critical)

Clicking a quick preset ("Last 1 hour", "Today", …) evaluated `getRange()` **once, at click time**, and stored the absolute `from`/`to` dates. Everything downstream filtered by those frozen dates:

- **"Last 1 hour" meant "the hour before I clicked" — forever.** The window never slid; alerts kept refreshing every 5s into a stale frame.
- **It persisted and got worse**: the frozen dates are saved to localStorage *and* to saved dashboards server-side. Open the app tomorrow with "Today" active → you're filtering *yesterday's* 00:00-to-click-time. A TV dashboard left running degrades silently.
- The filter chip shows the preset *name* ("Last 1 hour"), so the UI looked live while the data was frozen — which is why this hid so well.

## The fix

**Quick presets are stored as the preset alone (`from`/`to` = null) and resolved to a fresh window at filter time.** Only `custom` carries absolute dates.

- `resolveTimeRange()` (new, in `TimeFilter.utils`) materializes a preset via its existing `getRange()` closure at every evaluation.
- Both range consumers resolve: the alerts list filter (`useAlertsFiltering`) and the details-panel history filter (`filterHistoryByRange`).
- **A 10s tick re-anchors the window even when nothing re-renders.** (Discovered during verification: react-query's structural sharing keeps the alerts array identity stable when data is unchanged, so refetches do *not* invalidate the memo — without the tick the window would only roll when data changes.)
- **Old saved state heals on load**: `deserializeTimeRange` drops frozen dates whenever a quick preset is present — covers localStorage, saved dashboards, and TV-mode launches from before this fix. No migration, no schema change (`from`/`to` are simply null for presets).
- Custom-tab pickers prefill from the *resolved* window, so switching Quick→Custom starts at the live range.
- Typing fix in the hook's option-destructure (the union never narrowed): removes 4 pre-existing tsc errors — client baseline 81 → **77**.

## Verification

**Unit** (new `useAlertsFiltering.test.tsx`, fake timers): preset window rolls with the clock with zero prop changes (fresh alert ages out after 75s); custom ranges stay absolute over 10 minutes; "today" spans from local midnight. Client suite 40/40.

**Live E2E (Playwright)**:
- *Rolling*: seeded an alert, picked "Last 1 minute" → visible at +8s → **gone at +80s with no interaction**, chip still reading "Last 1 minute". (Before the fix this never expired.)
- *Healing*: wrote a frozen "today" range from *yesterday* into localStorage → page load shows today's alert anyway, and storage re-saves as `{from:null,to:null,preset:"today"}`.
- *Storage shape*: preset click now stores `{"from":null,"to":null,"preset":"last1m"}`.
- In-page check that `resolveTimeRange` returns a moving window between calls.

Gates: build 4/4, server tests 120/120, client tests 40/40 (3 new), lint + prettier clean, console audit 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time-based alert filters now keep rolling presets such as “Last hour” or “Today” aligned with the current time.
  * Preset filters update automatically as time passes without requiring a page refresh or data reload.
  * Custom date ranges continue to preserve their selected start and end dates.
* **Bug Fixes**
  * Improved alert history filtering for preset ranges and unbounded “All time” searches.
  * Corrected “Today” filtering to use local midnight boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->