### PR TITLE
fix: time-filtered Started At shows the current episode's start, not the first in-range firing

### DIFF
--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -71,21 +71,23 @@ export const useAlertsFiltering = (
 				return alertStartDate <= filterEnd && alertEndDate >= filterStart;
 			});
 
-			// Inside a time window, "Started At" means the first time the alert fired WITHIN
-			// that window: an alert that originally fired last week but re-fired/unresolved
-			// inside the range shows (and sorts by) the in-range firing, not the ancient one.
-			// Alerts that simply kept firing across the range boundary have no in-range
-			// transition and keep their real start.
+			// Inside a time window, "Started At" means when the firing episode CURRENT AS OF
+			// the window's end began: the LATEST transition into firing at or before the
+			// window closes. An alert that fired at 18:00, resolved at 19:00 and re-fired at
+			// 20:00 shows 20:00 — the 18:00 episode ended; showing it would misstate how long
+			// the alert has been burning. Transitions after the window's end belong to a
+			// later episode and are ignored; an alert that simply kept firing across the
+			// window's start keeps its real (pre-window) start.
 			result = result.map((alert) => {
-				const candidates = [alert.startsAt, ...(alert.firingTimes ?? [])].filter((iso) => {
-					const t = new Date(iso);
-					return !isNaN(t.getTime()) && t >= filterStart && t <= filterEnd;
-				});
+				// Numeric (epoch) comparison: startsAt can carry a timezone offset while
+				// firingTimes are normalized UTC — lexicographic order would mis-pick
+				// across formats.
+				const candidates = [alert.startsAt, ...(alert.firingTimes ?? [])]
+					.map((iso) => ({ iso, epoch: new Date(iso).getTime() }))
+					.filter(({ epoch }) => !isNaN(epoch) && epoch <= filterEnd.getTime());
 				if (candidates.length === 0) return alert;
-				// Numeric sort: startsAt can carry a timezone offset while firingTimes are
-				// normalized UTC — lexicographic order would mis-pick across formats.
-				const inRangeStart = candidates.sort((a, b) => new Date(a).getTime() - new Date(b).getTime())[0];
-				return inRangeStart === alert.startsAt ? alert : { ...alert, startsAt: inRangeStart };
+				const episodeStart = candidates.reduce((latest, c) => (c.epoch > latest.epoch ? c : latest));
+				return episodeStart.iso === alert.startsAt ? alert : { ...alert, startsAt: episodeStart.iso };
 			});
 		}
 

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -75,7 +75,7 @@ describe('useAlertsFiltering rolling time presets', () => {
 	});
 });
 
-describe('in-range Started At override', () => {
+describe('episode-start Started At override under a time filter', () => {
 	beforeEach(() => vi.useFakeTimers());
 	afterEach(() => vi.useRealTimers());
 
@@ -91,6 +91,22 @@ describe('in-range Started At override', () => {
 		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'last1h' as const } };
 		const { result } = renderHook(() => useAlertsFiltering([alert], options), { wrapper });
 		expect(result.current[0]?.startsAt).toBe(inRangeFiring);
+	});
+
+	test('multiple episodes inside the window: Started At is the latest transition into firing', () => {
+		// fired 18:00-style (3h ago), resolved, re-fired 1h... the current episode's start
+		// (the LAST transition to firing) must win — not the first in-range firing.
+		const firstEpisode = new Date(Date.now() - 3 * 3600_000).toISOString();
+		const currentEpisode = new Date(Date.now() - 40 * 60_000).toISOString();
+		const alert = {
+			...mkAlert('episodes', 0),
+			startsAt: currentEpisode,
+			updatedAt: new Date().toISOString(),
+			firingTimes: [firstEpisode, currentEpisode],
+		};
+		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'last6h' as const } };
+		const { result } = renderHook(() => useAlertsFiltering([alert], options), { wrapper });
+		expect(result.current[0]?.startsAt).toBe(currentEpisode);
 	});
 
 	test('an alert firing across the range boundary with no in-range transition keeps its real start', () => {
@@ -162,7 +178,8 @@ describe('in-range override with mixed timestamp formats', () => {
 		};
 		const options = { filters: {}, timeRange: { from: null, to: null, preset: 'last1h' as const } };
 		const { result } = renderHook(() => useAlertsFiltering([alert], options), { wrapper });
-		// The earliest REAL instant is the offset startsAt — numeric sort keeps it.
-		expect(result.current[0]?.startsAt).toBe(offsetIso);
+		// The latest REAL instant is the UTC firing time; a lexicographic comparison
+		// would have picked the offset startsAt ("…T14+03:00" > "…T11…Z").
+		expect(result.current[0]?.startsAt).toBe(laterUtc);
 	});
 });


### PR DESCRIPTION
## Bug

Under a time filter, Started At was overridden to the **first** firing transition inside the window (#716). With multiple firing episodes in one window that's wrong: an alert that fired at 18:00, resolved at 19:00, re-fired at 20:00 and got re-pushed at 21:00 showed **18:00** — the start of an episode that already ended. Without a filter the table (correctly, since #736) shows 20:00, so the two views disagreed.

## Fix

The override now selects the **latest transition into firing at or before the window's end** — the start of the firing episode current as of that window:

- 18:00 → resolve → 20:00 → re-push 21:00, window covering the evening: Started At **20:00**, Last Update 21:00.
- Fired last week, re-fired inside the window: shows the in-range re-fire (unchanged from #716's intent).
- Kept firing across the window's start with no in-range transition: keeps its real pre-window start (unchanged).
- Transitions after the window's end are ignored — they belong to a later episode.

Comparisons stay numeric (epoch), preserving the mixed timestamp-format safety (offset-ISO `startsAt` vs normalized-UTC `firingTimes`).

## Verification

- New unit test for the exact multi-episode scenario; the mixed-format test now guards the same lexical trap on max-selection. Client tests 55/55, tsc/lint at baseline.
- Live E2E: seeded the exact 18:00/19:00/20:00/21:00 chain via the API — without a filter the row shows the episode start (T20); with "Last 6 hours" it **still shows T20** and does not regress to T18 (the pre-fix behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Updated” events to alert history timelines.
  * Alert history now includes recent alert updates when no matching history event exists.

* **Bug Fixes**
  * Corrected alert filtering so “Started At” reflects the latest valid firing transition.
  * Preserved firing episodes that began before the selected window.
  * Improved handling of mixed timestamp formats and preset time ranges.

* **Tests**
  * Added coverage for multiple firing episodes and synthesized update history entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->