### PR TITLE
fix: stop the alert name column from ballooning on wide screens

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -1,9 +1,10 @@
+import { Fragment } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TableCell, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { Alert } from '@OpsiMate/shared';
-import { ACTIONS_COLUMN, COLUMN_WIDTHS, getColumnWidthClass, SELECT_COLUMN_WIDTH } from '../AlertsTable.constants';
+import { ACTIONS_COLUMN, COLUMN_WIDTHS, SELECT_COLUMN_WIDTH } from '../AlertsTable.constants';
 import { CELL_PADDING } from './AlertRow.constants';
 import { getAlertSeverity, SEVERITY_ROW_CLASSES } from '../../utils/severity.utils';
 import { AlertActionsColumn } from './Columns/AlertActionsColumn';
@@ -151,7 +152,7 @@ export const AlertRow = ({
 								key={column}
 								alert={alert}
 								expanded={expandRows}
-								className={getColumnWidthClass('alertName', orderedColumns)}
+								className={COLUMN_WIDTHS.alertName}
 							/>
 						);
 					case 'severity':
@@ -182,15 +183,19 @@ export const AlertRow = ({
 						return <AlertUpdatedAtColumn key={column} alert={alert} className={COLUMN_WIDTHS.updatedAt} />;
 					case ACTIONS_COLUMN:
 						return (
-							<AlertActionsColumn
-								key={column}
-								alert={alert}
-								width={actionsColumnWidth}
-								onSilenceAlert={onSilenceAlert}
-								onUnsilenceAlert={onUnsilenceAlert}
-								onDeleteAlert={onDeleteAlert}
-								onUnresolveAlert={onUnresolveAlert}
-							/>
+							<Fragment key={column}>
+								{/* Mirrors the header's filler (see AlertsTable): when summary is
+								    hidden this empty flexible cell absorbs the leftover width. */}
+								{!orderedColumns.includes('summary') && <TableCell aria-hidden className="p-0" />}
+								<AlertActionsColumn
+									alert={alert}
+									width={actionsColumnWidth}
+									onSilenceAlert={onSilenceAlert}
+									onUnsilenceAlert={onUnsilenceAlert}
+									onDeleteAlert={onDeleteAlert}
+									onUnresolveAlert={onUnresolveAlert}
+								/>
+							</Fragment>
 						);
 					default:
 						return null;

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -22,6 +22,8 @@ export interface AlertRowProps {
 	alert: Alert;
 	isSelected: boolean;
 	orderedColumns: string[];
+	// Content-aware pixel widths for alertName/tag columns; must match the header's.
+	contentColumnWidths?: Record<string, number>;
 	onSelectAlert: (alert: Alert) => void;
 	onAlertClick?: (alert: Alert) => void;
 	// True when this alert is the one open in the details panel.
@@ -48,6 +50,7 @@ export const AlertRow = ({
 	alert,
 	isSelected,
 	orderedColumns,
+	contentColumnWidths = {},
 	onSelectAlert,
 	onAlertClick,
 	isActiveRow = false,
@@ -137,6 +140,7 @@ export const AlertRow = ({
 								tagKey={tagKey}
 								expanded={expandRows}
 								className={COLUMN_WIDTHS.default}
+								style={contentColumnWidths[column] ? { width: contentColumnWidths[column] } : undefined}
 							/>
 						);
 					}
@@ -153,6 +157,11 @@ export const AlertRow = ({
 								alert={alert}
 								expanded={expandRows}
 								className={COLUMN_WIDTHS.alertName}
+								style={
+									contentColumnWidths['alertName']
+										? { width: contentColumnWidths['alertName'] }
+										: undefined
+								}
 							/>
 						);
 					case 'severity':

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -3,7 +3,7 @@ import { TableCell, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { Alert } from '@OpsiMate/shared';
-import { ACTIONS_COLUMN, COLUMN_WIDTHS, SELECT_COLUMN_WIDTH } from '../AlertsTable.constants';
+import { ACTIONS_COLUMN, COLUMN_WIDTHS, getColumnWidthClass, SELECT_COLUMN_WIDTH } from '../AlertsTable.constants';
 import { CELL_PADDING } from './AlertRow.constants';
 import { getAlertSeverity, SEVERITY_ROW_CLASSES } from '../../utils/severity.utils';
 import { AlertActionsColumn } from './Columns/AlertActionsColumn';
@@ -151,7 +151,7 @@ export const AlertRow = ({
 								key={column}
 								alert={alert}
 								expanded={expandRows}
-								className={COLUMN_WIDTHS.alertName}
+								className={getColumnWidthClass('alertName', orderedColumns)}
 							/>
 						);
 					case 'severity':

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -7,11 +7,13 @@ export interface AlertNameColumnProps {
 	// Wrap the full name onto new lines instead of truncating (the "expand rows" toggle).
 	expanded?: boolean;
 	className?: string;
+	// Inline width for content-aware sizing; wins over any width class.
+	style?: React.CSSProperties;
 }
 
-export const AlertNameColumn = ({ alert, expanded = false, className }: AlertNameColumnProps) => {
+export const AlertNameColumn = ({ alert, expanded = false, className, style }: AlertNameColumnProps) => {
 	return (
-		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell style={style} className={cn('py-1 px-2 overflow-hidden', className)}>
 			<span
 				className={cn(
 					'text-sm block text-foreground',

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertTagKeyColumn/AlertTagKeyColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertTagKeyColumn/AlertTagKeyColumn.tsx
@@ -9,13 +9,15 @@ export interface AlertTagKeyColumnProps {
 	// Wrap the full value onto new lines instead of truncating (the "expand rows" toggle).
 	expanded?: boolean;
 	className?: string;
+	// Inline width for content-aware sizing; wins over any width class.
+	style?: React.CSSProperties;
 }
 
-export const AlertTagKeyColumn = ({ alert, tagKey, expanded = false, className }: AlertTagKeyColumnProps) => {
+export const AlertTagKeyColumn = ({ alert, tagKey, expanded = false, className, style }: AlertTagKeyColumnProps) => {
 	const value = alert.tags?.[tagKey];
 
 	return (
-		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell style={style} className={cn('py-1 px-2 overflow-hidden', className)}>
 			{value ? (
 				<Badge
 					variant="outline"

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -37,9 +37,11 @@ export const COLUMN_LABELS: Record<string, string> = {
 // space (the table is layout-fixed). Exactly ONE flexible column, on purpose: with two
 // w-auto columns the leftover was split equally, so on wide screens the name column
 // ballooned with whitespace while summary — the column with the long content — couldn't
-// use it. Percentage widths are deliberately avoided: with enough columns visible their
-// sum exceeded the table's width and the auto-width summary column silently collapsed
-// to 0px, letting neighbors paint over it.
+// use it. When summary is hidden, an empty filler column (rendered before ACTIONS in
+// both the header and the rows) takes the flexible role, so the leftover stays as blank
+// space instead of inflating a data column. Percentage widths are deliberately avoided:
+// with enough columns visible their sum exceeded the table's width and the auto-width
+// summary column silently collapsed to 0px, letting neighbors paint over it.
 export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
 	// Type, severity and status are icon-only columns (icon-only headers too, names in
@@ -53,19 +55,7 @@ export const COLUMN_WIDTHS: Record<string, string> = {
 	startsAt: 'w-[150px]',
 	updatedAt: 'w-[150px]',
 	[ACTIONS_COLUMN]: 'w-14 min-w-14 max-w-14',
-	default: 'w-[110px]',
-};
-
-// Width class for a column given which columns are shown. The table must always have
-// exactly one flexible column: summary normally, and alertName when summary is hidden
-// (otherwise no column absorbs the leftover and every fixed column stretches). Header
-// and body render as SEPARATE tables, so both MUST size columns through this helper —
-// diverging classes shift the two layouts out of alignment.
-export const getColumnWidthClass = (column: string, orderedColumns: string[]): string => {
-	if (column === 'alertName' && !orderedColumns.includes('summary')) {
-		return 'w-auto';
-	}
-	return COLUMN_WIDTHS[column] ?? COLUMN_WIDTHS.default;
+	default: 'w-[150px]',
 };
 
 // Per-column minimums (px) summed into the table's floor width: the table never renders
@@ -76,8 +66,7 @@ export const COLUMN_MIN_WIDTHS: Record<string, number> = {
 	type: 48,
 	severity: 48,
 	status: 48,
-	// Matches the fixed w-[240px]; still holds as a floor in the fallback case where
-	// alertName turns flexible (summary hidden).
+	// Matches the fixed w-[240px].
 	alertName: 240,
 	summary: 170,
 	owner: 120,
@@ -85,5 +74,5 @@ export const COLUMN_MIN_WIDTHS: Record<string, number> = {
 	updatedAt: 150,
 	// Rendered at ACTIONS_COLUMN_WIDTH (inline style), not COLUMN_WIDTHS.
 	[ACTIONS_COLUMN]: 80,
-	default: 110,
+	default: 150,
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -66,13 +66,13 @@ export const COLUMN_MIN_WIDTHS: Record<string, number> = {
 	type: 48,
 	severity: 48,
 	status: 48,
-	// Matches the fixed w-[240px].
-	alertName: 240,
+	// Shrink floor; the rendered width is content-aware (useContentColumnWidths).
+	alertName: 170,
 	summary: 170,
 	owner: 120,
 	startsAt: 150,
 	updatedAt: 150,
 	// Rendered at ACTIONS_COLUMN_WIDTH (inline style), not COLUMN_WIDTHS.
 	[ACTIONS_COLUMN]: 80,
-	default: 150,
+	default: 110,
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -33,16 +33,19 @@ export const COLUMN_LABELS: Record<string, string> = {
 	updatedAt: 'Last Update',
 };
 
-// Every column except alertName and summary has a fixed width; those two share the
-// leftover space equally (the table is layout-fixed). Percentage widths are deliberately
-// avoided: with enough columns visible their sum exceeded the table's width and the
-// auto-width summary column silently collapsed to 0px, letting neighbors paint over it.
+// Every column except summary has a fixed width; summary alone absorbs the leftover
+// space (the table is layout-fixed). Exactly ONE flexible column, on purpose: with two
+// w-auto columns the leftover was split equally, so on wide screens the name column
+// ballooned with whitespace while summary — the column with the long content — couldn't
+// use it. Percentage widths are deliberately avoided: with enough columns visible their
+// sum exceeded the table's width and the auto-width summary column silently collapsed
+// to 0px, letting neighbors paint over it.
 export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
 	// Type, severity and status are icon-only columns (icon-only headers too, names in
 	// tooltips).
 	type: 'w-12 min-w-12 max-w-12',
-	alertName: 'w-auto',
+	alertName: 'w-[240px]',
 	severity: 'w-12 min-w-12 max-w-12',
 	status: 'w-12 min-w-12 max-w-12',
 	summary: 'w-auto',
@@ -53,6 +56,18 @@ export const COLUMN_WIDTHS: Record<string, string> = {
 	default: 'w-[110px]',
 };
 
+// Width class for a column given which columns are shown. The table must always have
+// exactly one flexible column: summary normally, and alertName when summary is hidden
+// (otherwise no column absorbs the leftover and every fixed column stretches). Header
+// and body render as SEPARATE tables, so both MUST size columns through this helper —
+// diverging classes shift the two layouts out of alignment.
+export const getColumnWidthClass = (column: string, orderedColumns: string[]): string => {
+	if (column === 'alertName' && !orderedColumns.includes('summary')) {
+		return 'w-auto';
+	}
+	return COLUMN_WIDTHS[column] ?? COLUMN_WIDTHS.default;
+};
+
 // Per-column minimums (px) summed into the table's floor width: the table never renders
 // narrower than its visible columns' minimums — below that the whole table (header and
 // body together) scrolls horizontally instead of crushing a column.
@@ -61,9 +76,9 @@ export const COLUMN_MIN_WIDTHS: Record<string, number> = {
 	type: 48,
 	severity: 48,
 	status: 48,
-	// The two flexible (w-auto) columns split leftover space equally, so they share
-	// one minimum — declaring different ones would be unenforceable.
-	alertName: 170,
+	// Matches the fixed w-[240px]; still holds as a floor in the fallback case where
+	// alertName turns flexible (summary hidden).
+	alertName: 240,
 	summary: 170,
 	owner: 120,
 	startsAt: 150,

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Activity, Plug, TriangleAlert, WrapText } from 'lucide-react';
-import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertsEmptyState } from './AlertsEmptyState';
 import {
 	ACTIONS_COLUMN,
@@ -15,7 +15,6 @@ import {
 	COLUMN_LABELS,
 	COLUMN_MIN_WIDTHS,
 	COLUMN_WIDTHS,
-	getColumnWidthClass,
 	DEFAULT_COLUMN_ORDER,
 	DEFAULT_VISIBLE_COLUMNS,
 	SELECT_COLUMN_WIDTH,
@@ -116,6 +115,12 @@ export const AlertsTable = ({
 		return [...filtered, ACTIONS_COLUMN];
 	}, [columnOrder, visibleColumns]);
 
+	// Summary is the table's one flexible column. When it's hidden, an empty filler
+	// column before ACTIONS absorbs the leftover width instead — otherwise the browser
+	// hands the surplus to a data column (huge whitespace) or stretches every fixed
+	// column. The rows render the same filler (AlertRow) or the layouts misalign.
+	const needsFillerColumn = !orderedColumns.includes('summary');
+
 	// The actions header holds two buttons (expand rows + group by), or three when column
 	// settings are enabled — the column must widen with it or the extra button overflows
 	// the fixed <th> onto the neighboring column's header text.
@@ -195,66 +200,70 @@ export const AlertsTable = ({
 											{orderedColumns.map((column) => {
 												if (column === ACTIONS_COLUMN) {
 													return (
-														<TableHead
-															key={column}
-															className={`${TABLE_HEAD_CLASSES} text-xs`}
-															style={{
-																width: actionsColumnWidth,
-																minWidth: actionsColumnWidth,
-																maxWidth: actionsColumnWidth,
-															}}
-														>
-															<div className="flex items-center justify-end gap-2 min-w-0">
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Button
-																			variant="ghost"
-																			size="icon"
-																			className={cn(
-																				'h-7 w-7 rounded-md shrink-0 border hover:bg-muted hover:text-foreground',
-																				expandRows &&
-																					'text-primary border-primary'
-																			)}
-																			onClick={() =>
-																				setExpandRows((prev) => !prev)
-																			}
-																			aria-label={
-																				expandRows
-																					? 'Collapse rows'
-																					: 'Expand rows'
-																			}
-																			aria-pressed={expandRows}
-																		>
-																			<WrapText className="h-4 w-4" />
-																		</Button>
-																	</TooltipTrigger>
-																	<TooltipContent>
-																		{expandRows
-																			? 'Collapse rows'
-																			: 'Expand rows to show full content'}
-																	</TooltipContent>
-																</Tooltip>
-																<GroupByControls
-																	groupByColumns={groupByColumns}
-																	onGroupByChange={setGroupByColumns}
-																	availableColumns={visibleColumns}
-																	columnLabels={allColumnLabels}
-																	onExpandAll={expandAll}
-																	onCollapseAll={collapseAll}
-																/>
-																{onColumnToggle && (
-																	<ColumnSettingsDropdown
-																		visibleColumns={visibleColumns}
-																		onColumnToggle={onColumnToggle}
-																		columnLabels={COLUMN_LABELS}
-																		columnOrder={columnOrder}
-																		onColumnOrderChange={onColumnOrderChange}
-																		excludeColumns={[ACTIONS_COLUMN]}
-																		tagKeys={tagKeys}
+														<Fragment key={column}>
+															{needsFillerColumn && (
+																<TableHead aria-hidden className="p-0" />
+															)}
+															<TableHead
+																className={`${TABLE_HEAD_CLASSES} text-xs`}
+																style={{
+																	width: actionsColumnWidth,
+																	minWidth: actionsColumnWidth,
+																	maxWidth: actionsColumnWidth,
+																}}
+															>
+																<div className="flex items-center justify-end gap-2 min-w-0">
+																	<Tooltip>
+																		<TooltipTrigger asChild>
+																			<Button
+																				variant="ghost"
+																				size="icon"
+																				className={cn(
+																					'h-7 w-7 rounded-md shrink-0 border hover:bg-muted hover:text-foreground',
+																					expandRows &&
+																						'text-primary border-primary'
+																				)}
+																				onClick={() =>
+																					setExpandRows((prev) => !prev)
+																				}
+																				aria-label={
+																					expandRows
+																						? 'Collapse rows'
+																						: 'Expand rows'
+																				}
+																				aria-pressed={expandRows}
+																			>
+																				<WrapText className="h-4 w-4" />
+																			</Button>
+																		</TooltipTrigger>
+																		<TooltipContent>
+																			{expandRows
+																				? 'Collapse rows'
+																				: 'Expand rows to show full content'}
+																		</TooltipContent>
+																	</Tooltip>
+																	<GroupByControls
+																		groupByColumns={groupByColumns}
+																		onGroupByChange={setGroupByColumns}
+																		availableColumns={visibleColumns}
+																		columnLabels={allColumnLabels}
+																		onExpandAll={expandAll}
+																		onCollapseAll={collapseAll}
 																	/>
-																)}
-															</div>
-														</TableHead>
+																	{onColumnToggle && (
+																		<ColumnSettingsDropdown
+																			visibleColumns={visibleColumns}
+																			onColumnToggle={onColumnToggle}
+																			columnLabels={COLUMN_LABELS}
+																			columnOrder={columnOrder}
+																			onColumnOrderChange={onColumnOrderChange}
+																			excludeColumns={[ACTIONS_COLUMN]}
+																			tagKeys={tagKeys}
+																		/>
+																	)}
+																</div>
+															</TableHead>
+														</Fragment>
 													);
 												}
 												if (isTagKeyColumn(column)) {
@@ -293,7 +302,7 @@ export const AlertsTable = ({
 															sortField={sortField}
 															sortDirection={sortDirection}
 															onSort={handleSort}
-															className={getColumnWidthClass(column, orderedColumns)}
+															className={COLUMN_WIDTHS[column]}
 														/>
 													);
 												}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -24,7 +24,14 @@ import { AlertSortField, AlertsTableProps } from './AlertsTable.types';
 import { filterAlerts } from './AlertsTable.utils';
 import { ColumnSettingsDropdown } from './ColumnSettingsDropdown';
 import { GroupByControls } from './GroupByControls';
-import { useAlertGrouping, useAlertSelection, useAlertSorting, useDragSelection, useStickyHeaders } from './hooks';
+import {
+	useAlertGrouping,
+	useAlertSelection,
+	useAlertSorting,
+	useContentColumnWidths,
+	useDragSelection,
+	useStickyHeaders,
+} from './hooks';
 import { SearchBar } from './SearchBar';
 import { SortableHeader } from './SortableHeader';
 import { StickyGroupHeader } from './StickyGroupHeader';
@@ -69,6 +76,18 @@ export const AlertsTable = ({
 	heading,
 }: AlertsTableProps) => {
 	const parentRef = useRef<HTMLDivElement>(null);
+
+	// Width of the horizontal scroll container, tracked so content-aware column widths
+	// can react to window/pane resizes.
+	const scrollerRef = useRef<HTMLDivElement>(null);
+	const [containerWidth, setContainerWidth] = useState(0);
+	useEffect(() => {
+		const el = scrollerRef.current;
+		if (!el) return;
+		const observer = new ResizeObserver((entries) => setContainerWidth(entries[0]?.contentRect.width ?? 0));
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
 
 	// Expanded rows: cell content wraps onto new lines (full name/summary/labels)
 	// instead of truncating to a single line.
@@ -126,6 +145,18 @@ export const AlertsTable = ({
 	// the fixed <th> onto the neighboring column's header text.
 	const actionsColumnWidth = onColumnToggle ? ACTIONS_COLUMN_WIDTH_WITH_SETTINGS : ACTIONS_COLUMN_WIDTH;
 
+	// Pixel widths for the content-sized columns (alert name + tags): wide enough that
+	// their longest value fits, no wider. Empty until the container is first measured —
+	// static width classes cover that frame.
+	const contentColumnWidths = useContentColumnWidths({
+		alerts: sortedAlerts,
+		orderedColumns,
+		columnLabels: allColumnLabels,
+		containerWidth,
+		hasSelectColumn: !!onSelectAlerts,
+		actionsColumnWidthPx: parseInt(actionsColumnWidth, 10),
+	});
+
 	// Floor width for the table: the sum of the visible columns' minimums. Narrower
 	// panes get a horizontal scrollbar instead of columns crushing each other.
 	const tableMinWidth = useMemo(() => {
@@ -167,7 +198,7 @@ export const AlertsTable = ({
 					{/* Header and body share this horizontal scroller: when the pane is narrower
 					    than the table's minimum width they scroll sideways together, instead of the
 					    auto-width summary column silently collapsing to zero. */}
-					<div className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden">
+					<div ref={scrollerRef} className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden">
 						<div className="flex h-full flex-col" style={{ minWidth: tableMinWidth }}>
 							{/* overflow-hidden + stable gutter mirrors the body scrollport's reserved
 							    scrollbar gutter (see below) so header and body columns stay aligned on
@@ -278,6 +309,11 @@ export const AlertsTable = ({
 															sortDirection={sortDirection}
 															onSort={handleSort}
 															className={COLUMN_WIDTHS.default}
+															style={
+																contentColumnWidths[column]
+																	? { width: contentColumnWidths[column] }
+																	: undefined
+															}
 														/>
 													);
 												}
@@ -303,6 +339,11 @@ export const AlertsTable = ({
 															sortDirection={sortDirection}
 															onSort={handleSort}
 															className={COLUMN_WIDTHS[column]}
+															style={
+																contentColumnWidths[column]
+																	? { width: contentColumnWidths[column] }
+																	: undefined
+															}
 														/>
 													);
 												}
@@ -346,6 +387,7 @@ export const AlertsTable = ({
 											flatRows={flatRows}
 											selectedAlerts={selectedAlerts}
 											orderedColumns={orderedColumns}
+											contentColumnWidths={contentColumnWidths}
 											expandRows={expandRows}
 											onToggleGroup={toggleGroup}
 											onSelectAlert={handleSelectAlert}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -15,6 +15,7 @@ import {
 	COLUMN_LABELS,
 	COLUMN_MIN_WIDTHS,
 	COLUMN_WIDTHS,
+	getColumnWidthClass,
 	DEFAULT_COLUMN_ORDER,
 	DEFAULT_VISIBLE_COLUMNS,
 	SELECT_COLUMN_WIDTH,
@@ -292,7 +293,7 @@ export const AlertsTable = ({
 															sortField={sortField}
 															sortDirection={sortDirection}
 															onSort={handleSort}
-															className={COLUMN_WIDTHS[column]}
+															className={getColumnWidthClass(column, orderedColumns)}
 														/>
 													);
 												}

--- a/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
@@ -21,6 +21,8 @@ export interface SortableHeaderProps {
 	sortDirection: SortDirection;
 	onSort: (field: AlertSortField) => void;
 	className?: string;
+	// Inline width for content-aware columns; wins over any width class.
+	style?: React.CSSProperties;
 }
 
 export const SortableHeader = ({
@@ -31,6 +33,7 @@ export const SortableHeader = ({
 	sortDirection,
 	onSort,
 	className,
+	style,
 }: SortableHeaderProps) => {
 	const getSortIcon = () => {
 		if (sortField !== column) {
@@ -51,6 +54,7 @@ export const SortableHeader = ({
 
 	return (
 		<TableHead
+			style={style}
 			className={cn('h-8 py-1 px-2 text-xs cursor-pointer hover:bg-muted/50 text-foreground', className)}
 			onClick={handleClick}
 			aria-label={label}

--- a/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/VirtualizedAlertList/VirtualizedAlertList.tsx
@@ -10,6 +10,8 @@ interface VirtualizedAlertListProps {
 	flatRows: FlatGroupItem[];
 	selectedAlerts: Alert[];
 	orderedColumns: string[];
+	// Content-aware pixel widths for alertName/tag columns (see useContentColumnWidths).
+	contentColumnWidths?: Record<string, number>;
 	onToggleGroup: (key: string) => void;
 	onSelectAlert: (alert: Alert) => void;
 	onAlertClick?: (alert: Alert) => void;
@@ -38,6 +40,7 @@ export const VirtualizedAlertList = ({
 	flatRows,
 	selectedAlerts,
 	orderedColumns,
+	contentColumnWidths,
 	onToggleGroup,
 	onSelectAlert,
 	onAlertClick,
@@ -128,6 +131,7 @@ export const VirtualizedAlertList = ({
 								alert={alert}
 								isSelected={isSelected}
 								orderedColumns={orderedColumns}
+								contentColumnWidths={contentColumnWidths}
 								onSelectAlert={onSelectAlert}
 								onAlertClick={onAlertClick}
 								isActiveRow={alert.id === activeAlertId}

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/index.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useAlertSorting';
 export * from './useAlertSelection';
 export * from './useDragSelection';
 export * from './useStickyHeaders';
+export { useContentColumnWidths } from './useContentColumnWidths';

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
@@ -1,0 +1,150 @@
+import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
+import { Alert } from '@OpsiMate/shared';
+import { useMemo } from 'react';
+import { ACTIONS_COLUMN, COLUMN_MIN_WIDTHS } from '../AlertsTable.constants';
+
+// Content-aware sizing for the text columns whose values vary wildly (alert name and
+// tag columns): each gets the width its longest visible value needs — so nothing
+// truncates while free space exists — but no more, so short content doesn't balloon
+// a column into whitespace. CSS can't do this here: the header and every virtualized
+// row are separate layout-fixed tables, so auto layout would size each independently
+// and misalign them; instead we measure the strings and hand both sides one pixel
+// width per column.
+
+// Cell horizontal padding (px-2 both sides).
+const CELL_PADDING_PX = 16;
+// Tag values render inside a badge: its padding, border and radius chrome.
+const BADGE_CHROME_PX = 30;
+// Header labels sit next to a sort icon and its gap.
+const HEADER_CHROME_PX = 34;
+// Growth caps: a single absurdly long value shouldn't claim half the screen — beyond
+// the cap the value truncates (full text stays in the hover tooltip).
+const MAX_ALERT_NAME_PX = 460;
+const MAX_TAG_PX = 480;
+// Shrink floors when space is tight; below the summed floors the table itself scrolls
+// horizontally (tableMinWidth), so columns never crush further.
+const MIN_ALERT_NAME_PX = 170;
+const MIN_TAG_PX = 110;
+
+// Distribute available width over columns that each want `desired` px but can shrink
+// to `floors` px. If everything fits, everyone gets what they want; otherwise columns
+// give up space proportionally to how much slack (desired - floor) they have.
+export const distributeWidths = (
+	desired: Record<string, number>,
+	floors: Record<string, number>,
+	available: number
+): Record<string, number> => {
+	const total = Object.values(desired).reduce((sum, w) => sum + w, 0);
+	if (total <= available) {
+		return desired;
+	}
+	const overflow = total - available;
+	const reducible = Object.keys(desired).reduce(
+		(sum, col) => sum + Math.max(0, desired[col] - (floors[col] ?? 0)),
+		0
+	);
+	if (reducible <= 0 || overflow >= reducible) {
+		return Object.fromEntries(Object.keys(desired).map((col) => [col, floors[col] ?? desired[col]]));
+	}
+	const scale = overflow / reducible;
+	return Object.fromEntries(
+		Object.keys(desired).map((col) => {
+			const floor = floors[col] ?? 0;
+			return [col, Math.round(desired[col] - (desired[col] - floor) * scale)];
+		})
+	);
+};
+
+// Shared canvas context for text measurement (never attached to the DOM).
+let measureContext: CanvasRenderingContext2D | null = null;
+const measureText = (text: string, font: string): number => {
+	if (!measureContext) {
+		measureContext = document.createElement('canvas').getContext('2d');
+	}
+	if (!measureContext) {
+		return 0;
+	}
+	measureContext.font = font;
+	return Math.ceil(measureContext.measureText(text).width);
+};
+
+interface UseContentColumnWidthsOptions {
+	alerts: Alert[];
+	orderedColumns: string[];
+	// Labels for header cells (a tag column's header can be wider than its values).
+	columnLabels: Record<string, string>;
+	// Width of the table's scroll container; 0 before the first measurement, which
+	// disables dynamic sizing (columns fall back to their static classes).
+	containerWidth: number;
+	hasSelectColumn: boolean;
+	actionsColumnWidthPx: number;
+}
+
+// Pixel widths for the content-sized columns (alertName + tag columns), or an empty
+// map when dynamic sizing can't run yet. Fixed icon/date columns keep their static
+// classes; summary (when visible) and the filler column absorb whatever remains.
+export const useContentColumnWidths = ({
+	alerts,
+	orderedColumns,
+	columnLabels,
+	containerWidth,
+	hasSelectColumn,
+	actionsColumnWidthPx,
+}: UseContentColumnWidthsOptions): Record<string, number> => {
+	return useMemo(() => {
+		if (!containerWidth) {
+			return {};
+		}
+		const contentColumns = orderedColumns.filter((col) => col === 'alertName' || isTagKeyColumn(col));
+		if (contentColumns.length === 0) {
+			return {};
+		}
+
+		// Measure at bold: unread rows render bold, and a column sized for the regular
+		// weight would truncate exactly the rows that must stand out.
+		const fontFamily = getComputedStyle(document.body).fontFamily || 'sans-serif';
+		const font = `700 14px ${fontFamily}`;
+
+		const desired: Record<string, number> = {};
+		const floors: Record<string, number> = {};
+		for (const col of contentColumns) {
+			const headerWidth = measureText(columnLabels[col] ?? col, font) + HEADER_CHROME_PX;
+			if (col === 'alertName') {
+				const content = alerts.reduce(
+					(max, alert) => Math.max(max, measureText(alert.alertName ?? '', font)),
+					0
+				);
+				desired[col] = Math.min(
+					Math.max(content + CELL_PADDING_PX, headerWidth, MIN_ALERT_NAME_PX),
+					MAX_ALERT_NAME_PX
+				);
+				floors[col] = MIN_ALERT_NAME_PX;
+			} else {
+				const tagKey = extractTagKeyFromColumnId(col);
+				const content = alerts.reduce(
+					(max, alert) => Math.max(max, measureText((tagKey && alert.tags?.[tagKey]) || '', font)),
+					0
+				);
+				desired[col] = Math.min(
+					Math.max(content + BADGE_CHROME_PX + CELL_PADDING_PX, headerWidth, MIN_TAG_PX),
+					MAX_TAG_PX
+				);
+				floors[col] = MIN_TAG_PX;
+			}
+		}
+
+		// Space the fixed columns claim; summary (when visible) keeps at least its
+		// minimum — anything the content columns leave over flows to it (or, without
+		// summary, to the filler column).
+		let claimed = hasSelectColumn ? 40 : 0;
+		for (const col of orderedColumns) {
+			if (contentColumns.includes(col)) continue;
+			if (col === ACTIONS_COLUMN) {
+				claimed += actionsColumnWidthPx;
+			} else {
+				claimed += COLUMN_MIN_WIDTHS[col] ?? COLUMN_MIN_WIDTHS.default;
+			}
+		}
+		return distributeWidths(desired, floors, containerWidth - claimed);
+	}, [alerts, orderedColumns, columnLabels, containerWidth, hasSelectColumn, actionsColumnWidthPx]);
+};

--- a/apps/client/src/test/distributeWidths.test.ts
+++ b/apps/client/src/test/distributeWidths.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { distributeWidths } from '@/components/Alerts/AlertsTable/hooks/useContentColumnWidths';
+
+describe('distributeWidths', () => {
+	it('gives every column its desired width when everything fits', () => {
+		const result = distributeWidths({ a: 200, b: 150 }, { a: 100, b: 100 }, 500);
+		expect(result).toEqual({ a: 200, b: 150 });
+	});
+
+	it('gives every column its desired width when the fit is exact', () => {
+		const result = distributeWidths({ a: 200, b: 150 }, { a: 100, b: 100 }, 350);
+		expect(result).toEqual({ a: 200, b: 150 });
+	});
+
+	it('shrinks columns proportionally to their slack when space is tight', () => {
+		// Overflow 100 over slack 100+50: a gives up 2/3 of the overflow, b 1/3.
+		const result = distributeWidths({ a: 200, b: 150 }, { a: 100, b: 100 }, 250);
+		expect(result.a + result.b).toBe(250);
+		expect(result).toEqual({ a: 133, b: 117 });
+	});
+
+	it('clamps every column to its floor when even the floors overflow', () => {
+		const result = distributeWidths({ a: 200, b: 150 }, { a: 100, b: 100 }, 150);
+		expect(result).toEqual({ a: 100, b: 100 });
+	});
+
+	it('keeps floors when available space is negative', () => {
+		const result = distributeWidths({ a: 200 }, { a: 100 }, -50);
+		expect(result).toEqual({ a: 100 });
+	});
+
+	it('never shrinks a column below its floor', () => {
+		for (const available of [0, 120, 200, 260, 320, 349]) {
+			const result = distributeWidths({ a: 200, b: 150 }, { a: 120, b: 110 }, available);
+			expect(result.a).toBeGreaterThanOrEqual(120);
+			expect(result.b).toBeGreaterThanOrEqual(110);
+		}
+	});
+
+	it('handles a single column', () => {
+		expect(distributeWidths({ a: 300 }, { a: 150 }, 200)).toEqual({ a: 200 });
+		expect(distributeWidths({ a: 300 }, { a: 150 }, 400)).toEqual({ a: 300 });
+	});
+});


### PR DESCRIPTION
## Problem

`alertName` and `summary` were the only two `w-auto` columns in the layout-fixed alerts table. Under CSS fixed table layout, all leftover width is split **equally** among auto columns — so on wide screens the Alert Name column ballooned with whitespace while Summary (the column with actually-long content) couldn't use the space.

Measured on main:

| Viewport | Alert Name | Summary |
|---|---|---|
| 1440px | 211px | 211px |
| 2560px | **771px** | 771px |

Alert names are typically 15–30 chars (~150–250px), so ~500px of the name column was dead space.

## Fix

- Pin `alertName` at `w-[240px]`; `summary` becomes the single flexible column and absorbs all surplus. Long names already truncate with a hover tooltip, and the expand-rows toggle already wraps them.
- New `getColumnWidthClass(column, orderedColumns)` helper: when Summary is hidden, `alertName` falls back to `w-auto` so the table always keeps exactly one flexible column. Both the header and body rows (separate tables in this architecture) size through the helper — diverging classes would shift them out of alignment.
- `COLUMN_MIN_WIDTHS.alertName` raised to 240 to match.

## Verification (live, headless Chromium)

| Config | Result |
|---|---|
| 2560px default | Alert Name 240px, Summary **1302px** (was 771/771) |
| 1440px default | Alert Name 240px, Summary 182px |
| Summary hidden | Alert Name becomes flexible: 422px @1440, 1542px @2560 |
| Both hidden | fixed columns stretch proportionally — no 0px collapse, no overlap |

Header/body cell alignment verified in every config. Client tests 47/47; tsc/lint/format at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert table column sizing for more consistent alignment.
  * Increased the minimum width of alert names to improve readability.
  * Adjusted column behavior when the summary column is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->