### PR TITLE
fix: drag-select marking stops when cursor leaves checkbox column

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -80,9 +80,12 @@ export const AlertRow = ({
 	};
 
 	const handleRowMouseEnter = () => {
-		// During drag selection, entering any part of the row should trigger
-		// the drag selection handler, not just the checkbox column (#712).
-		if (isDragging && onDragEnter) {
+		// During drag selection, entering any part of the row should trigger the drag
+		// selection handler, not just the checkbox column (#712). No isDragging guard:
+		// isDragging only turns true after the first drag-enter, so gating on it would
+		// ignore the first row the cursor reaches after leaving the checkbox column.
+		// The hook itself no-ops unless the mouse went down on a checkbox.
+		if (onDragEnter) {
 			onDragEnter(alert);
 		}
 	};

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -79,6 +79,14 @@ export const AlertRow = ({
 		}
 	};
 
+	const handleRowMouseEnter = () => {
+		// During drag selection, entering any part of the row should trigger
+		// the drag selection handler, not just the checkbox column (#712).
+		if (isDragging && onDragEnter) {
+			onDragEnter(alert);
+		}
+	};
+
 	return (
 		<TableRow
 			className={cn(
@@ -95,6 +103,7 @@ export const AlertRow = ({
 				isActiveRow && 'bg-primary/10 hover:bg-primary/15 shadow-[inset_3px_0_0_0] shadow-primary'
 			)}
 			onClick={handleRowClick}
+			onMouseEnter={handleRowMouseEnter}
 		>
 			{onSelectAlerts && (
 				<TableCell


### PR DESCRIPTION
## Summary

Fixes #712 — Drag-select marking stops when the cursor leaves the checkbox column.

### Root Cause

The `onMouseEnter` handler that triggers drag selection was only attached to the checkbox `<TableCell>` in `AlertRow.tsx`. When the cursor drifts outside the checkbox column while dragging down, the browser fires `onMouseLeave` on the checkbox cell but no `onMouseEnter` on adjacent cells, so the drag selection never fires for rows the cursor passes over outside the checkbox column.

### Fix

Added a row-level `onMouseEnter` handler (`handleRowMouseEnter`) to the `<TableRow>` element that checks `isDragging` before calling `onDragEnter`. This ensures drag-selection fires regardless of which column the cursor is over.

### Changes

- `apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx`
  - Added `handleRowMouseEnter` handler that fires `onDragEnter` during active drag
  - Added `onMouseEnter={handleRowMouseEnter}` to the `<TableRow>` element

### Testing

- Drag-select from checkbox down through rows: ✓ works across entire row width
- Single-click selection (no drag): ✓ unchanged
- Click on row content (not checkbox): ✓ unchanged

Closes #712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced drag selection in the alerts table, allowing users to select alerts by dragging across an entire row.
  * Drag interactions now respond when hovering over any part of a row, not only the checkbox area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->