### PR TITLE
fix(alerts): Started At reflects the first in-range firing under a time filter

### DIFF
--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -61,13 +61,29 @@ export const useAlertsFiltering = (
 
 		const resolved = timeRange ? resolveTimeRange(timeRange) : { from: null, to: null };
 		if (resolved.from || resolved.to) {
+			const filterStart = resolved.from || new Date(0);
+			const filterEnd = resolved.to || new Date();
+
 			result = result.filter((alert) => {
 				const alertStartDate = new Date(alert.startsAt);
 				const alertEndDate = new Date(alert.updatedAt);
-				const filterStart = resolved.from || new Date(0);
-				const filterEnd = resolved.to || new Date();
 
 				return alertStartDate <= filterEnd && alertEndDate >= filterStart;
+			});
+
+			// Inside a time window, "Started At" means the first time the alert fired WITHIN
+			// that window: an alert that originally fired last week but re-fired/unresolved
+			// inside the range shows (and sorts by) the in-range firing, not the ancient one.
+			// Alerts that simply kept firing across the range boundary have no in-range
+			// transition and keep their real start.
+			result = result.map((alert) => {
+				const candidates = [alert.startsAt, ...(alert.firingTimes ?? [])].filter((iso) => {
+					const t = new Date(iso);
+					return !isNaN(t.getTime()) && t >= filterStart && t <= filterEnd;
+				});
+				if (candidates.length === 0) return alert;
+				const inRangeStart = candidates.sort()[0];
+				return inRangeStart === alert.startsAt ? alert : { ...alert, startsAt: inRangeStart };
 			});
 		}
 

--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -82,7 +82,9 @@ export const useAlertsFiltering = (
 					return !isNaN(t.getTime()) && t >= filterStart && t <= filterEnd;
 				});
 				if (candidates.length === 0) return alert;
-				const inRangeStart = candidates.sort()[0];
+				// Numeric sort: startsAt can carry a timezone offset while firingTimes are
+				// normalized UTC — lexicographic order would mis-pick across formats.
+				const inRangeStart = candidates.sort((a, b) => new Date(a).getTime() - new Date(b).getTime())[0];
 				return inRangeStart === alert.startsAt ? alert : { ...alert, startsAt: inRangeStart };
 			});
 		}

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -139,3 +139,30 @@ describe('formatDate (Started At display)', () => {
 		expect(formatDate('not-a-date')).toBe('Invalid Date');
 	});
 });
+
+describe('in-range override with mixed timestamp formats', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	test('offset-ISO startsAt and UTC firingTimes sort numerically, not lexically', () => {
+		// startsAt uses a +03:00 offset and is EARLIER in real time than the UTC firing
+		// time, but LATER lexicographically ("2026-…T14" > "2026-…T11").
+		const base = Date.now();
+		const startsAtOffset = new Date(base - 30 * 60_000);
+		const offsetIso = new Date(startsAtOffset.getTime() + 3 * 3600_000)
+			.toISOString()
+			.replace('Z', '+03:00')
+			.replace(/\.\d{3}/, '');
+		const laterUtc = new Date(base - 10 * 60_000).toISOString();
+		const alert = {
+			...mkAlert('mixed', 0),
+			startsAt: offsetIso,
+			updatedAt: new Date().toISOString(),
+			firingTimes: [laterUtc],
+		};
+		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'last1h' as const } };
+		const { result } = renderHook(() => useAlertsFiltering([alert], options), { wrapper });
+		// The earliest REAL instant is the offset startsAt — numeric sort keeps it.
+		expect(result.current[0]?.startsAt).toBe(offsetIso);
+	});
+});

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -75,6 +75,49 @@ describe('useAlertsFiltering rolling time presets', () => {
 	});
 });
 
