### PR TITLE
feat(alerts): show time-only for today's Started At timestamps

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertStartsAtColumn/AlertStartsAtColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertStartsAtColumn/AlertStartsAtColumn.tsx
@@ -9,9 +9,15 @@ export interface AlertStartsAtColumnProps {
 }
 
 export const AlertStartsAtColumn = ({ alert, className }: AlertStartsAtColumnProps) => {
+	// Today's alerts render time-only (formatDate); the tooltip always carries the full
+	// timestamp so the date is one hover away.
+	const date = new Date(alert.startsAt);
+	const fullTimestamp = isNaN(date.getTime()) ? undefined : date.toLocaleString();
 	return (
 		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
-			<span className="text-xs text-foreground truncate block">{formatDate(alert.startsAt)}</span>
+			<span className="text-xs text-foreground truncate block" title={fullTimestamp}>
+				{formatDate(alert.startsAt)}
+			</span>
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
@@ -79,9 +79,18 @@ export const sortAlerts = (
 	});
 };
 
+// Timestamps from today render time-only — the date part is noise for the rows users
+// care about most; older timestamps keep the full date. Sorting is unaffected: it runs
+// on the raw epoch value (getSortValue), never on this display string.
 export const formatDate = (dateString: string): string => {
 	const date = new Date(dateString);
-	return isNaN(date.getTime()) ? 'Invalid Date' : date.toLocaleString();
+	if (isNaN(date.getTime())) return 'Invalid Date';
+	const now = new Date();
+	const isToday =
+		date.getFullYear() === now.getFullYear() &&
+		date.getMonth() === now.getMonth() &&
+		date.getDate() === now.getDate();
+	return isToday ? date.toLocaleTimeString() : date.toLocaleString();
 };
 
 export const getAlertValue = (alert: Alert, field: string, users: UserInfo[] = []): string => {

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -76,12 +76,21 @@ describe('useAlertsFiltering rolling time presets', () => {
 });
 
 describe('formatDate (Started At display)', () => {
+	// Frozen clock: formatDate reads new Date() internally, so a real-clock test running
+	// across midnight could see "today" flip between capturing `now` and asserting.
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 5, 15, 14, 30, 0));
+	});
+	afterEach(() => vi.useRealTimers());
+
 	test('today renders time-only, older timestamps keep the full date', async () => {
 		const { formatDate } = await import('@/components/Alerts/AlertsTable/AlertsTable.utils');
 		const now = new Date();
 		expect(formatDate(now.toISOString())).toBe(now.toLocaleTimeString());
 
-		const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+		const yesterday = new Date(now);
+		yesterday.setDate(yesterday.getDate() - 1);
 		expect(formatDate(yesterday.toISOString())).toBe(yesterday.toLocaleString());
 
 		expect(formatDate('not-a-date')).toBe('Invalid Date');

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -74,3 +74,16 @@ describe('useAlertsFiltering rolling time presets', () => {
 		expect(result.current.map((a) => a.id)).toEqual(['early-today']);
 	});
 });
+
+describe('formatDate (Started At display)', () => {
+	test('today renders time-only, older timestamps keep the full date', async () => {
+		const { formatDate } = await import('@/components/Alerts/AlertsTable/AlertsTable.utils');
+		const now = new Date();
+		expect(formatDate(now.toISOString())).toBe(now.toLocaleTimeString());
+
+		const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+		expect(formatDate(yesterday.toISOString())).toBe(yesterday.toLocaleString());
+
+		expect(formatDate('not-a-date')).toBe('Invalid Date');
+	});
+});


### PR DESCRIPTION
## What

When an alert's Started At timestamp is from **today**, the column shows just the time (e.g. `1:24:31 PM`) instead of the full date+time; older alerts keep the full `7/20/2026, 1:19:19 AM` form. The cell's tooltip always carries the complete timestamp, so the date is one hover away.

**Sorting is unaffected by construction**: the table sorts `startsAt` on the raw epoch value (`getSortValue` in `AlertsTable.utils.ts`), never on the display string — this change only touches `formatDate`, whose single consumer is the Started At cell.

## Verification

- Live (Playwright): seeded a today-alert next to the old seeds → renders time-only while old rows keep full dates; tooltip shows the full timestamp; default `desc` sort puts the newest (time-only) row first and clicking the header to flip `asc` puts it last — mixed formats sort correctly.
- Unit tests pin the behavior for today / older / invalid inputs, locale-independent (compared against `toLocaleTimeString` / `toLocaleString` of the same instant). Client suite 41/41.
- Gates: build 4/4, lint + prettier clean, tsc at baseline (77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Alert timestamps from today now display the local time for easier scanning.
  - Older alert timestamps continue to show the full localized date and time.
  - Hovering over a timestamp reveals the complete localized date and time.
  - Invalid timestamps are handled consistently without causing display errors.

- **Tests**
  - Added coverage for today’s timestamps, older dates, and invalid timestamp values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->