### PR TITLE
fix: keep Started At stable across re-pushes and match it to firing history

### DIFF
--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -16,19 +16,11 @@ import {
 import { AlertCommentsRepository } from '../../dal/alertCommentsRepository.ts';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
 import { UserRepository } from '../../dal/userRepository';
+import { toIsoUtc } from '../../utils/time';
 import { EnrichmentBL } from '../enrichments/enrichment.bl';
 import { MutePolicyBL } from '../mute-policies/mutePolicy.bl';
 
 const logger = new Logger('bl/alert.bl');
-
-// Normalizes a timestamp to ISO-8601 UTC. SQLite CURRENT_TIMESTAMP values are
-// "YYYY-MM-DD HH:MM:SS" (UTC, but without a timezone marker); already-ISO values pass through.
-// Guarantees the client receives unambiguous UTC timestamps for display and time-range filtering.
-const toIsoUtc = (value: string): string => {
-	if (!value) return value;
-	const d = value.includes('T') ? new Date(value) : new Date(value.replace(' ', 'T') + 'Z');
-	return isNaN(d.getTime()) ? value : d.toISOString();
-};
 
 export class AlertBL {
 	private mutePolicyBL: MutePolicyBL | null = null;

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -8,6 +8,7 @@ import {
 } from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
+import { toIsoUtc } from '../utils/time';
 import { AlertRow, TableInfoRow } from './models';
 
 export class AlertRepository {
@@ -19,6 +20,12 @@ export class AlertRepository {
 
 	async insertOrUpdateAlert(alert: Omit<SharedAlert, 'createdAt' | 'isSilenced'>): Promise<{ changes: number }> {
 		return runAsync(() => {
+			// starts_at is deliberately NOT in the DO UPDATE clause: "Started At" means when
+			// the current firing episode began. Sources that re-send an active alert with a
+			// fresh startsAt (some push "now" on every notification) must not drag it forward —
+			// the firing-history trigger only fires on INSERT, so a moving starts_at diverges
+			// from the recorded firing time. A new episode (resolve, then re-fire) deletes and
+			// re-inserts the row, which picks up the new starts_at.
 			const stmt = this.db.prepare(`
 				INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -28,7 +35,6 @@ export class AlertRepository {
 											  severity=excluded.severity,
 											  team=excluded.team,
 											  tags=excluded.tags,
-											  starts_at=excluded.starts_at,
 											  updated_at=excluded.updated_at,
 											  alert_url=excluded.alert_url,
 											  alert_name=excluded.alert_name,
@@ -146,6 +152,30 @@ export class AlertRepository {
 				END;
         	`);
 
+			// The trigger's definition changed over time (older versions stamped the insert
+			// moment instead of starts_at), and CREATE TRIGGER IF NOT EXISTS never upgrades
+			// an existing DB — so installs drifted apart. Recreate it whenever the stored
+			// definition doesn't stamp starts_at, so every install runs the current version.
+			const triggerSql = (
+				this.db
+					.prepare(
+						`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'archive_alert_on_insert'`
+					)
+					.get() as { sql: string } | undefined
+			)?.sql;
+			if (triggerSql && !triggerSql.includes('NEW.starts_at')) {
+				this.db.exec(`
+					DROP TRIGGER archive_alert_on_insert;
+					CREATE TRIGGER archive_alert_on_insert
+						AFTER INSERT ON alerts
+						FOR EACH ROW
+					BEGIN
+						INSERT INTO alerts_history (alert_id, status, archived_at)
+						VALUES (NEW.id, NEW.status, NEW.starts_at);
+					END;
+				`);
+			}
+
 			// Backward compatibility: ensure tags column exists
 			const columns = this.db.prepare(`PRAGMA table_info(alerts)`).all() as TableInfoRow[];
 			if (!columns.some((col: TableInfoRow) => col.name === 'is_read')) {
@@ -220,8 +250,10 @@ export class AlertRepository {
 			// Legacy rows (pre-team column) fall back to their team tag.
 			team: row.team ?? tags['team'] ?? null,
 			tags,
-			startsAt: row.starts_at,
-			updatedAt: row.updated_at,
+			// Normalized so the client never receives SQLite's marker-less UTC format
+			// (which browsers would parse as local time and display shifted).
+			startsAt: toIsoUtc(row.starts_at),
+			updatedAt: toIsoUtc(row.updated_at),
 			alertUrl: row.alert_url,
 			alertName: row.alert_name,
 			summary: row.summary,

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -1,4 +1,5 @@
 import { AlertStatus, Alert as SharedAlert, AlertHistory, normalizeAlertSeverity } from '@OpsiMate/shared';
+import { toIsoUtc } from '../utils/time';
 import Database from 'better-sqlite3';
 import { runAsync } from './db';
 import { ResolvedAlertRow, TableInfoRow } from './models';
@@ -179,8 +180,8 @@ export class ResolvedAlertRepository {
 			team: row.team ?? tags['team'] ?? null,
 			tags,
 			type: row.type,
-			startsAt: row.starts_at,
-			updatedAt: row.updated_at,
+			startsAt: toIsoUtc(row.starts_at),
+			updatedAt: toIsoUtc(row.updated_at),
 			alertUrl: row.alert_url,
 			alertName: row.alert_name,
 			summary: row.summary,

--- a/apps/server/src/utils/time.ts
+++ b/apps/server/src/utils/time.ts
@@ -1,0 +1,10 @@
+// Normalizes a timestamp to ISO-8601 UTC. SQLite CURRENT_TIMESTAMP values are
+// "YYYY-MM-DD HH:MM:SS" (UTC, but without a timezone marker) — a client's
+// `new Date(...)` would parse that as LOCAL time and shift the display by the
+// viewer's UTC offset. Already-ISO values pass through unchanged (modulo
+// canonical formatting); unparseable values are returned as-is.
+export const toIsoUtc = (value: string): string => {
+	if (!value) return value;
+	const d = value.includes('T') ? new Date(value) : new Date(value.replace(' ', 'T') + 'Z');
+	return isNaN(d.getTime()) ? value : d.toISOString();
+};

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1437,3 +1437,73 @@ describe('Firing times on alert listings', () => {
 		}
 	});
 });
+
+describe('Started At stability', () => {
+	test('re-sending an active alert with a newer startsAt does not move Started At', async () => {
+		const T1 = '2026-08-01T10:00:00.000Z';
+		const T2 = '2026-08-01T12:30:00.000Z';
+		const payload = {
+			id: 'episode-stable',
+			status: 'firing',
+			alertName: 'Episode Stability',
+			summary: 'first push',
+			tags: {},
+		};
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T1 });
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, summary: 'second push', startsAt: T2 });
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const alert = (listing.body.data.alerts as Alert[]).find((a) => a.id === payload.id);
+		// Same episode: Started At stays at the first firing, other fields update.
+		expect(alert?.startsAt).toBe(T1);
+		expect(alert?.summary).toBe('second push');
+
+		// The history's firing entry matches Started At exactly — this pair diverging is
+		// the bug this suite guards against (history showing an earlier "firing" hour).
+		const history = await app
+			.get(`/api/v1/alerts/${payload.id}/history`)
+			.set('Authorization', `Bearer ${jwtToken}`);
+		const firing = (history.body.data.data as { date: string; description?: string }[]).filter(
+			(e) => e.description === 'Alert started firing'
+		);
+		expect(firing).toHaveLength(1);
+		expect(firing[0].date).toBe(T1);
+	});
+
+	test('a new episode after resolve picks up the new startsAt', async () => {
+		const T1 = '2026-08-01T10:00:00.000Z';
+		const T3 = '2026-08-02T09:00:00.000Z';
+		const payload = { id: 'episode-new', status: 'firing', alertName: 'New Episode', summary: 's', tags: {} };
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T1 });
+		await app.delete(`/api/v1/alerts/${payload.id}`).set('Authorization', `Bearer ${jwtToken}`).send({});
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T3 });
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const alert = (listing.body.data.alerts as Alert[]).find((a) => a.id === payload.id);
+		expect(alert?.startsAt).toBe(T3);
+	});
+
+	test('marker-less SQLite timestamps are normalized to ISO UTC in listings', async () => {
+		db.prepare(
+			`INSERT INTO alerts (id, status, tags, starts_at, updated_at, alert_url, alert_name, summary, is_dismissed)
+			 VALUES ('legacy-format', 'firing', '{}', '2026-08-01 10:00:00', '2026-08-01 11:00:00', 'u', 'Legacy', 's', 0)`
+		).run();
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const alert = (listing.body.data.alerts as Alert[]).find((a) => a.id === 'legacy-format');
+		expect(alert?.startsAt).toBe('2026-08-01T10:00:00.000Z');
+		expect(alert?.updatedAt).toBe('2026-08-01T11:00:00.000Z');
+	});
+});