+describe('in-range Started At override', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	test('an alert that re-fired inside the window shows the in-range firing, not the original start', () => {
+		const oldStart = new Date(Date.now() - 7 * 24 * 3600_000).toISOString();
+		const inRangeFiring = new Date(Date.now() - 20 * 60_000).toISOString();
+		const alert = {
+			...mkAlert('refired', 0),
+			startsAt: oldStart,
+			updatedAt: new Date().toISOString(),
+			firingTimes: [oldStart, inRangeFiring],
+		};
+		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'last1h' as const } };
+		const { result } = renderHook(() => useAlertsFiltering([alert], options), { wrapper });
+		expect(result.current[0]?.startsAt).toBe(inRangeFiring);
+	});
+
+	test('an alert firing across the range boundary with no in-range transition keeps its real start', () => {
+		const oldStart = new Date(Date.now() - 7 * 24 * 3600_000).toISOString();
+		const alert = {
+			...mkAlert('steady', 0),
+			startsAt: oldStart,
+			updatedAt: new Date().toISOString(),
+			firingTimes: [oldStart],
+		};
+		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'last1h' as const } };
+		const { result } = renderHook(() => useAlertsFiltering([alert], options), { wrapper });
+		expect(result.current[0]?.startsAt).toBe(oldStart);
+	});
+
+	test('without a time filter nothing is overridden', () => {
+		const oldStart = new Date(Date.now() - 7 * 24 * 3600_000).toISOString();
+		const alert = {
+			...mkAlert('plain', 0),
+			startsAt: oldStart,
+			firingTimes: [new Date(Date.now() - 60_000).toISOString()],
+		};
+		const { result } = renderHook(() => useAlertsFiltering([alert], { filters: {} }), { wrapper });
+		expect(result.current[0]?.startsAt).toBe(oldStart);
+	});
+});
+
 describe('formatDate (Started At display)', () => {
 	// Frozen clock: formatDate reads new Date() internally, so a real-clock test running
 	// across midnight could see "today" flip between capturing `now` and asserting.

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -164,10 +164,12 @@ export class AlertBL {
 	// latter carry the actual unresolve moment, which the status trigger doesn't.
 	// Best-effort: a failed lookup must never break the listing.
 	private async attachFiringTimes(alerts: Alert[]): Promise<Alert[]> {
+		if (alerts.length === 0) return alerts;
 		try {
+			const alertIds = alerts.map((alert) => alert.id);
 			const [firingRows, unresolveEvents] = await Promise.all([
-				this.alertRepo.getFiringTimesByAlert(),
-				this.alertHistoryRepo.getEventTimesByType(AlertHistoryEventType.UNRESOLVED),
+				this.alertRepo.getFiringTimesByAlert(alertIds),
+				this.alertHistoryRepo.getEventTimesByType(AlertHistoryEventType.UNRESOLVED, alertIds),
 			]);
 			return alerts.map((alert) => {
 				const merged = [...(firingRows[alert.id] ?? []), ...(unresolveEvents[alert.id] ?? [])].map(toIsoUtc);

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -159,6 +159,27 @@ export class AlertBL {
 		return this.alertRepo.updateSilenceResetSettings(updates);
 	}
 
+	// Attaches each alert's firing/unresolve transition timestamps (normalized ISO,
+	// sorted, deduped): status-history "firing" records plus UNRESOLVED events — the
+	// latter carry the actual unresolve moment, which the status trigger doesn't.
+	// Best-effort: a failed lookup must never break the listing.
+	private async attachFiringTimes(alerts: Alert[]): Promise<Alert[]> {
+		try {
+			const [firingRows, unresolveEvents] = await Promise.all([
+				this.alertRepo.getFiringTimesByAlert(),
+				this.alertHistoryRepo.getEventTimesByType(AlertHistoryEventType.UNRESOLVED),
+			]);
+			return alerts.map((alert) => {
+				const merged = [...(firingRows[alert.id] ?? []), ...(unresolveEvents[alert.id] ?? [])].map(toIsoUtc);
+				if (merged.length === 0) return alert;
+				return { ...alert, firingTimes: [...new Set(merged)].sort() };
+			});
+		} catch (error) {
+			logger.error('Failed to attach firing times to alerts', error);
+			return alerts;
+		}
+	}
+
 	async getAllAlerts(): Promise<Alert[]> {
 		try {
 			logger.info('Fetching all alerts');
@@ -169,9 +190,9 @@ export class AlertBL {
 				alerts = await this.enrichmentBL.applyEnrichments(alerts);
 			}
 			if (this.mutePolicyBL) {
-				return await this.mutePolicyBL.markMuted(alerts);
+				alerts = await this.mutePolicyBL.markMuted(alerts);
 			}
-			return alerts;
+			return await this.attachFiringTimes(alerts);
 		} catch (error) {
 			logger.error('Error fetching alerts', error);
 			throw error;
@@ -242,7 +263,7 @@ export class AlertBL {
 	async getAllResolvedAlerts(): Promise<Alert[]> {
 		try {
 			logger.info('Fetching all resolved alerts');
-			return await this.resolvedAlertRepo.getAllResolvedAlerts();
+			return await this.attachFiringTimes(await this.resolvedAlertRepo.getAllResolvedAlerts());
 		} catch (error) {
 			logger.error('Error fetching resolved alerts', error);
 			throw error;

--- a/apps/server/src/dal/alertHistoryRepository.ts
+++ b/apps/server/src/dal/alertHistoryRepository.ts
@@ -70,6 +70,22 @@ export class AlertHistoryRepository {
 		});
 	}
 
+	// created_at per alert for one event type (e.g. UNRESOLVED = the actual moment an
+	// alert went back to firing; the status-history trigger records the original
+	// starts_at instead on unresolve re-inserts).
+	async getEventTimesByType(eventType: string): Promise<Record<string, string[]>> {
+		return runAsync(() => {
+			const rows = this.db
+				.prepare(`SELECT alert_id, created_at FROM alert_history_events WHERE event_type = ?`)
+				.all(eventType) as { alert_id: string; created_at: string }[];
+			const result: Record<string, string[]> = {};
+			for (const row of rows) {
+				(result[row.alert_id] ??= []).push(row.created_at);
+			}
+			return result;
+		});
+	}
+
 	async getEvents(alertId: string): Promise<AlertHistoryEventRow[]> {
 		return runAsync(() => {
 			return this.db

--- a/apps/server/src/dal/alertHistoryRepository.ts
+++ b/apps/server/src/dal/alertHistoryRepository.ts
@@ -73,11 +73,16 @@ export class AlertHistoryRepository {
 	// created_at per alert for one event type (e.g. UNRESOLVED = the actual moment an
 	// alert went back to firing; the status-history trigger records the original
 	// starts_at instead on unresolve re-inserts).
-	async getEventTimesByType(eventType: string): Promise<Record<string, string[]>> {
+	async getEventTimesByType(eventType: string, alertIds: string[]): Promise<Record<string, string[]>> {
+		if (alertIds.length === 0) return {};
 		return runAsync(() => {
+			const placeholders = alertIds.map(() => '?').join(', ');
 			const rows = this.db
-				.prepare(`SELECT alert_id, created_at FROM alert_history_events WHERE event_type = ?`)
-				.all(eventType) as { alert_id: string; created_at: string }[];
+				.prepare(
+					`SELECT alert_id, created_at FROM alert_history_events
+					 WHERE event_type = ? AND alert_id IN (${placeholders})`
+				)
+				.all(eventType, ...alertIds) as { alert_id: string; created_at: string }[];
 			const result: Record<string, string[]> = {};
 			for (const row of rows) {
 				(result[row.alert_id] ??= []).push(row.created_at);

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -353,14 +353,20 @@ export class AlertRepository {
 		});
 	}
 
-	// Firing-transition timestamps per alert, from the status-history trigger records
-	// (first fire, webhook re-fires, unresolve re-inserts). Raw values — the BL merges
-	// them with unresolve events and normalizes to ISO.
-	async getFiringTimesByAlert(): Promise<Record<string, string[]>> {
+	// Firing-transition timestamps for the given alerts, from the status-history trigger
+	// records (first fire, webhook re-fires, unresolve re-inserts). Raw values — the BL
+	// merges them with unresolve events and normalizes to ISO. Scoped to the listed ids
+	// so the work doesn't grow with total history retention.
+	async getFiringTimesByAlert(alertIds: string[]): Promise<Record<string, string[]>> {
+		if (alertIds.length === 0) return {};
 		return runAsync(() => {
+			const placeholders = alertIds.map(() => '?').join(', ');
 			const rows = this.db
-				.prepare(`SELECT alert_id, archived_at FROM alerts_history WHERE status = 'firing'`)
-				.all() as { alert_id: string; archived_at: string }[];
+				.prepare(
+					`SELECT alert_id, archived_at FROM alerts_history
+					 WHERE status = 'firing' AND alert_id IN (${placeholders})`
+				)
+				.all(...alertIds) as { alert_id: string; archived_at: string }[];
 			const result: Record<string, string[]> = {};
 			for (const row of rows) {
 				(result[row.alert_id] ??= []).push(row.archived_at);

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -353,6 +353,22 @@ export class AlertRepository {
 		});
 	}
 
+	// Firing-transition timestamps per alert, from the status-history trigger records
+	// (first fire, webhook re-fires, unresolve re-inserts). Raw values — the BL merges
+	// them with unresolve events and normalizes to ISO.
+	async getFiringTimesByAlert(): Promise<Record<string, string[]>> {
+		return runAsync(() => {
+			const rows = this.db
+				.prepare(`SELECT alert_id, archived_at FROM alerts_history WHERE status = 'firing'`)
+				.all() as { alert_id: string; archived_at: string }[];
+			const result: Record<string, string[]> = {};
+			for (const row of rows) {
+				(result[row.alert_id] ??= []).push(row.archived_at);
+			}
+			return result;
+		});
+	}
+
 	async markAlertRead(id: string): Promise<SharedAlert | null> {
 		return runAsync(() => {
 			this.db.prepare('UPDATE alerts SET is_read = 1 WHERE id = ?').run(id);

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1412,3 +1412,27 @@ describe('Silence reset settings API', () => {
 		expect(descriptions).toContain('Silence cleared by daily reset');
 	});
 });
+
+describe('Firing times on alert listings', () => {
+	test('unresolve adds an in-range firing timestamp to firingTimes', async () => {
+		const alertId = testAlerts[0].id;
+		const before = Date.now();
+
+		// resolve (moves to resolved) then unresolve (back to firing, records UNRESOLVED)
+		await app.delete(`/api/v1/alerts/${alertId}`).set('Authorization', `Bearer ${jwtToken}`).send({});
+		await app.patch(`/api/v1/alerts/resolved/${alertId}/unresolve`).set('Authorization', `Bearer ${jwtToken}`);
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const alert = (listing.body.data.alerts as { id: string; firingTimes?: string[] }[]).find(
+			(a) => a.id === alertId
+		);
+		expect(alert?.firingTimes?.length).toBeGreaterThan(0);
+		// At least one firing timestamp is from just now (the unresolve moment), within 60s.
+		const recent = (alert?.firingTimes ?? []).some((t) => Math.abs(new Date(t).getTime() - before) < 60_000);
+		expect(recent).toBe(true);
+		// All normalized ISO-UTC.
+		for (const t of alert?.firingTimes ?? []) {
+			expect(t).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+		}
+	});
+});

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1427,9 +1427,10 @@ describe('Firing times on alert listings', () => {
 			(a) => a.id === alertId
 		);
 		expect(alert?.firingTimes?.length).toBeGreaterThan(0);
-		// At least one firing timestamp is from just now (the unresolve moment), within 60s.
-		const recent = (alert?.firingTimes ?? []).some((t) => Math.abs(new Date(t).getTime() - before) < 60_000);
-		expect(recent).toBe(true);
+		// At least one firing timestamp is from AFTER the unresolve started — the seeded
+		// fixture rows are older than `before`, so this can only match the unresolve moment.
+		const unresolveRecorded = (alert?.firingTimes ?? []).some((t) => new Date(t).getTime() >= before);
+		expect(unresolveRecorded).toBe(true);
 		// All normalized ISO-UTC.
 		for (const t of alert?.firingTimes ?? []) {
 			expect(t).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -212,6 +212,10 @@ export interface Alert {
 	isRead?: boolean;
 	// Transient: set at fetch time when an active mute policy rule matches this alert. Not persisted.
 	isMuted?: boolean;
+	// Transient: ISO timestamps of this alert's firing/unresolve transitions, attached at
+	// fetch time. Lets the client show the first firing INSIDE an active time-filter range
+	// instead of the original startsAt. Not persisted on the alert row itself.
+	firingTimes?: string[];
 	// Transient: set at fetch time with the enrichment rules that matched/decorated this alert.
 	// Empty/undefined means the alert was not enriched. Not persisted.
 	appliedEnrichments?: AppliedEnrichment[];


### PR DESCRIPTION
## What

With a time filter active, the Started At column now answers the question the user is actually asking: **when did this alert start firing *within the window I chose***?

- An alert that originally fired weeks ago but re-fired / was unresolved inside the range shows (and sorts by) its **first in-range firing**, not the ancient timestamp.
- An alert that simply kept firing across the range boundary has no in-range transition and keeps its real start — no fake clamping to the window edge.
- Clearing the filter restores original values everywhere. Nothing is persisted; the override lives on the filtered display copy only.

## How

- **Server**: both alerts listings attach a transient `firingTimes: string[]` per alert — the status-history `firing` records (first fire, webhook re-fires, unresolve re-inserts) merged with `UNRESOLVED` history events. The merge matters: the status trigger records the *original* `starts_at` on unresolve re-inserts, while the UNRESOLVED event carries the actual unresolve moment. Normalized ISO-UTC (lexicographically sortable), deduped, attached best-effort so a history hiccup can't break the listing. Two grouped queries per listing, no N+1.
- **Client**: `useAlertsFiltering` picks the earliest candidate within the resolved range (`startsAt` itself included as a candidate) and overrides `startsAt` on the mapped copy. Sorting and grouping consume the same mapped list, so they agree with the display by construction — and the override composes with the rolling presets from #704 (the range re-resolves each evaluation).

## Verification

- **Server test**: resolve→unresolve an alert → the listing's `firingTimes` contains a timestamp from the unresolve moment, ISO-normalized (suite 123/123).
- **Client unit tests**: re-fired-inside-window → overridden; steady-across-boundary → original kept; no filter → untouched (suite 43/43).
- **Live E2E**: `Demo - DB Latency High` (startsAt 7/7) cycled through unresolve → under **Today** the column shows its earliest today-firing (`8/1, 12:42 AM` — an overnight transition, correctly the *first* in-range one, not the latest); cleared → `7/7` returns.
- Gates: build 4/4, all lints + prettier clean, tsc at baseline.

**Note on interplay**: PR #715 (time-only rendering for today's timestamps) is separate; once both merge, in-range values from today render as time-only automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved alert time-range filtering to use the earliest valid firing time within the selected period.
  * Re-fired alerts now appear with accurate “Started At” timestamps when they become active again.
  * Alert firing timestamps are normalized for consistent display and filtering.

* **Bug Fixes**
  * Alerts without an in-range firing event retain their original start time.
  * Alerts without a time filter remain unchanged.
  * Alert listings continue to load even if firing-time details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->