### PR TITLE
fix(client): stop nesting <button> inside TimeFilter trigger button

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.test.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@/test/test-utils';
+import { TimeFilter } from './TimeFilter';
+
+const presetValue = { from: null, to: null, preset: 'today' as const };
+
+describe('TimeFilter', () => {
+	it('renders the clear control without nesting a <button> inside the trigger <button>', () => {
+		const { container } = render(<TimeFilter value={presetValue} onChange={vi.fn()} />);
+
+		// Invalid HTML nesting (button inside button) is what React 19 flags as a
+		// hydration error — the clear control must not be a real <button>.
+		expect(container.querySelectorAll('button button')).toHaveLength(0);
+
+		const clear = screen.getByRole('button', { name: /clear filter/i });
+		expect(clear.tagName).toBe('SPAN');
+	});
+
+	it('clears the range when the clear control is clicked', () => {
+		const onChange = vi.fn();
+		render(<TimeFilter value={presetValue} onChange={onChange} />);
+
+		fireEvent.click(screen.getByRole('button', { name: /clear filter/i }));
+
+		expect(onChange).toHaveBeenCalledWith({ from: null, to: null, preset: null });
+	});
+
+	it('clears the range when the clear control is activated from the keyboard', () => {
+		const onChange = vi.fn();
+		render(<TimeFilter value={presetValue} onChange={onChange} />);
+
+		fireEvent.keyDown(screen.getByRole('button', { name: /clear filter/i }), { key: 'Enter' });
+
+		expect(onChange).toHaveBeenCalledWith({ from: null, to: null, preset: null });
+	});
+});

--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.tsx
@@ -33,7 +33,7 @@ export const TimeFilter = ({ value, onChange }: TimeFilterProps) => {
 	);
 
 	const handleClear = useCallback(
-		(e?: React.MouseEvent) => {
+		(e?: React.SyntheticEvent) => {
 			if (e) {
 				e.stopPropagation();
 			}

--- a/apps/client/src/components/ui/clear-button.tsx
+++ b/apps/client/src/components/ui/clear-button.tsx
@@ -3,36 +3,47 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-export interface ClearButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-	onClear?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+export interface ClearButtonProps extends React.HTMLAttributes<HTMLSpanElement> {
+	onClear?: (e: React.SyntheticEvent) => void;
 }
 
-const ClearButton = React.forwardRef<HTMLButtonElement, ClearButtonProps>(
-	({ className, onClick, onClear, ...props }, ref) => {
-		const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+const ClearButton = React.forwardRef<HTMLSpanElement, ClearButtonProps>(
+	({ className, onClick, onClear, onKeyDown, ...props }, ref) => {
+		const handleActivate = (e: React.SyntheticEvent) => {
 			e.stopPropagation();
 			e.preventDefault();
 			if (onClear) {
 				onClear(e);
 			}
 			if (onClick) {
-				onClick(e);
+				onClick(e as React.MouseEvent<HTMLSpanElement>);
 			}
 		};
 
+		const handleKeyDown = (e: React.KeyboardEvent<HTMLSpanElement>) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				handleActivate(e);
+			}
+			onKeyDown?.(e);
+		};
+
 		return (
-			<button
+			<span
 				ref={ref}
-				type="button"
-				onClick={handleClick}
+				role="button"
+				tabIndex={0}
+				aria-label="Clear filter"
+				onClick={handleActivate}
+				onKeyDown={handleKeyDown}
+				{...props}
 				className={cn(
-					'flex items-center justify-center shrink-0 rounded-sm opacity-70 hover:opacity-100 focus:outline-hidden hover:bg-primary hover:text-primary-foreground transition-colors',
+					'flex cursor-pointer items-center justify-center shrink-0 rounded-sm opacity-70 hover:opacity-100 focus:outline-hidden hover:bg-primary hover:text-primary-foreground transition-colors',
 					className
 				)}
-				{...props}
 			>
-				<X className="h-3.5 w-3.5" />
-			</button>
+				<X aria-hidden="true" className="h-3.5 w-3.5" />
+			</span>
 		);
 	}
 );


### PR DESCRIPTION
Closes #717

## What & why
`ClearButton` was rendered as a real `<button>` inside the `TimeFilter` trigger `<button>` (via `PopoverTrigger asChild`). React 19 flags that as invalid HTML nesting (`<button> cannot be a descendant of <button>`) and logs a hydration error as soon as a time filter has a value.

Fix follows the first option suggested in the issue: the clear control is now a `<span role="button" tabIndex={0}>` with Enter/Space key handling, so the DOM stays valid while keeping identical behavior (click stops propagation and clears the range).

## Changes
- `apps/client/src/components/ui/clear-button.tsx` — root element `button` → `span role="button" tabIndex={0}`; adds `onKeyDown` (Enter/Space → activate), `aria-label` + `aria-hidden` on the icon, `cursor-pointer`; props/ref types updated to `HTMLSpanElement`; `onClear` now receives a `SyntheticEvent` (click or keyboard).
- `apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.tsx` — `handleClear` param type widened to `React.SyntheticEvent` (keyboard activation also reaches it).
- `apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.test.tsx` — new tests: no `<button>` nested inside the trigger button, click clears the range, keyboard (Enter) clears the range.

## Verification
| Check | Result |
|---|---|
| `pnpm --filter @OpsiMate/client test:run` | ✅ 48/48 pass (incl. 3 new TimeFilter tests) |
| `pnpm --filter @OpsiMate/client lint` (eslint) | ✅ 0 errors (no new warnings) |
| `pnpm --filter @OpsiMate/client format` (prettier --check) | ✅ all files formatted |
| `pnpm run build` (turbo, client + server) | ✅ success |
| Invalid nesting (`button button` in DOM) | ✅ gone — asserted in test |

Keyboard-operable clear control: focus it (Tab) and press Enter or Space — the range clears and the popover does not open (same as click).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved the time-filter clear control with button semantics and keyboard support.
  * Users can now activate clearing with Enter or Space, in addition to mouse interaction.

* **Bug Fixes**
  * Clearing a time filter now consistently resets the start date, end date, and selected preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->