### PR TITLE
fix: URL-encode alert IDs in API request paths

### DIFF
--- a/apps/client/src/hooks/queries/alertComments/alertComments.api.ts
+++ b/apps/client/src/hooks/queries/alertComments/alertComments.api.ts
@@ -3,7 +3,7 @@ import { AlertComment } from '@OpsiMate/shared';
 
 export const alertCommentsApi = {
 	getCommentsByAlertId: async (alertId: string): Promise<ApiResponse<{ comments: AlertComment[] }>> => {
-		return apiRequest<{ comments: AlertComment[] }>(`/alerts/${alertId}/comments`, 'GET');
+		return apiRequest<{ comments: AlertComment[] }>(`/alerts/${encodeURIComponent(alertId)}/comments`, 'GET');
 	},
 
 	createComment: async (
@@ -11,7 +11,10 @@ export const alertCommentsApi = {
 		userId: string,
 		comment: string
 	): Promise<ApiResponse<{ comment: AlertComment }>> => {
-		return apiRequest<{ comment: AlertComment }>(`/alerts/${alertId}/comments`, 'POST', { userId, comment });
+		return apiRequest<{ comment: AlertComment }>(`/alerts/${encodeURIComponent(alertId)}/comments`, 'POST', {
+			userId,
+			comment,
+		});
 	},
 
 	updateComment: async (commentId: string, comment: string): Promise<ApiResponse<{ comment: AlertComment }>> => {

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -543,6 +543,9 @@ export const integrationApi = {
 /**
  * Alerts API endpoints
  */
+// Alert IDs are caller-supplied (custom alerts API) and may contain URL-hostile
+// characters (#, /, ?, %); any ID placed in a request path must be encoded or the
+// browser truncates/mangles the URL.
 export const alertsApi = {
 	// Get all alerts
 	async getAllAlerts(): Promise<ApiResponse<{ alerts: SharedAlert[] }>> {
@@ -555,7 +558,7 @@ export const alertsApi = {
 		alertId: string,
 		options?: { silencedUntil?: string | null; comment?: string }
 	): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/silence`, 'PATCH', {
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${encodeURIComponent(alertId)}/silence`, 'PATCH', {
 			silencedUntil: options?.silencedUntil ?? null,
 			comment: options?.comment,
 		});
@@ -563,21 +566,25 @@ export const alertsApi = {
 
 	// Unsilence an alert
 	async unsilenceAlert(alertId: string): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/unsilence`, 'PATCH');
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${encodeURIComponent(alertId)}/unsilence`, 'PATCH');
 	},
 
 	// Delete an alert (the UI's manual resolve); an optional note is stored as a comment.
 	async deleteAlert(alertId: string, comment?: string): Promise<ApiResponse<void>> {
-		return await apiRequest<void>(`/alerts/${alertId}`, 'DELETE', comment ? { comment } : undefined);
+		return await apiRequest<void>(
+			`/alerts/${encodeURIComponent(alertId)}`,
+			'DELETE',
+			comment ? { comment } : undefined
+		);
 	},
 
 	// Mark alert as read (unread alerts render bold in the table)
 	async markAlertRead(alertId: string): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/read`, 'PATCH');
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${encodeURIComponent(alertId)}/read`, 'PATCH');
 	},
 
 	getAlertHistory: (alertId: string) => {
-		return apiRequest<AlertHistory>(`/alerts/${alertId}/history`, 'GET');
+		return apiRequest<AlertHistory>(`/alerts/${encodeURIComponent(alertId)}/history`, 'GET');
 	},
 
 	// Get alerts by tag
@@ -617,22 +624,31 @@ export const alertsApi = {
 
 	// Delete an resolved alert permanently
 	async deleteResolvedAlert(alertId: string): Promise<ApiResponse<void>> {
-		return await apiRequest<void>(`/alerts/resolved/${alertId}`, 'DELETE');
+		return await apiRequest<void>(`/alerts/resolved/${encodeURIComponent(alertId)}`, 'DELETE');
 	},
 
 	// Move a resolved alert back to the active (firing) list
 	async unresolveAlert(alertId: string): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/resolved/${alertId}/unresolve`, 'PATCH');
+		return await apiRequest<{ alert: SharedAlert }>(
+			`/alerts/resolved/${encodeURIComponent(alertId)}/unresolve`,
+			'PATCH'
+		);
 	},
 
 	// Set alert owner
 	async setAlertOwner(alertId: string, ownerId: string | null): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${alertId}/owner`, 'PATCH', { ownerId });
+		return await apiRequest<{ alert: SharedAlert }>(`/alerts/${encodeURIComponent(alertId)}/owner`, 'PATCH', {
+			ownerId,
+		});
 	},
 
 	// Set resolved alert owner
 	async setResolvedAlertOwner(alertId: string, ownerId: string | null): Promise<ApiResponse<{ alert: SharedAlert }>> {
-		return await apiRequest<{ alert: SharedAlert }>(`/alerts/resolved/${alertId}/owner`, 'PATCH', { ownerId });
+		return await apiRequest<{ alert: SharedAlert }>(
+			`/alerts/resolved/${encodeURIComponent(alertId)}/owner`,
+			'PATCH',
+			{ ownerId }
+		);
 	},
 };
 


### PR DESCRIPTION
## Problem

Alert IDs are caller-supplied (custom-alerts API) and may contain URL-hostile characters. For an alert with id `demo#42`, every per-alert client call built its URL by raw interpolation — and the browser treats `#` as the start of the URL fragment, silently truncating the request path:

```
GET /alerts/demo#42/history   →  actually sent as  GET /alerts/demo   →  404
```

Verified live: the server stores and processes such IDs correctly everywhere — the break is purely in URL construction on the client.

### Blast radius (all confirmed against the dev app)
- History panel loads empty
- Comments can't be loaded or added
- Silence / unsilence, resolve, unresolve, delete, delete-resolved, mark-as-read, set-owner: all 404
- mark-as-read failing means the alert stays bold/unread forever
- If another alert's ID equals the truncated prefix (`demo` vs `demo#42`), actions land on the **wrong alert** — a silent cross-alert hit, not just a 404
- `/`, `?`, and `%` in IDs corrupt paths the same way

## Fix

`encodeURIComponent()` at all 11 path-interpolation sites (9 in `lib/api.ts`, 2 in `alertComments.api.ts`). Express decodes percent-encoding in route params automatically, so zero server changes. Bulk endpoints already send IDs in the request body and were unaffected.

## Verification

E2E against the dev app with a real `demo#42` alert through the UI:

| Action | Before | After |
|---|---|---|
| Open details → history | `GET /alerts/demo` → 404 | `GET /alerts/demo%2342/history` → 200 |
| Open details → comments | `GET /alerts/demo` → 404 | `GET /alerts/demo%2342/comments` → 200 |
| Silence via row menu | `PATCH /alerts/demo` → 404 | `PATCH /alerts/demo%2342/silence` → 200 |
| Unsilence | — | `PATCH /alerts/demo%2342/unsilence` → 200 |

Client tests 47/47, tsc/lint/format at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alert-related requests for IDs containing special characters.
  - Fixed URL handling across alert comments, silencing, deletion, history, resolution, and ownership actions.
  - Preserved existing request and response behavior while improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->