### PR TITLE
fix(docker): pin pnpm to the repo's packageManager version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 FROM node:26-alpine AS builder
 
 # Install build tools and clean up in same layer
-RUN npm install -g pnpm typescript && \
+# pnpm is pinned to the repo's packageManager version: an unpinned install pulls
+# latest, and pnpm 11 refuses this project's v9 lockfile (broke Build and Release).
+RUN npm install -g pnpm@9.12.0 typescript && \
     npm cache clean --force
 
 WORKDIR /app
@@ -55,7 +57,7 @@ COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/packages/custom-actions/package.json ./packages/custom-actions/
 
 # Install production dependencies using the actual package.json files
-RUN npm install -g pnpm && \
+RUN npm install -g pnpm@9.12.0 && \
     pnpm install --prod --frozen-lockfile && \
     pnpm store prune && \
     npm cache clean --force && \

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,6 +1,8 @@
 FROM node:26-alpine AS client-builder
 
-RUN npm install -g pnpm typescript && npm cache clean --force
+# pnpm is pinned to the repo's packageManager version: an unpinned install pulls
+# latest, and pnpm 11 refuses this project's v9 lockfile (broke Build and Release).
+RUN npm install -g pnpm@9.12.0 typescript && npm cache clean --force
 WORKDIR /app
 
 # Copy workspace manifests for caching

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,6 +1,8 @@
 FROM node:26-alpine AS server-builder
 
-RUN npm install -g pnpm typescript && npm cache clean --force
+# pnpm is pinned to the repo's packageManager version: an unpinned install pulls
+# latest, and pnpm 11 refuses this project's v9 lockfile (broke Build and Release).
+RUN npm install -g pnpm@9.12.0 typescript && npm cache clean --force
 WORKDIR /app
 
 # Copy workspace manifests for caching
@@ -38,7 +40,7 @@ COPY --from=server-builder /app/packages/custom-actions/package.json packages/cu
 COPY --from=server-builder /app/packages/custom-actions/dist packages/custom-actions/dist
 
 # Install only production deps
-RUN npm install -g pnpm && \
+RUN npm install -g pnpm@9.12.0 && \
     pnpm install --prod --frozen-lockfile && \
     pnpm store prune && \
     rm -rf /root/.npm /root/.cache /tmp/*


### PR DESCRIPTION
## Failure

**Build and Release is red on every main push since Aug 3** (both image jobs):

```
[ERROR] Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it is missing from pnpm-lock.yaml.
ERROR: process "/bin/sh -c pnpm install --frozen-lockfile && pnpm store prune" did not complete successfully: exit code: 1
```

## Root cause — external, not our code

Last success: Aug 2 21:40 (`9982d29`). First failure: Aug 3 14:45 (`272e489` — a pure client-logic change with zero dependency changes). In that window the registry's `pnpm@latest` moved to **pnpm 11**, and every Dockerfile stage installs pnpm **unpinned** (`npm install -g pnpm`). pnpm 11 refuses this project's v9 lockfile (`packageManager: pnpm@9.12.0`). CI kept passing because `pnpm/action-setup` honors the pinned `packageManager` field — only the Docker builds float on latest.

## Fix

Pin all five install sites across `Dockerfile`, `Dockerfile.server`, `Dockerfile.client` (builder + runtime stages) to `pnpm@9.12.0`, with a comment explaining why, so a registry release can never break image builds again.

## Verification

Both images built **fully and successfully** locally from this branch (`docker build -f Dockerfile.server` and `-f Dockerfile.client`) — the same commands that fail on main's tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the package manager version used during application builds and runtime setup.
  * Improved build consistency by ensuring the same compatible package manager version is used across client, server, and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->