### PR DESCRIPTION
## Bug

History log sometimes showed **"Alert started firing" at an earlier hour than the table's Started At**. Reproduced in dev data: an alert pushed at 21:26 and re-pushed at 21:34 showed Started At 21:34:26 while history said firing at 21:26:04.

## Root causes

1. **The upsert rewrote `starts_at` on every re-send** (`starts_at=excluded.starts_at`). Sources that send a fresh `startsAt` with each notification dragged Started At forward — but the firing-history trigger only fires on INSERT, so the history entry stayed at the true episode start. The two diverge further with every push.
2. **Trigger drift**: the trigger's definition changed over time (old: stamp insert moment; current: stamp `starts_at`), but `CREATE TRIGGER IF NOT EXISTS` never upgrades an existing DB — installs disagreed with each other and with the code.

## Fix

- `starts_at` removed from the upsert's `DO UPDATE` clause — **Started At = when the current firing episode began**, stable across re-notifications. A new episode (resolve → re-fire) is a fresh INSERT and picks up its new start.
- Init detects a stale trigger definition (no `NEW.starts_at`) and recreates it, converging all installs.
- `startsAt`/`updatedAt` normalized to ISO UTC at the API boundary (both alert repositories): SQLite's marker-less `YYYY-MM-DD HH:MM:SS` parses as *local* time in browsers, shifting the display by the viewer's UTC offset — same bug class, latent until an ingestion path stores that format.

## Verification

- 3 new server tests (126 total): re-push keeps Started At + history firing entry matches it exactly; resolve→re-fire picks up the new start; marker-less timestamps normalize to ISO UTC.
- Live against the dev app: two pushes (08:00, then 11:45) → Started At stays 08:00, summary updates, history firing entry reads exactly 08:00; the dev DB's stale trigger was auto-migrated on server start.
- Server lint/format clean, tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert timestamps are now consistently returned in ISO 8601 UTC format.
  * Active alerts retain their original start time when updated.
  * New alert episodes correctly record their new start time.
  * Legacy timestamps without timezone markers are normalized correctly.

* **Tests**
  * Added coverage for alert start-time stability, episode transitions, and timestamp normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->