### PR TITLE
feat: show the alert's last update in the history log when a time window hides all real events

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistorySection/AlertHistorySection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistorySection/AlertHistorySection.tsx
@@ -3,7 +3,7 @@ import { History } from 'lucide-react';
 import { useMemo } from 'react';
 import { TimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.types';
 import { AlertHistoryTimeline } from '../AlertHistoryTimeline';
-import { filterHistoryByRange } from '../AlertHistoryTimeline/alertHistory.utils';
+import { selectHistoryEntries } from '../AlertHistoryTimeline/alertHistory.utils';
 import { CollapsibleSection } from '../CollapsibleSection';
 
 interface AlertHistorySectionProps {
@@ -21,7 +21,7 @@ export const AlertHistorySection = ({ historyData, timeRange }: AlertHistorySect
 		timeRange &&
 		(timeRange.from || timeRange.to || (timeRange.preset && timeRange.preset !== 'custom'))
 	);
-	const filtered = useMemo(() => filterHistoryByRange(historyData.data, timeRange), [historyData.data, timeRange]);
+	const filtered = useMemo(() => selectHistoryEntries(historyData.data, timeRange), [historyData.data, timeRange]);
 
 	if (!historyData.data.length) {
 		return null;

--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistorySection/AlertHistorySection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistorySection/AlertHistorySection.tsx
@@ -15,7 +15,12 @@ interface AlertHistorySectionProps {
 // Self-contained collapsible History section, rendered as a timeline and filtered by the
 // active time range so it mirrors what the "All time" button shows for the alerts list.
 export const AlertHistorySection = ({ historyData, timeRange }: AlertHistorySectionProps) => {
-	const isFiltered = !!(timeRange && (timeRange.from || timeRange.to));
+	// Quick presets carry only `preset` (from/to stay null), so checking the dates
+	// alone would treat a preset window as unfiltered.
+	const isFiltered = !!(
+		timeRange &&
+		(timeRange.from || timeRange.to || (timeRange.preset && timeRange.preset !== 'custom'))
+	);
 	const filtered = useMemo(() => filterHistoryByRange(historyData.data, timeRange), [historyData.data, timeRange]);
 
 	if (!historyData.data.length) {

--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/AlertHistoryTimeline.tsx
@@ -1,5 +1,16 @@
 import { AlertHistoryData, AlertHistoryEventType, AlertStatus } from '@OpsiMate/shared';
-import { Bell, BellOff, CheckCircle2, Flame, MessageSquare, RefreshCw, UserMinus, UserPlus, Zap } from 'lucide-react';
+import {
+	Activity,
+	Bell,
+	BellOff,
+	CheckCircle2,
+	Flame,
+	MessageSquare,
+	RefreshCw,
+	UserMinus,
+	UserPlus,
+	Zap,
+} from 'lucide-react';
 import { ComponentType } from 'react';
 
 interface AlertHistoryTimelineProps {
@@ -77,6 +88,12 @@ const EVENT_STYLES: Record<Exclude<AlertHistoryEventType, AlertHistoryEventType.
 		dotClass: 'bg-violet-500',
 		textClass: 'text-violet-600 dark:text-violet-400',
 		Icon: Zap,
+	},
+	[AlertHistoryEventType.UPDATED]: {
+		label: 'Updated',
+		dotClass: 'bg-sky-500',
+		textClass: 'text-sky-600 dark:text-sky-400',
+		Icon: Activity,
 	},
 	[AlertHistoryEventType.COMMENT_ADDED]: {
 		label: 'Comment added',

--- a/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/alertHistory.utils.ts
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertHistoryTimeline/alertHistory.utils.ts
@@ -1,4 +1,4 @@
-import { AlertHistoryData } from '@OpsiMate/shared';
+import { AlertHistoryData, AlertHistoryEventType } from '@OpsiMate/shared';
 import { TimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.types';
 import { resolveTimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.utils';
 
@@ -21,4 +21,19 @@ export const filterHistoryByRange = (data: AlertHistoryData[], timeRange?: TimeR
 		if (toMs !== null && t > toMs) return false;
 		return true;
 	});
+};
+
+// Entries the timeline should show for the active window. Real events (transitions,
+// silences, comments…) always win; the synthesized last-update entry is a FALLBACK: it
+// steps in only when the window hides every real event — the case where the alert is
+// listed because of a recent update but all its history predates the window. On "All
+// time" (or any window containing real events) it stays out of the log entirely.
+export const selectHistoryEntries = (data: AlertHistoryData[], timeRange?: TimeRange | null): AlertHistoryData[] => {
+	const realEntries = data.filter((entry) => entry.eventType !== AlertHistoryEventType.UPDATED);
+	const filteredReal = filterHistoryByRange(realEntries, timeRange);
+	if (filteredReal.length > 0 || realEntries.length === data.length) {
+		return filteredReal;
+	}
+	const updatedEntries = data.filter((entry) => entry.eventType === AlertHistoryEventType.UPDATED);
+	return filterHistoryByRange(updatedEntries, timeRange);
 };

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -444,9 +444,30 @@ export class AlertBL {
 				description: entry.status === AlertStatus.FIRING ? 'Alert started firing' : 'Alert resolved',
 			}));
 
-		const data = [...statusEntries, ...eventEntries].sort(
-			(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-		);
+		const data = [...statusEntries, ...eventEntries];
+
+		// Synthesize a "last update received" entry from the alert row's updated_at (not
+		// persisted — updates are upserts and write no history). Without it, an alert
+		// whose only real entries predate an active time window shows an empty history
+		// log even though its recent update is what keeps it in the list (e.g. fired
+		// 23:00 yesterday, updated 00:01, window "Today"). Skipped when an entry already
+		// sits at that moment (a fresh alert whose updated_at still equals starts_at).
+		const alertRow =
+			(await this.alertRepo.getAlert(alertId)) ?? (await this.resolvedAlertRepo.getResolvedAlert(alertId));
+		if (alertRow?.updatedAt) {
+			const updatedIso = toIsoUtc(alertRow.updatedAt);
+			const updatedMs = new Date(updatedIso).getTime();
+			const covered = data.some((entry) => Math.abs(new Date(entry.date).getTime() - updatedMs) < 1_000);
+			if (!isNaN(updatedMs) && !covered) {
+				data.push({
+					date: updatedIso,
+					eventType: AlertHistoryEventType.UPDATED,
+					description: 'Last update received from the source',
+				});
+			}
+		}
+
+		data.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
 		return { alertId, data };
 	}

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1599,3 +1599,46 @@ describe('Unresolve starts a new episode', () => {
 		expect(alert?.startsAt).toBe(fresh);
 	});
 });
+
+describe('Synthesized last-update history entry', () => {
+	test('an alert updated after its start gains an UPDATED entry at updated_at', async () => {
+		const T_START = '2026-08-02T21:00:00.000Z';
+		const T_UPDATE = '2026-08-03T00:01:00.000Z';
+		const payload = { id: 'late-update', status: 'firing', alertName: 'LateUpdate', summary: 's', tags: {} };
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T_START, updatedAt: T_START });
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ...payload, startsAt: T_UPDATE, updatedAt: T_UPDATE });
+
+		const history = await app.get('/api/v1/alerts/late-update/history').set('Authorization', `Bearer ${jwtToken}`);
+		const entries = history.body.data.data as { date: string; eventType?: string }[];
+		const updated = entries.filter((e) => e.eventType === 'updated');
+		// Exactly one synthesized entry, at the latest update - so a time window that
+		// contains the update but not the original firing still shows history.
+		expect(updated).toHaveLength(1);
+		expect(updated[0].date).toBe(T_UPDATE);
+	});
+
+	test('a never-updated alert gets no duplicate entry at its start moment', async () => {
+		const T = '2026-08-02T21:00:00.000Z';
+		await app.post('/api/v1/alerts/custom').set('Authorization', `Bearer ${jwtToken}`).send({
+			id: 'fresh',
+			status: 'firing',
+			alertName: 'Fresh',
+			summary: 's',
+			tags: {},
+			startsAt: T,
+			updatedAt: T,
+		});
+
+		const history = await app.get('/api/v1/alerts/fresh/history').set('Authorization', `Bearer ${jwtToken}`);
+		const entries = history.body.data.data as { date: string; eventType?: string }[];
+		expect(entries.filter((e) => e.eventType === 'updated')).toHaveLength(0);
+		// The firing entry itself is still there at that moment.
+		expect(entries.some((e) => e.date === T)).toBe(true);
+	});
+});

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1609,18 +1609,24 @@ describe('Synthesized last-update history entry', () => {
 			.post('/api/v1/alerts/custom')
 			.set('Authorization', `Bearer ${jwtToken}`)
 			.send({ ...payload, startsAt: T_START, updatedAt: T_START });
+		// The update re-sends the ORIGINAL start (like real sources do) so the scenario
+		// stays purely "same episode, new update" — only updated_at moves.
 		await app
 			.post('/api/v1/alerts/custom')
 			.set('Authorization', `Bearer ${jwtToken}`)
-			.send({ ...payload, startsAt: T_UPDATE, updatedAt: T_UPDATE });
+			.send({ ...payload, startsAt: T_START, updatedAt: T_UPDATE });
 
 		const history = await app.get('/api/v1/alerts/late-update/history').set('Authorization', `Bearer ${jwtToken}`);
-		const entries = history.body.data.data as { date: string; eventType?: string }[];
+		const entries = history.body.data.data as { date: string; eventType?: string; description?: string }[];
 		const updated = entries.filter((e) => e.eventType === 'updated');
 		// Exactly one synthesized entry, at the latest update - so a time window that
 		// contains the update but not the original firing still shows history.
 		expect(updated).toHaveLength(1);
 		expect(updated[0].date).toBe(T_UPDATE);
+		// The firing entry itself stays at the episode start.
+		const firing = entries.filter((e) => e.description === 'Alert started firing');
+		expect(firing).toHaveLength(1);
+		expect(firing[0].date).toBe(T_START);
 	});
 
 	test('a never-updated alert gets no duplicate entry at its start moment', async () => {
@@ -1638,7 +1644,8 @@ describe('Synthesized last-update history entry', () => {
 		const history = await app.get('/api/v1/alerts/fresh/history').set('Authorization', `Bearer ${jwtToken}`);
 		const entries = history.body.data.data as { date: string; eventType?: string }[];
 		expect(entries.filter((e) => e.eventType === 'updated')).toHaveLength(0);
-		// The firing entry itself is still there at that moment.
-		expect(entries.some((e) => e.date === T)).toBe(true);
+		// The firing entry itself is still there at that moment — matched by type, not
+		// just timestamp, so an unrelated same-moment event can't satisfy this.
+		expect(entries.some((e) => e.date === T && e.eventType === 'status_changed')).toBe(true);
 	});
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -252,6 +252,10 @@ export enum AlertHistoryEventType {
 	UNRESOLVED = 'unresolved',
 	ACTION_RUN = 'action_run',
 	COMMENT_ADDED = 'comment_added',
+	// Synthesized (not persisted): the alert's most recent update from its source,
+	// derived from updated_at at read time. Guarantees a visible alert always has at
+	// least one history entry inside any time window that shows it.
+	UPDATED = 'updated',
 }
 
 export interface AlertHistoryData {


### PR DESCRIPTION
## Problem

An alert that fired at 23:00 and was re-sent at 00:01 correctly appears in the table under a "Today" filter (the update keeps it in range) — but its history log showed **nothing**: all real events predate the window, and updates are deliberately not logged. A visible alert with an empty timeline looks broken.

## Approach

**Nothing is persisted per update** (no update logging, per maintainer requirement). Instead:

- The server synthesizes a single transient "Last update received from the source" entry from the alert's `updated_at` at history-read time — always exactly one, always the latest update, zero storage.
- The client shows it **only as a fallback**: when the active time window hides every real event. On "All time" (or any window containing real events) the synthesized entry stays out of the log entirely — no per-update noise in normal timelines.

## Behavior

| View | History shows |
|---|---|
| No filter / window with real events | Real timeline only (firing, resolves, silences, comments…) |
| Window hiding all real events (the 23:00 → 00:01 case) | One "Last update received" entry at the update moment |

## Verification

- Live E2E of the exact reported scenario (fired yesterday 23:00, re-sent 00:01, "Today" filter): no filter → 1 firing entry, 0 update entries; Today → 0 firing entries, 1 "Last update received" entry.
- Server tests 132/132 (2 new: synthesized entry present once at `updated_at`; never-updated alert gains no duplicate), client 55/55, tsc/lint/format at baseline.
- Review feedback from the earlier CodeRabbit pass already applied (update push re-sends original startsAt; firing entry asserted by type and moment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert history now displays alert update events with a distinct visual style.
  * Alert history timelines include synthesized update entries when applicable.
  * Time-range filtering now handles preset and custom ranges more accurately.

* **Bug Fixes**
  * Prevented duplicate or invalid update entries in alert history.
  * Preserved existing firing events when displaying later alert updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->