### PR TITLE
feat: persist split-by-owner and severity-colors toggles with the dashboard

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -46,7 +46,6 @@ import {
 	useAlertTagKeys,
 	useResolvedTabStatusFilterReset,
 	useColumnManagement,
-	useSeverityColors,
 } from './hooks';
 
 // Options for the alert-list picker (one dropdown instead of three toggle buttons);
@@ -86,8 +85,14 @@ const Alerts = () => {
 	const [filterPanelCollapsed, setFilterPanelCollapsed] = useState(false);
 	const [showDashboardSettings, setShowDashboardSettings] = useState(false);
 	const [pendingAction, setPendingAction] = useState<PendingAlertAction | null>(null);
-	const [splitByAssignment, setSplitByAssignment] = useState(false);
-	const { severityColors, toggleSeverityColors } = useSeverityColors();
+	// Read "Split by owner" toggle from dashboard state (persisted with the dashboard).
+	// Falls back to false when no dashboard is loaded.
+	const splitByAssignment = dashboardState.splitByAssignment;
+	const handleToggleSplitByAssignment = () => updateDashboardField('splitByAssignment', !splitByAssignment);
+	// Read "Severity colors" toggle from dashboard state, with localStorage as fallback
+	// for unsaved drafts (legacy behavior).
+	const severityColors = dashboardState.severityColors ?? (localStorage.getItem('opsimate-alerts-severity-colors') === 'true');
+	const handleToggleSeverityColors = () => updateDashboardField('severityColors', !severityColors);
 
 	const allAlerts = useMemo(() => [...alerts, ...resolvedAlerts], [alerts, resolvedAlerts]);
 	const tagKeys = useAlertTagKeys(allAlerts);
@@ -164,6 +169,8 @@ const Alerts = () => {
 			filters: dashboardState.filters,
 			visibleColumns: dashboardState.visibleColumns.filter((col) => col !== ACTIONS_COLUMN),
 			columnOrder: dashboardState.columnOrder.filter((col) => col !== ACTIONS_COLUMN),
+			splitByAssignment: dashboardState.splitByAssignment,
+			severityColors: dashboardState.severityColors,
 			query: dashboardState.query,
 			groupBy: dashboardState.groupBy,
 			timeRange: serializeTimeRange(dashboardState.timeRange),
@@ -415,6 +422,8 @@ const Alerts = () => {
 				visibleColumns: dashboard.visibleColumns || [],
 				filters: dashboard.filters || {},
 				columnOrder: dashboard.columnOrder || [],
+				splitByAssignment: dashboard.splitByAssignment ?? false,
+				severityColors: dashboard.severityColors ?? false,
 				groupBy: dashboard.groupBy || [],
 				query: dashboard.query || '',
 				timeRange: deserializeTimeRange(dashboard.timeRange),
@@ -579,7 +588,7 @@ const Alerts = () => {
 									<Button
 										variant={splitByAssignment ? 'default' : 'outline'}
 										size="sm"
-										onClick={() => setSplitByAssignment((v) => !v)}
+										onClick={handleToggleSplitByAssignment}
 										className="gap-1.5 shrink-0"
 										title="Split into Unassigned and Assigned"
 									>
@@ -591,7 +600,7 @@ const Alerts = () => {
 								<Button
 									variant={severityColors ? 'default' : 'outline'}
 									size="sm"
-									onClick={toggleSeverityColors}
+									onClick={handleToggleSeverityColors}
 									className="gap-1.5 shrink-0"
 									title="Color rows by severity"
 								>

--- a/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
+++ b/apps/client/src/components/Alerts/AlertsTVMode/AlertsTVMode.tsx
@@ -146,6 +146,8 @@ const AlertsTVMode = () => {
 			description: dashboardState.description,
 			filters: dashboardState.filters,
 			visibleColumns: dashboardState.visibleColumns,
+			splitByAssignment: dashboardState.splitByAssignment,
+			severityColors: dashboardState.severityColors,
 			query: dashboardState.query,
 			groupBy: dashboardState.groupBy,
 			timeRange: serializeTimeRange(dashboardState.timeRange),

--- a/apps/client/src/context/DashboardContext.tsx
+++ b/apps/client/src/context/DashboardContext.tsx
@@ -33,6 +33,10 @@ export interface DashboardState {
 	visibleColumns: string[];
 	filters: Record<string, string[]>;
 	columnOrder: string[];
+	// Persist the "Split by owner" toggle with the dashboard.
+	splitByAssignment: boolean;
+	// Persist the "Severity colors" toggle with the dashboard.
+	severityColors: boolean;
 	groupBy: string[];
 	query: string;
 	timeRange: TimeRange;
@@ -63,6 +67,8 @@ const defaultState: DashboardState = {
 	visibleColumns: [],
 	filters: {},
 	columnOrder: [],
+	splitByAssignment: false,
+	severityColors: false,
 	groupBy: [],
 	query: '',
 	timeRange: { from: null, to: null, preset: null },
@@ -113,6 +119,10 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 		// strings), so the stringified comparison is stable.
 		const currentTimeRange = JSON.stringify(serializeTimeRange(dashboardState.timeRange));
 		const initialTimeRange = JSON.stringify(serializeTimeRange(initialState.timeRange));
+		const currentSplitByAssignment = dashboardState.splitByAssignment;
+		const initialSplitByAssignment = initialState.splitByAssignment;
+		const currentSeverityColors = dashboardState.severityColors;
+		const initialSeverityColors = initialState.severityColors;
 
 		return (
 			currentName !== initialName ||
@@ -122,7 +132,9 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 			currentVisibleColumns !== initialVisibleColumns ||
 			currentColumnOrder !== initialColumnOrder ||
 			currentQuery !== initialQuery ||
-			currentTimeRange !== initialTimeRange
+			currentTimeRange !== initialTimeRange ||
+			currentSplitByAssignment !== initialSplitByAssignment ||
+			currentSeverityColors !== initialSeverityColors
 		);
 	}, [dashboardState, initialState, hasUserMadeChanges]);
 
@@ -136,6 +148,8 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
 			'columnOrder',
 			'query',
 			'timeRange',
+			'splitByAssignment',
+			'severityColors',
 		];
 		if (userEditableFields.includes(field)) {
 			setHasUserMadeChanges(true);

--- a/apps/client/src/hooks/queries/dashboards/dashboards.types.ts
+++ b/apps/client/src/hooks/queries/dashboards/dashboards.types.ts
@@ -9,6 +9,10 @@ export interface Dashboard {
 	visibleColumns: string[];
 	// User-arranged base-column order; absent on dashboards saved before reordering shipped.
 	columnOrder?: string[];
+	// Persist the "Split by owner" toggle with the dashboard.
+	splitByAssignment?: boolean;
+	// Persist the "Severity colors" toggle with the dashboard.
+	severityColors?: boolean;
 	query: string;
 	groupBy: string[];
 	timeRange?: DashboardTimeRange;
@@ -22,6 +26,8 @@ export interface CreateDashboardInput {
 	filters: Record<string, string[]>;
 	visibleColumns: string[];
 	columnOrder?: string[];
+	splitByAssignment?: boolean;
+	severityColors?: boolean;
 	query: string;
 	groupBy: string[];
 	timeRange?: DashboardTimeRange;

--- a/apps/server/src/dal/dashboardRepository.ts
+++ b/apps/server/src/dal/dashboardRepository.ts
@@ -16,6 +16,8 @@ export class DashboardRepository {
 			visibleColumns: JSON.parse(dashboardRow.visible_columns) as string[],
 			query: dashboardRow.query,
 			columnOrder: dashboardRow.column_order ? (JSON.parse(dashboardRow.column_order) as string[]) : undefined,
+			splitByAssignment: dashboardRow.split_by_assignment ?? undefined,
+			severityColors: dashboardRow.severity_colors ?? undefined,
 			groupBy: JSON.parse(dashboardRow.group_by) as string[],
 			timeRange: dashboardRow.time_range
 				? (JSON.parse(dashboardRow.time_range) as DashboardTimeRange)
@@ -41,8 +43,8 @@ export class DashboardRepository {
 	async createDashboard(dashboard: Omit<Dashboard, 'createdAt' | 'id'>): Promise<number> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
-                INSERT INTO dashboards (name, type, description, filters, visible_columns, column_order, query, group_by, time_range)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO dashboards (name, type, description, filters, visible_columns, column_order, split_by_assignment, severity_colors, query, group_by, time_range)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             `);
 			const result = stmt.run(
 				dashboard.name,
@@ -51,6 +53,8 @@ export class DashboardRepository {
 				JSON.stringify(dashboard.filters),
 				JSON.stringify(dashboard.visibleColumns),
 				dashboard.columnOrder ? JSON.stringify(dashboard.columnOrder) : null,
+				dashboard.splitByAssignment ?? null,
+				dashboard.severityColors ?? null,
 				dashboard.query,
 				JSON.stringify(dashboard.groupBy),
 				dashboard.timeRange ? JSON.stringify(dashboard.timeRange) : null
@@ -97,6 +101,14 @@ export class DashboardRepository {
 			if (!columns.some((col) => col.name === 'column_order')) {
 				this.db.prepare(`ALTER TABLE dashboards ADD COLUMN column_order TEXT`).run();
 			}
+			// Backward compatibility: persist "Split by owner" and "Severity colors" toggles.
+			const columnsAfter = this.db.prepare(`PRAGMA table_info(dashboards)`).all() as TableInfoRow[];
+			if (!columnsAfter.some((col) => col.name === 'split_by_assignment')) {
+				this.db.prepare(`ALTER TABLE dashboards ADD COLUMN split_by_assignment INTEGER`).run();
+			}
+			if (!columnsAfter.some((col) => col.name === 'severity_colors')) {
+				this.db.prepare(`ALTER TABLE dashboards ADD COLUMN severity_colors INTEGER`).run();
+			}
 		});
 	}
 
@@ -111,6 +123,8 @@ export class DashboardRepository {
                 filters = ?,
                 visible_columns = ?,
                 column_order = ?,
+                split_by_assignment = ?,
+                severity_colors = ?,
                 query = ?,
                 group_by = ?,
                 time_range = ?
@@ -124,6 +138,8 @@ export class DashboardRepository {
 				JSON.stringify(dashboard.filters),
 				JSON.stringify(dashboard.visibleColumns),
 				dashboard.columnOrder ? JSON.stringify(dashboard.columnOrder) : null,
+				dashboard.splitByAssignment ?? null,
+				dashboard.severityColors ?? null,
 				dashboard.query,
 				JSON.stringify(dashboard.groupBy),
 				dashboard.timeRange ? JSON.stringify(dashboard.timeRange) : null,

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -48,6 +48,8 @@ export interface DashboardRow {
 	filters: string; // Record<string, string>
 	visible_columns: string; // string[]
 	column_order?: string | null; // string[]
+	split_by_assignment?: boolean | null; // boolean
+	severity_colors?: boolean | null; // boolean
 	query: string;
 	group_by: string; // string[]
 	time_range?: string | null; // DashboardTimeRange

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -263,6 +263,8 @@ export const CreateDashboardSchema = z.object({
 	filters: z.record(z.unknown()),
 	visibleColumns: z.array(z.string()),
 	columnOrder: z.array(z.string()).optional(),
+	splitByAssignment: z.boolean().optional(),
+	severityColors: z.boolean().optional(),
 	query: z.string(),
 	groupBy: z.array(z.string()),
 	timeRange: z

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -355,6 +355,13 @@ export interface Dashboard {
 	// User-arranged column order for the alerts table (base columns; tag-key columns
 	// follow the visible list). Absent on dashboards saved before reordering shipped.
 	columnOrder?: string[];
+	// Persist the "Split by owner" toggle so a saved dashboard reproduces the exact
+	// view the user works with. Absent on legacy dashboards (defaults to false).
+	splitByAssignment?: boolean;
+	// Persist the "Severity colors" toggle (row tinting by severity) with the dashboard.
+	// When both a dashboard value and the legacy localStorage value exist, the dashboard
+	// value wins on load; localStorage remains the fallback for unsaved drafts.
+	severityColors?: boolean;
 	query: string;
 	groupBy: string[];
 	timeRange?: DashboardTimeRange;


### PR DESCRIPTION
Store the 'Split by owner' and 'Severity colors' toolbar toggles as dashboard fields so a saved dashboard reproduces the exact view the user worked with. Follows the established pattern from #707.

Closes #714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard preferences for “Split by owner” and “Severity colors” are now saved and restored automatically.
  * Toolbar controls update the active dashboard’s saved settings.
  * Preferences remain available when dashboards are viewed in TV mode.
* **Bug Fixes**
  * Dashboard preference changes are now included when saving and detecting unsaved changes.
  * Existing dashboards continue to work with the new settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->