### PR TITLE
fix(alerts): refresh the history timeline immediately after unresolve

### DIFF
--- a/apps/client/src/hooks/queries/alerts/useUnresolveAlert.ts
+++ b/apps/client/src/hooks/queries/alerts/useUnresolveAlert.ts
@@ -37,10 +37,13 @@ export const useUnresolveAlert = () => {
 				queryClient.setQueryData(queryKeys.resolvedAlerts, context.previousAlerts);
 			}
 		},
-		onSettled: () => {
+		onSettled: (_data, _error, alertId) => {
 			// Always refetch after error or success: the alert left one list and joined the other
 			queryClient.invalidateQueries({ queryKey: queryKeys.resolvedAlerts });
 			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+			// The server records an UNRESOLVED history event ("Alert moved back to firing");
+			// without this the open details panel keeps showing the pre-unresolve timeline.
+			queryClient.invalidateQueries({ queryKey: queryKeys.alertHistory(alertId) });
 		},
 	});
 };


### PR DESCRIPTION
## What

Resolving an alert shows the event in the details panel's history log immediately — unresolving didn't. The server records the `UNRESOLVED` event fine; the bug was client-side: `useUnresolveAlert.onSettled` invalidated the two alert lists but never the `alertHistory` query. The details panel deliberately stays open across resolve/unresolve transitions, so its mounted history query kept showing the pre-unresolve timeline until some unrelated refetch.

One-line family fix: the same `alertHistory(alertId)` invalidation the resolve path (`useDeleteAlert`) has had since #680. Audited all sibling alert-mutation hooks — silence, unsilence, resolve, set-owner (both variants) already invalidate history; unresolve was the only gap (permanent-delete doesn't need it).

## Verification

Live E2E: resolved an alert → opened its details with the History section expanded → clicked **Unresolve** from the panel (panel stays open) → the "Alert moved back to firing" entry appears in the visible timeline immediately, no interaction. Gates: client tests 40/40, lint/prettier clean, tsc at baseline. Dev DB restored (7 active / 0 resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert history now refreshes automatically after an alert is unresolved, keeping the displayed activity details up to date.
  * Resolved and active alert lists continue to refresh as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->