### PR TITLE
[FIX]: avoid nested buttons in the time filter

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.test.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@/test/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { TimeFilter } from './TimeFilter';
+
+describe('TimeFilter', () => {
+	it('keeps the clear control outside the popover trigger button', () => {
+		const onChange = vi.fn();
+		const { container } = render(
+			<TimeFilter
+				value={{
+					from: new Date('2026-08-01T10:00:00Z'),
+					to: new Date('2026-08-01T11:00:00Z'),
+					preset: 'custom',
+				}}
+				onChange={onChange}
+			/>
+		);
+
+		expect(container.querySelectorAll('button button')).toHaveLength(0);
+		expect(screen.getByRole('button', { name: 'Clear time filter' })).toBeInTheDocument();
+	});
+
+	it('clears the active range without opening the popover', () => {
+		const onChange = vi.fn();
+		render(
+			<TimeFilter
+				value={{
+					from: new Date('2026-08-01T10:00:00Z'),
+					to: new Date('2026-08-01T11:00:00Z'),
+					preset: 'custom',
+				}}
+				onChange={onChange}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Clear time filter' }));
+
+		expect(onChange).toHaveBeenCalledWith({ from: null, to: null, preset: null });
+		expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+	});
+});

--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.tsx
@@ -47,25 +47,28 @@ export const TimeFilter = ({ value, onChange }: TimeFilterProps) => {
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
-			<PopoverTrigger asChild>
-				<Button
-					variant="outline"
-					size="sm"
-					className={cn(
-						'h-8 gap-2 text-xs font-semibold w-auto items-center rounded-full',
-						hasValue && 'border-primary text-primary'
-					)}
-				>
-					<Clock className="h-4 w-4 shrink-0" />
-					<span className="whitespace-nowrap">{displayText}</span>
-					{hasValue && (
-						<ClearButton
-							onClear={handleClear}
-							className="h-auto w-auto inline-flex items-center justify-center"
-						/>
-					)}
-				</Button>
-			</PopoverTrigger>
+			<div className="relative inline-flex items-center">
+				<PopoverTrigger asChild>
+					<Button
+						variant="outline"
+						size="sm"
+						className={cn(
+							'h-8 gap-2 text-xs font-semibold w-auto items-center rounded-full',
+							hasValue && 'border-primary text-primary pr-8'
+						)}
+					>
+						<Clock className="h-4 w-4 shrink-0" />
+						<span className="whitespace-nowrap">{displayText}</span>
+					</Button>
+				</PopoverTrigger>
+				{hasValue && (
+					<ClearButton
+						onClear={handleClear}
+						aria-label="Clear time filter"
+						className="absolute right-1 h-6 w-6 inline-flex items-center justify-center"
+					/>
+				)}
+			</div>
 			<PopoverContent className="w-[353px] p-0" align="end" side="bottom" sideOffset={4}>
 				<Tabs defaultValue="quick" className="w-full">
 					<TabsList className="w-full grid grid-cols-2 h-9 rounded-b-none">


### PR DESCRIPTION
## Summary

Fixes #717 by moving the time filter clear control outside the popover trigger button. This removes invalid button nesting while preserving the existing clear behavior and visual placement.

## Verification

- `vitest run src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.test.tsx` (2 passed)
- `vite build` for `packages/shared`
- `vite build` for `packages/custom-actions`
- `vite build` for `apps/client`
- Prettier check passed for changed files
- ESLint passed for changed files (existing max-lines warning remains on `TimeFilter`)

The standalone client TypeScript check still reports unrelated existing workspace errors, including unresolved generated package declarations and pre-existing type mismatches outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the time filter’s clear control so it can be used without opening the filter menu.
  * Added an accessible label and adjusted spacing for the active filter state.
* **Tests**
  * Added coverage for clearing active time ranges and confirming the filter menu remains closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->