### PR TITLE
fix: re-activation always starts a new episode — unresolve and stale-claim re-fires stamp the observed moment

### DIFF
--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -350,6 +350,7 @@ export class AlertBL {
 				return null;
 			}
 
+			const now = new Date().toISOString();
 			const alert: Alert = {
 				...resolved,
 				status: AlertStatus.FIRING,
@@ -358,7 +359,13 @@ export class AlertBL {
 				// Restored as unread (matches the is_read = 0 the repository writes) so the
 				// returned alert renders with the unread treatment without waiting for a refetch.
 				isRead: false,
-				updatedAt: new Date().toISOString(),
+				// Unresolving starts a NEW firing episode: "Started At" means the last
+				// transition into firing, so it stamps the unresolve moment — not the original
+				// start, which would make a re-activated alert look ancient. The original
+				// start stays visible in the history timeline, and filtered/unfiltered views
+				// now agree (the UNRESOLVED event and starts_at carry the same moment).
+				startsAt: now,
+				updatedAt: now,
 			};
 
 			await this.alertRepo.restoreAlert(alert);
@@ -408,7 +415,9 @@ export class AlertBL {
 		// A manual resolve records a RESOLVED event (with the acting user) AND fires the
 		// automatic status trigger. Suppress the trigger's entry when a manual-resolve event
 		// sits right next to it, so the timeline shows one entry per resolve — with the actor
-		// for manual resolves, without one for API/source-driven resolution.
+		// for manual resolves, without one for API/source-driven resolution. (Unresolve needs
+		// no counterpart: restoreAlert deletes the trigger's re-insert row, leaving the
+		// UNRESOLVED event as the transition's single record.)
 		const manualResolveTimes = eventEntries
 			.filter((e) => e.eventType === AlertHistoryEventType.RESOLVED)
 			.map((e) => new Date(e.date).getTime());
@@ -416,8 +425,18 @@ export class AlertBL {
 			entry.status !== AlertStatus.FIRING &&
 			manualResolveTimes.some((t) => Math.abs(t - new Date(toIsoUtc(entry.date)).getTime()) < 10_000);
 
+		// Exact-duplicate transitions collapse to one entry: unresolve re-inserts used to
+		// stamp the trigger row with the ORIGINAL starts_at, so older alerts carry several
+		// identical "firing" rows at the same instant.
+		const seenTransitions = new Set<string>();
 		const statusEntries: AlertHistoryData[] = statusHistory.data
 			.filter((entry) => !coveredByManualResolve(entry))
+			.filter((entry) => {
+				const key = `${entry.status}@${toIsoUtc(entry.date)}`;
+				if (seenTransitions.has(key)) return false;
+				seenTransitions.add(key);
+				return true;
+			})
 			.map((entry) => ({
 				...entry,
 				date: toIsoUtc(entry.date),

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -47,6 +47,25 @@ export class AlertRepository {
 			// copy — the active row is the truth. Same transaction as the upsert so a
 			// failure between the two can't leave the alert in neither table.
 			const upsert = this.db.transaction(() => {
+				// Re-fire after a resolve = a new episode. Sources often replay the ORIGINAL
+				// incident startsAt on the re-fire push; trusting that claim would show a
+				// freshly re-activated alert as weeks old. If the claimed start predates the
+				// resolve that ended the previous episode (a contradiction — it can't have
+				// started before it last ended), stamp the observed re-fire moment instead.
+				// A claimed start AFTER the resolve is a genuine fresh start and is kept.
+				let startsAt = alert.startsAt;
+				const resolvedCopy = this.db
+					.prepare(`SELECT archived_at, updated_at FROM alerts_resolved WHERE id = ?`)
+					.get(alert.id) as { archived_at: string | null; updated_at: string } | undefined;
+				if (resolvedCopy) {
+					const resolveMoment = new Date(
+						toIsoUtc(resolvedCopy.archived_at ?? resolvedCopy.updated_at)
+					).getTime();
+					const claimed = new Date(startsAt).getTime();
+					if (isNaN(claimed) || (!isNaN(resolveMoment) && claimed <= resolveMoment)) {
+						startsAt = new Date().toISOString();
+					}
+				}
 				this.db.prepare(`DELETE FROM alerts_resolved WHERE id = ?`).run(alert.id);
 				return stmt.run(
 					alert.id,
@@ -55,7 +74,7 @@ export class AlertRepository {
 					alert.severity,
 					alert.team ?? null,
 					JSON.stringify(alert.tags ?? {}),
-					alert.startsAt,
+					startsAt,
 					alert.updatedAt,
 					alert.alertUrl,
 					alert.alertName,

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1478,7 +1478,9 @@ describe('Started At stability', () => {
 
 	test('a new episode after resolve picks up the new startsAt', async () => {
 		const T1 = '2026-08-01T10:00:00.000Z';
-		const T3 = '2026-08-02T09:00:00.000Z';
+		// Must postdate the resolve: a re-fire claiming a PRE-resolve start is treated as
+		// a replayed stale claim and stamped with the observed moment instead.
+		const T3 = new Date(Date.now() + 1000).toISOString();
 		const payload = { id: 'episode-new', status: 'firing', alertName: 'New Episode', summary: 's', tags: {} };
 		await app
 			.post('/api/v1/alerts/custom')
@@ -1505,5 +1507,93 @@ describe('Started At stability', () => {
 		const alert = (listing.body.data.alerts as Alert[]).find((a) => a.id === 'legacy-format');
 		expect(alert?.startsAt).toBe('2026-08-01T10:00:00.000Z');
 		expect(alert?.updatedAt).toBe('2026-08-01T11:00:00.000Z');
+	});
+});
+
+describe('Unresolve starts a new episode', () => {
+	test('unresolving stamps Started At with the unresolve moment, not the original start', async () => {
+		const alertId = testAlerts[0].id;
+		const before = Date.now();
+		const original = (await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`)).body.data
+			.alerts as Alert[];
+		const originalStart = original.find((a) => a.id === alertId)?.startsAt;
+
+		await app.delete(`/api/v1/alerts/${alertId}`).set('Authorization', `Bearer ${jwtToken}`).send({});
+		const unresolved = await app
+			.patch(`/api/v1/alerts/resolved/${alertId}/unresolve`)
+			.set('Authorization', `Bearer ${jwtToken}`);
+		expect(unresolved.status).toBe(200);
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const alert = (listing.body.data.alerts as Alert[]).find((a) => a.id === alertId);
+		// New episode: startsAt is the unresolve moment (>= test start), not the seed value.
+		expect(alert?.startsAt).not.toBe(originalStart);
+		expect(new Date(alert?.startsAt ?? 0).getTime()).toBeGreaterThanOrEqual(before);
+		expect(alert?.startsAt).toBe(alert?.updatedAt);
+	});
+
+	test('the history timeline keeps the original firing entry and shows one unresolve entry', async () => {
+		// Seed via the API so the alert's status is genuinely 'firing' (the fixture rows
+		// use 'active'/'warning', whose trigger entries don't render as firing).
+		const T1 = '2026-08-01T08:00:00.000Z';
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ id: 'unresolve-hist', status: 'firing', alertName: 'UH', summary: 's', tags: {}, startsAt: T1 });
+		await app.delete('/api/v1/alerts/unresolve-hist').set('Authorization', `Bearer ${jwtToken}`).send({});
+		await app.patch('/api/v1/alerts/resolved/unresolve-hist/unresolve').set('Authorization', `Bearer ${jwtToken}`);
+
+		const history = await app
+			.get('/api/v1/alerts/unresolve-hist/history')
+			.set('Authorization', `Bearer ${jwtToken}`);
+		const entries = history.body.data.data as { eventType: string; description?: string; date: string }[];
+		const firingEntries = entries.filter((e) => e.description === 'Alert started firing');
+		const unresolveEntries = entries.filter((e) => e.eventType === 'unresolved');
+		// The original firing survives as the episode's historical record; the unresolve
+		// is recorded once (restoreAlert removes the trigger's duplicate re-insert row).
+		expect(firingEntries).toHaveLength(1);
+		expect(firingEntries[0].date).toBe(T1);
+		expect(unresolveEntries).toHaveLength(1);
+	});
+
+	test('a source re-fire replaying a pre-resolve startsAt stamps the observed moment instead', async () => {
+		const T1 = '2026-08-01T08:00:00.000Z';
+		const payload = { id: 'refire-stale', status: 'firing', alertName: 'RS', summary: 's', tags: {} };
+		const before = Date.now();
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T1 });
+		await app.delete('/api/v1/alerts/refire-stale').set('Authorization', `Bearer ${jwtToken}`).send({});
+		// Source re-fires but replays the ORIGINAL incident start (predates the resolve).
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T1 });
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const alert = (listing.body.data.alerts as Alert[]).find((a) => a.id === 'refire-stale');
+		expect(alert?.startsAt).not.toBe(T1);
+		expect(new Date(alert?.startsAt ?? 0).getTime()).toBeGreaterThanOrEqual(before);
+	});
+
+	test('a source re-fire with a genuinely fresh startsAt keeps the claimed start', async () => {
+		const T1 = '2026-08-01T08:00:00.000Z';
+		const fresh = new Date(Date.now() + 60_000).toISOString();
+		const payload = { id: 'refire-fresh', status: 'firing', alertName: 'RF', summary: 's', tags: {} };
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T1 });
+		await app.delete('/api/v1/alerts/refire-fresh').set('Authorization', `Bearer ${jwtToken}`).send({});
+		// New incident with its own recent start (after the resolve): trusted verbatim.
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: fresh });
+
+		const listing = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+		const alert = (listing.body.data.alerts as Alert[]).find((a) => a.id === 'refire-fresh');
+		expect(alert?.startsAt).toBe(fresh);
 	});
 });

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1579,13 +1579,15 @@ describe('Unresolve starts a new episode', () => {
 
 	test('a source re-fire with a genuinely fresh startsAt keeps the claimed start', async () => {
 		const T1 = '2026-08-01T08:00:00.000Z';
-		const fresh = new Date(Date.now() + 60_000).toISOString();
 		const payload = { id: 'refire-fresh', status: 'firing', alertName: 'RF', summary: 's', tags: {} };
 		await app
 			.post('/api/v1/alerts/custom')
 			.set('Authorization', `Bearer ${jwtToken}`)
 			.send({ ...payload, startsAt: T1 });
 		await app.delete('/api/v1/alerts/refire-fresh').set('Authorization', `Bearer ${jwtToken}`).send({});
+		// Created AFTER the resolve so it postdates archived_at no matter how slowly the
+		// requests above ran — otherwise the stale-claim rule would (correctly) reject it.
+		const fresh = new Date(Date.now() + 60_000).toISOString();
 		// New incident with its own recent start (after the resolve): trusted verbatim.
 		await app
 			.post('/api/v1/alerts/custom')


### PR DESCRIPTION
## Bugs (both observed in real history logs)

1. **Unresolve**: history said "Alert moved back to firing — Aug 3, 2:02 PM" while Started At showed 7/20. Manual unresolve restored the alert with its *original* `starts_at`.
2. **Source re-fire replaying a stale claim**: history said "Alert started firing — Aug 2, 11:46 PM" while Started At showed 7/7. The source re-fired after a resolve but replayed the original incident `startsAt`, and the insert path trusted it.

Both violate the semantics established in #736/#738: **Started At = the last transition into firing**.

## Fix

- **Unresolve stamps the unresolve moment** — it starts a new firing episode. The original start stays visible in the history timeline, and filtered/unfiltered views now agree.
- **Re-fire after a resolve**: if the claimed `startsAt` **predates the resolve that ended the previous episode** (a contradiction — it can't have started before it last ended), the observed re-fire moment is stamped instead. A claimed start *after* the resolve is a genuine fresh incident and is kept verbatim — so sources reporting honest late-arriving starts are untouched.
- **History timeline**: exact-duplicate status transitions collapse to one entry (old unresolve re-inserts left identical "firing" rows at the same instant).

With #736 (re-pushes can't move Started At) these close every re-activation path under one rule.

## Verification

- 4 new/updated server tests (130 total): unresolve stamps now + timeline shows one original firing + one unresolve entry; stale-claim re-fire stamps observed moment; fresh-claim re-fire trusted verbatim.
- Live on the dev app: re-fired an alert replaying its 7/7 start → Started At = the observed moment (stale claim rejected); resolve→unresolve → Started At = the unresolve moment.
- Server tsc 0, lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unresolving an alert now correctly starts a new firing episode.
  * Refired alerts now use valid start times, replacing stale or invalid timestamps when necessary.
  * Existing valid refire times are preserved.
  * Alert history now accurately records unresolve events, removes duplicate status transitions, and preserves previous firing history.
  * Legacy alert records are automatically corrected to reflect the appropriate firing episode start time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->