### PR TITLE
feat(alerts): drag-to-reorder any table column (tags included), saved with the dashboard

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -148,6 +148,14 @@ const Alerts = () => {
 			),
 	});
 
+	// Persist a user-arranged base-column order (tag columns follow the visible list).
+	const handleColumnOrderChange = (columns: string[]) => {
+		updateDashboardField(
+			'columnOrder',
+			columns.filter((col) => col !== ACTIONS_COLUMN)
+		);
+	};
+
 	const handleSaveDashboard = async () => {
 		const dashboardData = {
 			name: dashboardState.name || 'New Dashboard',
@@ -155,6 +163,7 @@ const Alerts = () => {
 			description: dashboardState.description,
 			filters: dashboardState.filters,
 			visibleColumns: dashboardState.visibleColumns.filter((col) => col !== ACTIONS_COLUMN),
+			columnOrder: dashboardState.columnOrder.filter((col) => col !== ACTIONS_COLUMN),
 			query: dashboardState.query,
 			groupBy: dashboardState.groupBy,
 			timeRange: serializeTimeRange(dashboardState.timeRange),
@@ -371,6 +380,7 @@ const Alerts = () => {
 			groupByColumns={dashboardState.groupBy}
 			onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
 			onColumnToggle={handleColumnToggle}
+			onColumnOrderChange={handleColumnOrderChange}
 			tagKeys={tagKeys}
 			timeRange={dashboardState.timeRange}
 			onTimeRangeChange={(range) => updateDashboardField('timeRange', range)}
@@ -404,7 +414,7 @@ const Alerts = () => {
 				description: dashboard.description || '',
 				visibleColumns: dashboard.visibleColumns || [],
 				filters: dashboard.filters || {},
-				columnOrder: [],
+				columnOrder: dashboard.columnOrder || [],
 				groupBy: dashboard.groupBy || [],
 				query: dashboard.query || '',
 				timeRange: deserializeTimeRange(dashboard.timeRange),
@@ -675,6 +685,7 @@ const Alerts = () => {
 									groupByColumns={dashboardState.groupBy}
 									onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
 									onColumnToggle={handleColumnToggle}
+									onColumnOrderChange={handleColumnOrderChange}
 									tagKeys={tagKeys}
 									timeRange={dashboardState.timeRange}
 									onTimeRangeChange={(range) => updateDashboardField('timeRange', range)}
@@ -712,6 +723,7 @@ const Alerts = () => {
 									groupByColumns={dashboardState.groupBy}
 									onGroupByChange={(cols) => updateDashboardField('groupBy', cols)}
 									onColumnToggle={handleColumnToggle}
+									onColumnOrderChange={handleColumnOrderChange}
 									tagKeys={tagKeys}
 									timeRange={dashboardState.timeRange}
 									onTimeRangeChange={(range) => updateDashboardField('timeRange', range)}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -57,6 +57,7 @@ export const AlertsTable = ({
 	groupByColumns: controlledGroupBy,
 	onGroupByChange,
 	onColumnToggle,
+	onColumnOrderChange,
 	tagKeys = [],
 	searchTerm,
 	onSearchTermChange,
@@ -245,6 +246,8 @@ export const AlertsTable = ({
 																		visibleColumns={visibleColumns}
 																		onColumnToggle={onColumnToggle}
 																		columnLabels={COLUMN_LABELS}
+																		columnOrder={columnOrder}
+																		onColumnOrderChange={onColumnOrderChange}
 																		excludeColumns={[ACTIONS_COLUMN]}
 																		tagKeys={tagKeys}
 																	/>

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -34,6 +34,8 @@ export interface AlertsTableProps {
 	groupByColumns?: string[];
 	onGroupByChange?: (cols: string[]) => void;
 	onColumnToggle?: (column: string) => void;
+	// Persists a user-arranged base-column order (from the column settings drag list).
+	onColumnOrderChange?: (columns: string[]) => void;
 	tagKeys?: TagKeyInfo[];
 	timeRange?: TimeRange;
 	onTimeRangeChange?: (range: TimeRange) => void;

--- a/apps/client/src/components/Alerts/AlertsTable/ColumnSettingsDropdown/ColumnSettingsDropdown.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/ColumnSettingsDropdown/ColumnSettingsDropdown.tsx
@@ -36,8 +36,11 @@ export const ColumnSettingsDropdown = ({
 	tagKeys = [],
 }: ColumnSettingsDropdownProps) => {
 	const [searchQuery, setSearchQuery] = useState('');
-	const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-	const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+	// Keys, not indexes: after the first preview render, row indexes refer to the
+	// rearranged list, so an index-based drop could land somewhere other than shown.
+	// Keys stay stable and their positions are derived from the immutable base list.
+	const [draggedKey, setDraggedKey] = useState<string | null>(null);
+	const [dragOverKey, setDragOverKey] = useState<string | null>(null);
 
 	// One flat list: base columns and tag-key columns together, sorted by the current
 	// column order — the user arranges the table freely, nothing is segregated. Columns
@@ -62,43 +65,50 @@ export const ColumnSettingsDropdown = ({
 	// splice items at misleading positions.
 	const canReorder = !!onColumnOrderChange && !searchQuery;
 
-	// Live preview: the list as it would look if the dragged item were dropped here.
+	// Live preview: the dragged column shown at the hovered column's base position.
+	// Both positions are resolved from the immutable filtered list on every render, so
+	// hovering across several rows never accumulates stale indexes.
 	const displayColumns = (() => {
-		if (draggedIndex === null || dragOverIndex === null || draggedIndex === dragOverIndex) {
+		if (!draggedKey || !dragOverKey || draggedKey === dragOverKey) {
+			return filteredColumns;
+		}
+		const from = filteredColumns.findIndex(([key]) => key === draggedKey);
+		const to = filteredColumns.findIndex(([key]) => key === dragOverKey);
+		if (from === -1 || to === -1) {
 			return filteredColumns;
 		}
 		const next = [...filteredColumns];
-		const [moved] = next.splice(draggedIndex, 1);
-		next.splice(dragOverIndex, 0, moved);
+		const [moved] = next.splice(from, 1);
+		next.splice(to, 0, moved);
 		return next;
 	})();
 
-	const handleDragStart = (e: DragEvent<HTMLDivElement>, index: number) => {
-		setDraggedIndex(index);
+	const handleDragStart = (e: DragEvent<HTMLDivElement>, key: string) => {
+		setDraggedKey(key);
 		e.dataTransfer.effectAllowed = 'move';
-		e.dataTransfer.setData('text/plain', index.toString());
+		e.dataTransfer.setData('text/plain', key);
 	};
 
-	const handleDragOver = (e: DragEvent<HTMLDivElement>, index: number) => {
+	const handleDragOver = (e: DragEvent<HTMLDivElement>, key: string) => {
 		e.preventDefault();
 		e.dataTransfer.dropEffect = 'move';
-		if (draggedIndex === null) return;
-		setDragOverIndex(index);
+		if (!draggedKey || key === draggedKey) return;
+		setDragOverKey(key);
 	};
 
 	const handleDrop = (e: DragEvent<HTMLDivElement>) => {
 		e.preventDefault();
 		e.stopPropagation();
-		if (draggedIndex !== null && dragOverIndex !== null && draggedIndex !== dragOverIndex) {
+		if (draggedKey && dragOverKey && draggedKey !== dragOverKey) {
 			onColumnOrderChange?.(displayColumns.map(([key]) => key));
 		}
-		setDraggedIndex(null);
-		setDragOverIndex(null);
+		setDraggedKey(null);
+		setDragOverKey(null);
 	};
 
 	const handleDragEnd = () => {
-		setDraggedIndex(null);
-		setDragOverIndex(null);
+		setDraggedKey(null);
+		setDragOverKey(null);
 	};
 
 	const totalItems = filteredColumns.length;
@@ -148,19 +158,15 @@ export const ColumnSettingsDropdown = ({
 
 					{/* Scrollable Column List */}
 					<div className={totalItems > 10 ? 'max-h-[280px] overflow-y-auto' : ''}>
-						{displayColumns.map(([key, label], index) => (
+						{displayColumns.map(([key, label]) => (
 							<div
 								key={key}
 								draggable={canReorder}
-								onDragStart={(e) => handleDragStart(e, index)}
-								onDragOver={(e) => handleDragOver(e, index)}
+								onDragStart={(e) => handleDragStart(e, key)}
+								onDragOver={(e) => handleDragOver(e, key)}
 								onDrop={handleDrop}
 								onDragEnd={handleDragEnd}
-								className={
-									draggedIndex !== null && displayColumns[dragOverIndex ?? -1]?.[0] === key
-										? 'rounded-sm bg-accent/50'
-										: undefined
-								}
+								className={draggedKey === key && dragOverKey ? 'rounded-sm bg-accent/50' : undefined}
 							>
 								<DropdownMenuCheckboxItem
 									checked={visibleColumns.includes(key)}

--- a/apps/client/src/components/Alerts/AlertsTable/ColumnSettingsDropdown/ColumnSettingsDropdown.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/ColumnSettingsDropdown/ColumnSettingsDropdown.tsx
@@ -9,15 +9,19 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { getTagKeyColumnId, TagKeyInfo } from '@/types';
-import { Columns3, Search, X } from 'lucide-react';
-import { useState } from 'react';
+import { getTagKeyColumnId, isTagKeyColumn, TagKeyInfo } from '@/types';
+import { Columns3, GripVertical, Search, X } from 'lucide-react';
+import { DragEvent, useState } from 'react';
 import { ALERT_TAGS_LABEL, TOGGLE_COLUMNS_LABEL } from './ColumnSettingsDropdown.constants';
 
 export interface ColumnSettingsDropdownProps {
 	visibleColumns: string[];
 	onColumnToggle: (column: string) => void;
 	columnLabels: Record<string, string>;
+	// Current base-column order; the list renders in this order and drags rearrange it.
+	columnOrder?: string[];
+	// When provided, the base columns get drag handles; called with the full new base order.
+	onColumnOrderChange?: (columns: string[]) => void;
 	excludeColumns?: string[];
 	tagKeys?: TagKeyInfo[];
 }
@@ -26,17 +30,73 @@ export const ColumnSettingsDropdown = ({
 	visibleColumns,
 	onColumnToggle,
 	columnLabels,
+	columnOrder = [],
+	onColumnOrderChange,
 	excludeColumns = [],
 	tagKeys = [],
 }: ColumnSettingsDropdownProps) => {
 	const [searchQuery, setSearchQuery] = useState('');
+	const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+	const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
-	const availableColumns = Object.entries(columnLabels).filter(([key]) => !excludeColumns.includes(key));
+	// Base columns sorted by the current order; columns the (possibly stale) saved order
+	// doesn't know about sink to the end in their label-map order.
+	const baseOrder = columnOrder.filter((col) => !isTagKeyColumn(col));
+	const availableColumns = Object.entries(columnLabels)
+		.filter(([key]) => !excludeColumns.includes(key))
+		.sort(([a], [b]) => {
+			const ia = baseOrder.indexOf(a);
+			const ib = baseOrder.indexOf(b);
+			return (ia === -1 ? Number.MAX_SAFE_INTEGER : ia) - (ib === -1 ? Number.MAX_SAFE_INTEGER : ib);
+		});
 
 	// Filter columns based on search query
 	const filteredColumns = availableColumns.filter(([, label]) =>
 		label.toLowerCase().includes(searchQuery.toLowerCase())
 	);
+
+	// Reordering is disabled while searching — dragging within a filtered subset would
+	// splice items at misleading positions.
+	const canReorder = !!onColumnOrderChange && !searchQuery;
+
+	// Live preview: the list as it would look if the dragged item were dropped here.
+	const displayColumns = (() => {
+		if (draggedIndex === null || dragOverIndex === null || draggedIndex === dragOverIndex) {
+			return filteredColumns;
+		}
+		const next = [...filteredColumns];
+		const [moved] = next.splice(draggedIndex, 1);
+		next.splice(dragOverIndex, 0, moved);
+		return next;
+	})();
+
+	const handleDragStart = (e: DragEvent<HTMLDivElement>, index: number) => {
+		setDraggedIndex(index);
+		e.dataTransfer.effectAllowed = 'move';
+		e.dataTransfer.setData('text/plain', index.toString());
+	};
+
+	const handleDragOver = (e: DragEvent<HTMLDivElement>, index: number) => {
+		e.preventDefault();
+		e.dataTransfer.dropEffect = 'move';
+		if (draggedIndex === null) return;
+		setDragOverIndex(index);
+	};
+
+	const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		if (draggedIndex !== null && dragOverIndex !== null && draggedIndex !== dragOverIndex) {
+			onColumnOrderChange?.(displayColumns.map(([key]) => key));
+		}
+		setDraggedIndex(null);
+		setDragOverIndex(null);
+	};
+
+	const handleDragEnd = () => {
+		setDraggedIndex(null);
+		setDragOverIndex(null);
+	};
 
 	const filteredTagKeys = tagKeys.filter((tagKey) => tagKey.label.toLowerCase().includes(searchQuery.toLowerCase()));
 
@@ -87,15 +147,37 @@ export const ColumnSettingsDropdown = ({
 
 					{/* Scrollable Column List */}
 					<div className={totalItems > 10 ? 'max-h-[280px] overflow-y-auto' : ''}>
-						{filteredColumns.map(([key, label]) => (
-							<DropdownMenuCheckboxItem
+						{displayColumns.map(([key, label], index) => (
+							<div
 								key={key}
-								checked={visibleColumns.includes(key)}
-								onCheckedChange={() => onColumnToggle(key)}
-								onSelect={(e) => e.preventDefault()}
+								draggable={canReorder}
+								onDragStart={(e) => handleDragStart(e, index)}
+								onDragOver={(e) => handleDragOver(e, index)}
+								onDrop={handleDrop}
+								onDragEnd={handleDragEnd}
+								className={
+									draggedIndex !== null && displayColumns[dragOverIndex ?? -1]?.[0] === key
+										? 'rounded-sm bg-accent/50'
+										: undefined
+								}
 							>
-								{label}
-							</DropdownMenuCheckboxItem>
+								<DropdownMenuCheckboxItem
+									checked={visibleColumns.includes(key)}
+									onCheckedChange={() => onColumnToggle(key)}
+									onSelect={(e) => e.preventDefault()}
+									className={canReorder ? 'pr-7 relative' : undefined}
+								>
+									{label}
+									{canReorder && (
+										<span
+											className="absolute right-1.5 top-1/2 -translate-y-1/2 cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"
+											aria-label={`Drag to reorder ${label}`}
+										>
+											<GripVertical className="h-3.5 w-3.5" />
+										</span>
+									)}
+								</DropdownMenuCheckboxItem>
+							</div>
 						))}
 						{filteredTagKeys.length > 0 && (
 							<>

--- a/apps/client/src/components/Alerts/AlertsTable/ColumnSettingsDropdown/ColumnSettingsDropdown.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/ColumnSettingsDropdown/ColumnSettingsDropdown.tsx
@@ -9,10 +9,10 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { getTagKeyColumnId, isTagKeyColumn, TagKeyInfo } from '@/types';
+import { getTagKeyColumnId, TagKeyInfo } from '@/types';
 import { Columns3, GripVertical, Search, X } from 'lucide-react';
 import { DragEvent, useState } from 'react';
-import { ALERT_TAGS_LABEL, TOGGLE_COLUMNS_LABEL } from './ColumnSettingsDropdown.constants';
+import { TOGGLE_COLUMNS_LABEL } from './ColumnSettingsDropdown.constants';
 
 export interface ColumnSettingsDropdownProps {
 	visibleColumns: string[];
@@ -39,16 +39,19 @@ export const ColumnSettingsDropdown = ({
 	const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
 	const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
-	// Base columns sorted by the current order; columns the (possibly stale) saved order
-	// doesn't know about sink to the end in their label-map order.
-	const baseOrder = columnOrder.filter((col) => !isTagKeyColumn(col));
-	const availableColumns = Object.entries(columnLabels)
-		.filter(([key]) => !excludeColumns.includes(key))
-		.sort(([a], [b]) => {
-			const ia = baseOrder.indexOf(a);
-			const ib = baseOrder.indexOf(b);
-			return (ia === -1 ? Number.MAX_SAFE_INTEGER : ia) - (ib === -1 ? Number.MAX_SAFE_INTEGER : ib);
-		});
+	// One flat list: base columns and tag-key columns together, sorted by the current
+	// column order — the user arranges the table freely, nothing is segregated. Columns
+	// the (possibly stale) saved order doesn't know about sink to the end: base columns
+	// first, then tag keys, each group keeping its own listing order.
+	const availableColumns: [string, string][] = [
+		...Object.entries(columnLabels).filter(([key]) => !excludeColumns.includes(key)),
+		...tagKeys.map((tagKey): [string, string] => [getTagKeyColumnId(tagKey.key), tagKey.label]),
+	].sort(([a], [b]) => {
+		const ia = columnOrder.indexOf(a);
+		const ib = columnOrder.indexOf(b);
+		if (ia === -1 && ib === -1) return 0;
+		return (ia === -1 ? Number.MAX_SAFE_INTEGER : ia) - (ib === -1 ? Number.MAX_SAFE_INTEGER : ib);
+	});
 
 	// Filter columns based on search query
 	const filteredColumns = availableColumns.filter(([, label]) =>
@@ -98,9 +101,7 @@ export const ColumnSettingsDropdown = ({
 		setDragOverIndex(null);
 	};
 
-	const filteredTagKeys = tagKeys.filter((tagKey) => tagKey.label.toLowerCase().includes(searchQuery.toLowerCase()));
-
-	const totalItems = filteredColumns.length + filteredTagKeys.length;
+	const totalItems = filteredColumns.length;
 
 	return (
 		<div className="flex items-center border rounded-md">
@@ -179,25 +180,6 @@ export const ColumnSettingsDropdown = ({
 								</DropdownMenuCheckboxItem>
 							</div>
 						))}
-						{filteredTagKeys.length > 0 && (
-							<>
-								<DropdownMenuSeparator />
-								<DropdownMenuLabel>{ALERT_TAGS_LABEL}</DropdownMenuLabel>
-								{filteredTagKeys.map((tagKey) => {
-									const columnId = getTagKeyColumnId(tagKey.key);
-									return (
-										<DropdownMenuCheckboxItem
-											key={columnId}
-											checked={visibleColumns.includes(columnId)}
-											onCheckedChange={() => onColumnToggle(columnId)}
-											onSelect={(e) => e.preventDefault()}
-										>
-											{tagKey.label}
-										</DropdownMenuCheckboxItem>
-									);
-								})}
-							</>
-						)}
 
 						{/* No Results */}
 						{totalItems === 0 && searchQuery && (

--- a/apps/client/src/components/Alerts/hooks/useColumnManagement.ts
+++ b/apps/client/src/components/Alerts/hooks/useColumnManagement.ts
@@ -61,9 +61,14 @@ export const useColumnManagement = (options: ColumnManagementOptions = {}) => {
 	const tagKeyColumnIds = useMemo(() => tagKeys.map((tk) => getTagKeyColumnId(tk.key)), [tagKeys]);
 
 	const effectiveColumnOrder = useMemo(() => {
-		const tagKeysInOrder = visibleColumns.filter((col) => isTagKeyColumn(col));
-		const baseOrder = columnOrder.filter((col) => !isTagKeyColumn(col) && col !== ACTIONS_COLUMN);
-		return [...baseOrder, ...tagKeysInOrder];
+		// One unified order — base columns and tag-key columns interleave however the user
+		// arranged them; nothing is segregated. Columns missing from the stored order
+		// (ones that shipped after it was persisted, or tags toggled visible for the first
+		// time) append at the end until the user drags them elsewhere. The table renders
+		// orderedColumns = order ∩ visible, so hidden entries are just remembered positions.
+		const storedOrder = columnOrder.filter((col) => col !== ACTIONS_COLUMN);
+		const missingVisible = visibleColumns.filter((col) => col !== ACTIONS_COLUMN && !storedOrder.includes(col));
+		return [...storedOrder, ...missingVisible];
 	}, [columnOrder, visibleColumns]);
 
 	const handleColumnToggle = useCallback(

--- a/apps/client/src/context/DashboardContext.tsx
+++ b/apps/client/src/context/DashboardContext.tsx
@@ -105,6 +105,8 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 		const initialFilters = JSON.stringify(initialState.filters);
 		const currentVisibleColumns = JSON.stringify(dashboardState.visibleColumns);
 		const initialVisibleColumns = JSON.stringify(initialState.visibleColumns);
+		const currentColumnOrder = JSON.stringify(dashboardState.columnOrder);
+		const initialColumnOrder = JSON.stringify(initialState.columnOrder);
 		const currentQuery = dashboardState.query;
 		const initialQuery = initialState.query;
 		// serializeTimeRange fixes the property order (and turns Dates into ISO
@@ -118,6 +120,7 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 			currentGroupBy !== initialGroupBy ||
 			currentFilters !== initialFilters ||
 			currentVisibleColumns !== initialVisibleColumns ||
+			currentColumnOrder !== initialColumnOrder ||
 			currentQuery !== initialQuery ||
 			currentTimeRange !== initialTimeRange
 		);
@@ -130,6 +133,7 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 			'groupBy',
 			'filters',
 			'visibleColumns',
+			'columnOrder',
 			'query',
 			'timeRange',
 		];

--- a/apps/client/src/hooks/queries/dashboards/dashboards.types.ts
+++ b/apps/client/src/hooks/queries/dashboards/dashboards.types.ts
@@ -7,6 +7,8 @@ export interface Dashboard {
 	description?: string;
 	filters: Record<string, string[]>;
 	visibleColumns: string[];
+	// User-arranged base-column order; absent on dashboards saved before reordering shipped.
+	columnOrder?: string[];
 	query: string;
 	groupBy: string[];
 	timeRange?: DashboardTimeRange;
@@ -19,6 +21,7 @@ export interface CreateDashboardInput {
 	description?: string;
 	filters: Record<string, string[]>;
 	visibleColumns: string[];
+	columnOrder?: string[];
 	query: string;
 	groupBy: string[];
 	timeRange?: DashboardTimeRange;

--- a/apps/server/src/dal/dashboardRepository.ts
+++ b/apps/server/src/dal/dashboardRepository.ts
@@ -15,6 +15,7 @@ export class DashboardRepository {
 			filters: JSON.parse(dashboardRow.filters) as Record<string, unknown>,
 			visibleColumns: JSON.parse(dashboardRow.visible_columns) as string[],
 			query: dashboardRow.query,
+			columnOrder: dashboardRow.column_order ? (JSON.parse(dashboardRow.column_order) as string[]) : undefined,
 			groupBy: JSON.parse(dashboardRow.group_by) as string[],
 			timeRange: dashboardRow.time_range
 				? (JSON.parse(dashboardRow.time_range) as DashboardTimeRange)
@@ -40,8 +41,8 @@ export class DashboardRepository {
 	async createDashboard(dashboard: Omit<Dashboard, 'createdAt' | 'id'>): Promise<number> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
-                INSERT INTO dashboards (name, type, description, filters, visible_columns, query, group_by, time_range)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO dashboards (name, type, description, filters, visible_columns, column_order, query, group_by, time_range)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             `);
 			const result = stmt.run(
 				dashboard.name,
@@ -49,6 +50,7 @@ export class DashboardRepository {
 				dashboard.description,
 				JSON.stringify(dashboard.filters),
 				JSON.stringify(dashboard.visibleColumns),
+				dashboard.columnOrder ? JSON.stringify(dashboard.columnOrder) : null,
 				dashboard.query,
 				JSON.stringify(dashboard.groupBy),
 				dashboard.timeRange ? JSON.stringify(dashboard.timeRange) : null
@@ -91,6 +93,10 @@ export class DashboardRepository {
 			if (!columns.some((col) => col.name === 'time_range')) {
 				this.db.prepare(`ALTER TABLE dashboards ADD COLUMN time_range TEXT`).run();
 			}
+			// Backward compatibility: user-arranged column order (JSON string[]).
+			if (!columns.some((col) => col.name === 'column_order')) {
+				this.db.prepare(`ALTER TABLE dashboards ADD COLUMN column_order TEXT`).run();
+			}
 		});
 	}
 
@@ -104,6 +110,7 @@ export class DashboardRepository {
                 description = ?,
                 filters = ?,
                 visible_columns = ?,
+                column_order = ?,
                 query = ?,
                 group_by = ?,
                 time_range = ?
@@ -116,6 +123,7 @@ export class DashboardRepository {
 				dashboard.description,
 				JSON.stringify(dashboard.filters),
 				JSON.stringify(dashboard.visibleColumns),
+				dashboard.columnOrder ? JSON.stringify(dashboard.columnOrder) : null,
 				dashboard.query,
 				JSON.stringify(dashboard.groupBy),
 				dashboard.timeRange ? JSON.stringify(dashboard.timeRange) : null,

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -47,6 +47,7 @@ export interface DashboardRow {
 	created_at: string;
 	filters: string; // Record<string, string>
 	visible_columns: string; // string[]
+	column_order?: string | null; // string[]
 	query: string;
 	group_by: string; // string[]
 	time_range?: string | null; // DashboardTimeRange

--- a/apps/server/tests/dashboards.test.ts
+++ b/apps/server/tests/dashboards.test.ts
@@ -1,0 +1,71 @@
+import { SuperTest, Test } from 'supertest';
+import Database from 'better-sqlite3';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
+
+let app: SuperTest<Test>;
+let db: Database.Database;
+let jwtToken: string;
+
+beforeAll(async () => {
+	db = await setupDB();
+	app = await setupExpressApp(db);
+	jwtToken = await setupUserWithToken(app);
+});
+
+afterAll(() => {
+	db.close();
+});
+
+describe('Dashboards API — column order persistence', () => {
+	test('create and update round-trip columnOrder', async () => {
+		const base = {
+			name: 'order test',
+			type: 'alerts' as const,
+			description: '',
+			filters: {},
+			visibleColumns: ['type', 'alertName', 'summary'],
+			columnOrder: ['type', 'alertName', 'summary', 'owner'],
+			query: '',
+			groupBy: [],
+		};
+		const created = await app.post('/api/v1/dashboards').set('Authorization', `Bearer ${jwtToken}`).send(base);
+		expect(created.status).toBe(200);
+		const id = String(created.body.data.id);
+
+		const listById = async () => {
+			const list = await app.get('/api/v1/dashboards').set('Authorization', `Bearer ${jwtToken}`);
+			return (list.body.data as { id: string | number; columnOrder?: string[] }[]).find(
+				(d) => String(d.id) === id
+			);
+		};
+		expect((await listById())?.columnOrder).toEqual(['type', 'alertName', 'summary', 'owner']);
+
+		const updated = await app
+			.put(`/api/v1/dashboards/${id}`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...base, columnOrder: ['alertName', 'type', 'summary', 'owner'] });
+		expect(updated.status).toBe(200);
+		expect((await listById())?.columnOrder).toEqual(['alertName', 'type', 'summary', 'owner']);
+	});
+
+	test('a dashboard saved without columnOrder returns it as undefined', async () => {
+		const created = await app
+			.post('/api/v1/dashboards')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({
+				name: 'legacy dashboard',
+				type: 'alerts',
+				description: '',
+				filters: {},
+				visibleColumns: ['type'],
+				query: '',
+				groupBy: [],
+			});
+		expect(created.status).toBe(200);
+		const list = await app.get('/api/v1/dashboards').set('Authorization', `Bearer ${jwtToken}`);
+		const legacy = (list.body.data as { id: string | number; name: string; columnOrder?: string[] }[]).find(
+			(d) => d.name === 'legacy dashboard'
+		);
+		expect(legacy?.columnOrder).toBeUndefined();
+	});
+});

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -262,6 +262,7 @@ export const CreateDashboardSchema = z.object({
 	description: z.string().optional(),
 	filters: z.record(z.unknown()),
 	visibleColumns: z.array(z.string()),
+	columnOrder: z.array(z.string()).optional(),
 	query: z.string(),
 	groupBy: z.array(z.string()),
 	timeRange: z

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -348,6 +348,9 @@ export interface Dashboard {
 	description?: string;
 	filters: Record<string, unknown>;
 	visibleColumns: string[];
+	// User-arranged column order for the alerts table (base columns; tag-key columns
+	// follow the visible list). Absent on dashboards saved before reordering shipped.
+	columnOrder?: string[];
 	query: string;
 	groupBy: string[];
 	timeRange?: DashboardTimeRange;


### PR DESCRIPTION
## What

Users can rearrange the alerts table's columns by drag-and-drop, and the arrangement is saved as part of the dashboard. **Built-in columns and tag columns are equals**: one flat list, one unified order — drag any column anywhere.

- **Reordering**: the column-settings dropdown is now a single flat list (the separate "Alert Tags" section is gone). Every row — Type, Summary, a `pod` tag, anything — has a grip handle; dragging rearranges the table live. The list renders in the actual current order (it previously always rendered label-map order). Same native-DnD pattern GroupByControls already uses; dragging is disabled while the search box filters the list (splicing within a filtered subset lands at misleading positions).
- **Unified order model**: `effectiveColumnOrder` keeps the stored order verbatim (minus the actions column) and appends any visible columns it doesn't know about — so newly toggled columns (typically tags) land at the end until dragged elsewhere, and columns that shipped after a dashboard was saved still appear when toggled. Hidden entries in the order are remembered positions.
- **Persistence**: `columnOrder` rides the full dashboard lifecycle — localStorage draft, dirty tracking (reordering makes Save appear), new `column_order` TEXT column on `dashboards` (guarded migration, JSON `string[]`), shared type + zod schema, load-on-select. Legacy dashboards keep the default order.

## Verification

- **Server tests** (new `dashboards.test.ts`, suite 122/122): `columnOrder` round-trips create/update; legacy dashboards return it as `undefined`.
- **Live E2E, base columns**: dragged Owner above Summary → header reorders instantly → survives reload as draft → saves to the server → fresh draft resets to default → loading the saved dashboard restores the order.
- **Live E2E, tag columns**: one flat list with grips on all 19 rows and no section split; toggled `Pod` on (appends at end), dragged it between Summary and Owner → header shows `Summary | Pod | Owner`, the stored order carries `tagKey:pod` interleaved with base columns, and it survives a reload.
- Gates: build 4/4, client tests 40/40, all lints + prettier clean, tsc at baseline (server 0 / client 77). Test dashboards cleaned from the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop reordering for alert table columns, including tag-based columns.
  * Column arrangements are saved with dashboards and restored when dashboards are reopened.
  * Column reordering is temporarily disabled while searching.
* **Bug Fixes**
  * Improved handling of newly added or unavailable columns while preserving saved arrangements.
* **Tests**
  * Added coverage for saving, updating, loading, and maintaining dashboards without a custom column order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->