### PR TITLE
feat: re-bold an alert row whenever the alert arrives again, not only on first firing

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -104,8 +104,9 @@ export const AlertRow = ({
 				// Selection carries its own hover class so the severity hover tint can't
 				// override the selection cue while the pointer is over the row.
 				isSelected && 'bg-muted/50 hover:bg-muted/50',
-				// Unread alerts render bold until someone opens them.
-				alert.isRead === false && 'font-bold',
+				// Unread alerts render extra-bold until someone opens them, so an updated
+				// or freshly firing row stands out clearly from the regular-weight ones.
+				alert.isRead === false && 'font-extrabold',
 				// The alert currently open in the details panel: tinted row + accent edge,
 				// inset shadow instead of a border so the columns don't shift.
 				isActiveRow && 'bg-primary/10 hover:bg-primary/15 shadow-[inset_3px_0_0_0] shadow-primary'

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -104,9 +104,9 @@ export const AlertRow = ({
 				// Selection carries its own hover class so the severity hover tint can't
 				// override the selection cue while the pointer is over the row.
 				isSelected && 'bg-muted/50 hover:bg-muted/50',
-				// Unread alerts render extra-bold until someone opens them, so an updated
-				// or freshly firing row stands out clearly from the regular-weight ones.
-				alert.isRead === false && 'font-extrabold',
+				// Unread alerts render at the heaviest weight until someone opens them, so an
+				// updated or freshly firing row stands out clearly from the regular-weight ones.
+				alert.isRead === false && 'font-black',
 				// The alert currently open in the details panel: tinted row + accent edge,
 				// inset shadow instead of a border so the columns don't shift.
 				isActiveRow && 'bg-primary/10 hover:bg-primary/15 shadow-[inset_3px_0_0_0] shadow-primary'

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -18,9 +18,9 @@ export const AlertNameColumn = ({ alert, expanded = false, className, style }: A
 				className={cn(
 					'text-sm block text-foreground',
 					expanded ? 'whitespace-normal wrap-break-word line-clamp-6' : 'truncate',
-					// Unread alerts: extra-bold the name so it clearly outweighs the read rows
-					// (font-medium) instead of sitting just a hair heavier.
-					alert.isRead === false ? 'font-extrabold' : 'font-medium'
+					// Unread alerts: render the name at the heaviest weight so it clearly
+					// outweighs the read rows (font-medium) instead of sitting a hair heavier.
+					alert.isRead === false ? 'font-black' : 'font-medium'
 				)}
 				title={expanded ? undefined : alert.alertName}
 			>

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -18,8 +18,9 @@ export const AlertNameColumn = ({ alert, expanded = false, className, style }: A
 				className={cn(
 					'text-sm block text-foreground',
 					expanded ? 'whitespace-normal wrap-break-word line-clamp-6' : 'truncate',
-					// Unread alerts: bold the name (the row's own font-medium would otherwise win).
-					alert.isRead === false ? 'font-bold' : 'font-medium'
+					// Unread alerts: extra-bold the name so it clearly outweighs the read rows
+					// (font-medium) instead of sitting just a hair heavier.
+					alert.isRead === false ? 'font-extrabold' : 'font-medium'
 				)}
 				title={expanded ? undefined : alert.alertName}
 			>

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
@@ -100,10 +100,10 @@ export const useContentColumnWidths = ({
 			return {};
 		}
 
-		// Measure at extra-bold: unread rows render font-extrabold (800), and a column
+		// Measure at the heaviest weight: unread rows render font-black (900), and a column
 		// sized for the regular weight would truncate exactly the rows that must stand out.
 		const fontFamily = getComputedStyle(document.body).fontFamily || 'sans-serif';
-		const font = `800 14px ${fontFamily}`;
+		const font = `900 14px ${fontFamily}`;
 
 		const desired: Record<string, number> = {};
 		const floors: Record<string, number> = {};

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
@@ -100,10 +100,10 @@ export const useContentColumnWidths = ({
 			return {};
 		}
 
-		// Measure at bold: unread rows render bold, and a column sized for the regular
-		// weight would truncate exactly the rows that must stand out.
+		// Measure at extra-bold: unread rows render font-extrabold (800), and a column
+		// sized for the regular weight would truncate exactly the rows that must stand out.
 		const fontFamily = getComputedStyle(document.body).fontFamily || 'sans-serif';
-		const font = `700 14px ${fontFamily}`;
+		const font = `800 14px ${fontFamily}`;
 
 		const desired: Record<string, number> = {};
 		const floors: Record<string, number> = {};

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -18,21 +18,6 @@ export class AlertRepository {
 		this.db = db;
 	}
 
-	// Serialize tags with keys in a stable (sorted) order so the SAME set of tags always
-	// produces the SAME stored string. The is_read comparison in insertOrUpdateAlert diffs
-	// the stored tags string against the incoming one; without canonical order a source that
-	// merely reorders identical keys would look "changed" and wrongly re-bold a read alert.
-	private static serializeTags(tags?: Record<string, string> | null): string {
-		if (!tags) return '{}';
-		return JSON.stringify(
-			Object.fromEntries(
-				Object.keys(tags)
-					.sort()
-					.map((k) => [k, tags[k]])
-			)
-		);
-	}
-
 	async insertOrUpdateAlert(alert: Omit<SharedAlert, 'createdAt' | 'isSilenced'>): Promise<{ changes: number }> {
 		return runAsync(() => {
 			// starts_at is deliberately NOT in the DO UPDATE clause: "Started At" means when
@@ -55,23 +40,12 @@ export class AlertRepository {
 											  alert_name=excluded.alert_name,
 											  summary=excluded.summary,
 											  runbook_url=excluded.runbook_url,
-											  -- An alert whose content actually changed is "new" again: mark it unread
-											  -- so the row re-bolds, exactly like a freshly inserted alert. Compared with
-											  -- IS NOT (null-safe) against the incoming values; updated_at is excluded on
-											  -- purpose because sources that push "now" on every replay would otherwise
-											  -- flip read alerts back to unread on each poll with no real change.
-											  is_read=CASE
-												WHEN alerts.status IS NOT excluded.status
-													OR alerts.severity IS NOT excluded.severity
-													OR alerts.team IS NOT excluded.team
-													OR alerts.tags IS NOT excluded.tags
-													OR alerts.alert_name IS NOT excluded.alert_name
-													OR alerts.summary IS NOT excluded.summary
-													OR alerts.runbook_url IS NOT excluded.runbook_url
-													OR alerts.alert_url IS NOT excluded.alert_url
-												THEN 0
-												ELSE alerts.is_read
-											  END
+											  -- Every arrival re-surfaces the alert: any push for this id — an update
+											  -- OR an identical replay — marks it unread so the row re-bolds. All
+											  -- ingestion here is push-based webhooks, so a repeat notification is the
+											  -- source deliberately saying "this is still happening"; that deserves
+											  -- the same visual weight as a brand-new alert.
+											  is_read=0
 			`);
 
 			// An alert id must never live in both tables: if this alert was previously
@@ -105,7 +79,7 @@ export class AlertRepository {
 					alert.type,
 					alert.severity,
 					alert.team ?? null,
-					AlertRepository.serializeTags(alert.tags),
+					JSON.stringify(alert.tags ?? {}),
 					startsAt,
 					alert.updatedAt,
 					alert.alertUrl,
@@ -149,7 +123,7 @@ export class AlertRepository {
 						alert.type,
 						alert.severity,
 						alert.team ?? null,
-						AlertRepository.serializeTags(alert.tags),
+						JSON.stringify(alert.tags ?? {}),
 						alert.startsAt,
 						alert.updatedAt,
 						alert.alertUrl,
@@ -269,29 +243,6 @@ export class AlertRepository {
 			const hasSilencedAt = columns.some((col: TableInfoRow) => col.name === 'silenced_at');
 			if (!hasSilencedAt) {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN silenced_at TEXT`).run();
-			}
-
-			// Re-serialize any stored tags whose keys aren't in canonical (sorted) order.
-			// Rows written before serializeTags existed kept the source's key order; the
-			// is_read change-detection in insertOrUpdateAlert compares the stored string
-			// against the canonical incoming one, so a legacy unsorted row would read as
-			// "changed" on its first post-upgrade push and wrongly re-bold a read alert.
-			// Cheap full sweep (active alerts number in the hundreds); no-op once canonical.
-			const legacyRows = this.db.prepare(`SELECT id, tags FROM alerts WHERE tags IS NOT NULL`).all() as {
-				id: string;
-				tags: string;
-			}[];
-			const rewriteTags = this.db.prepare(`UPDATE alerts SET tags = ? WHERE id = ?`);
-			for (const row of legacyRows) {
-				try {
-					const canonical = AlertRepository.serializeTags(JSON.parse(row.tags) as Record<string, string>);
-					if (canonical !== row.tags) {
-						rewriteTags.run(canonical, row.id);
-					}
-				} catch {
-					// Unparseable tags blob: leave it as-is rather than fail startup; the next
-					// push for that alert overwrites it with a canonical value anyway.
-				}
 			}
 
 			// Repair: an alert id must never exist as both active and resolved. Ingestion used

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -25,7 +25,11 @@ export class AlertRepository {
 	private static serializeTags(tags?: Record<string, string> | null): string {
 		if (!tags) return '{}';
 		return JSON.stringify(
-			Object.fromEntries(Object.keys(tags).sort().map((k) => [k, tags[k]]))
+			Object.fromEntries(
+				Object.keys(tags)
+					.sort()
+					.map((k) => [k, tags[k]])
+			)
 		);
 	}
 
@@ -265,6 +269,29 @@ export class AlertRepository {
 			const hasSilencedAt = columns.some((col: TableInfoRow) => col.name === 'silenced_at');
 			if (!hasSilencedAt) {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN silenced_at TEXT`).run();
+			}
+
+			// Re-serialize any stored tags whose keys aren't in canonical (sorted) order.
+			// Rows written before serializeTags existed kept the source's key order; the
+			// is_read change-detection in insertOrUpdateAlert compares the stored string
+			// against the canonical incoming one, so a legacy unsorted row would read as
+			// "changed" on its first post-upgrade push and wrongly re-bold a read alert.
+			// Cheap full sweep (active alerts number in the hundreds); no-op once canonical.
+			const legacyRows = this.db.prepare(`SELECT id, tags FROM alerts WHERE tags IS NOT NULL`).all() as {
+				id: string;
+				tags: string;
+			}[];
+			const rewriteTags = this.db.prepare(`UPDATE alerts SET tags = ? WHERE id = ?`);
+			for (const row of legacyRows) {
+				try {
+					const canonical = AlertRepository.serializeTags(JSON.parse(row.tags) as Record<string, string>);
+					if (canonical !== row.tags) {
+						rewriteTags.run(canonical, row.id);
+					}
+				} catch {
+					// Unparseable tags blob: leave it as-is rather than fail startup; the next
+					// push for that alert overwrites it with a canonical value anyway.
+				}
 			}
 
 			// Repair: an alert id must never exist as both active and resolved. Ingestion used

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -39,7 +39,24 @@ export class AlertRepository {
 											  alert_url=excluded.alert_url,
 											  alert_name=excluded.alert_name,
 											  summary=excluded.summary,
-											  runbook_url=excluded.runbook_url
+											  runbook_url=excluded.runbook_url,
+											  -- An alert whose content actually changed is "new" again: mark it unread
+											  -- so the row re-bolds, exactly like a freshly inserted alert. Compared with
+											  -- IS NOT (null-safe) against the incoming values; updated_at is excluded on
+											  -- purpose because sources that push "now" on every replay would otherwise
+											  -- flip read alerts back to unread on each poll with no real change.
+											  is_read=CASE
+												WHEN alerts.status IS NOT excluded.status
+													OR alerts.severity IS NOT excluded.severity
+													OR alerts.team IS NOT excluded.team
+													OR alerts.tags IS NOT excluded.tags
+													OR alerts.alert_name IS NOT excluded.alert_name
+													OR alerts.summary IS NOT excluded.summary
+													OR alerts.runbook_url IS NOT excluded.runbook_url
+													OR alerts.alert_url IS NOT excluded.alert_url
+												THEN 0
+												ELSE alerts.is_read
+											  END
 			`);
 
 			// An alert id must never live in both tables: if this alert was previously

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -18,6 +18,17 @@ export class AlertRepository {
 		this.db = db;
 	}
 
+	// Serialize tags with keys in a stable (sorted) order so the SAME set of tags always
+	// produces the SAME stored string. The is_read comparison in insertOrUpdateAlert diffs
+	// the stored tags string against the incoming one; without canonical order a source that
+	// merely reorders identical keys would look "changed" and wrongly re-bold a read alert.
+	private static serializeTags(tags?: Record<string, string> | null): string {
+		if (!tags) return '{}';
+		return JSON.stringify(
+			Object.fromEntries(Object.keys(tags).sort().map((k) => [k, tags[k]]))
+		);
+	}
+
 	async insertOrUpdateAlert(alert: Omit<SharedAlert, 'createdAt' | 'isSilenced'>): Promise<{ changes: number }> {
 		return runAsync(() => {
 			// starts_at is deliberately NOT in the DO UPDATE clause: "Started At" means when
@@ -90,7 +101,7 @@ export class AlertRepository {
 					alert.type,
 					alert.severity,
 					alert.team ?? null,
-					JSON.stringify(alert.tags ?? {}),
+					AlertRepository.serializeTags(alert.tags),
 					startsAt,
 					alert.updatedAt,
 					alert.alertUrl,
@@ -134,7 +145,7 @@ export class AlertRepository {
 						alert.type,
 						alert.severity,
 						alert.team ?? null,
-						JSON.stringify(alert.tags ?? {}),
+						AlertRepository.serializeTags(alert.tags),
 						alert.startsAt,
 						alert.updatedAt,
 						alert.alertUrl,

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -2,6 +2,7 @@ import { SuperTest, Test } from 'supertest';
 import { Alert, AlertStatus, Logger } from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { AlertRow } from '../src/dal/models';
+import { AlertRepository } from '../src/dal/alertRepository';
 import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
 
 const logger = new Logger('test-alerts');
@@ -624,6 +625,108 @@ describe('Alerts API', () => {
 
 			expect(response.status).toBe(401);
 			expect(response.body.success).toBe(false);
+		});
+	});
+
+	describe('is_read change detection (re-bold on update)', () => {
+		const basePayload = {
+			id: 'reread-1',
+			tags: { service: 'api', team: 'platform' },
+			alertName: 'Re-read Test Alert',
+			summary: 'p99 latency above 800ms',
+			severity: 'critical',
+		};
+
+		const postAlert = (overrides: Record<string, unknown> = {}) =>
+			app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ ...basePayload, updatedAt: new Date().toISOString(), ...overrides });
+
+		const isRead = () =>
+			(db.prepare('SELECT is_read FROM alerts WHERE id = ?').get(basePayload.id) as { is_read: number }).is_read;
+
+		const markRead = async () => {
+			const response = await app
+				.patch(`/api/v1/alerts/${basePayload.id}/read`)
+				.set('Authorization', `Bearer ${jwtToken}`);
+			expect(response.status).toBe(200);
+			expect(isRead()).toBe(1);
+		};
+
+		test('a new alert starts unread', async () => {
+			expect((await postAlert()).status).toBe(200);
+			expect(isRead()).toBe(0);
+		});
+
+		test('a replay with identical content stays read even with a new updatedAt', async () => {
+			await postAlert();
+			await markRead();
+
+			expect((await postAlert()).status).toBe(200);
+			expect(isRead()).toBe(1);
+		});
+
+		test('the same tags in a different key order stay read', async () => {
+			await postAlert();
+			await markRead();
+
+			expect((await postAlert({ tags: { team: 'platform', service: 'api' } })).status).toBe(200);
+			expect(isRead()).toBe(1);
+		});
+
+		test('a summary change flips the alert back to unread', async () => {
+			await postAlert();
+			await markRead();
+
+			expect((await postAlert({ summary: 'p99 latency above 1600ms (escalating)' })).status).toBe(200);
+			expect(isRead()).toBe(0);
+		});
+
+		test('a severity change flips the alert back to unread', async () => {
+			await postAlert();
+			await markRead();
+
+			expect((await postAlert({ severity: 'warning' })).status).toBe(200);
+			expect(isRead()).toBe(0);
+		});
+
+		test('a tag value change flips the alert back to unread', async () => {
+			await postAlert();
+			await markRead();
+
+			expect((await postAlert({ tags: { service: 'api', team: 'checkout' } })).status).toBe(200);
+			expect(isRead()).toBe(0);
+		});
+
+		test('initAlertsTable canonicalizes legacy unsorted tags so the first replay does not re-bold', async () => {
+			// Simulates a row written before serializeTags existed: keys stored in source
+			// order. Without the startup sweep, the first identical replay would compare
+			// unsorted-stored vs sorted-incoming, read as "changed", and re-bold the row.
+			db.prepare(
+				`INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, is_read)
+				 VALUES (?, 'firing', 'Custom', 'critical', 'platform', ?, ?, ?, '', ?, ?, 1)`
+			).run(
+				basePayload.id,
+				JSON.stringify({ team: 'platform', severity: 'critical', service: 'api' }),
+				new Date().toISOString(),
+				new Date().toISOString(),
+				basePayload.alertName,
+				basePayload.summary
+			);
+
+			await new AlertRepository(db).initAlertsTable();
+
+			const stored = (
+				db.prepare('SELECT tags FROM alerts WHERE id = ?').get(basePayload.id) as {
+					tags: string;
+				}
+			).tags;
+			expect(stored).toBe(JSON.stringify({ service: 'api', severity: 'critical', team: 'platform' }));
+
+			// The replay carries the same content; the canonicalized row must stay read.
+			expect((await postAlert()).status).toBe(200);
+			expect(isRead()).toBe(1);
 		});
 	});
 

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -2,7 +2,6 @@ import { SuperTest, Test } from 'supertest';
 import { Alert, AlertStatus, Logger } from '@OpsiMate/shared';
 import Database from 'better-sqlite3';
 import { AlertRow } from '../src/dal/models';
-import { AlertRepository } from '../src/dal/alertRepository';
 import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
 
 const logger = new Logger('test-alerts');
@@ -628,7 +627,7 @@ describe('Alerts API', () => {
 		});
 	});
 
-	describe('is_read change detection (re-bold on update)', () => {
+	describe('is_read on re-arrival (re-bold whenever an alert fires again)', () => {
 		const basePayload = {
 			id: 'reread-1',
 			tags: { service: 'api', team: 'platform' },
@@ -659,23 +658,15 @@ describe('Alerts API', () => {
 			expect(isRead()).toBe(0);
 		});
 
-		test('a replay with identical content stays read even with a new updatedAt', async () => {
+		test('a repeat arrival with identical content flips a read alert back to unread', async () => {
 			await postAlert();
 			await markRead();
 
 			expect((await postAlert()).status).toBe(200);
-			expect(isRead()).toBe(1);
+			expect(isRead()).toBe(0);
 		});
 
-		test('the same tags in a different key order stay read', async () => {
-			await postAlert();
-			await markRead();
-
-			expect((await postAlert({ tags: { team: 'platform', service: 'api' } })).status).toBe(200);
-			expect(isRead()).toBe(1);
-		});
-
-		test('a summary change flips the alert back to unread', async () => {
+		test('an arrival with updated content flips a read alert back to unread', async () => {
 			await postAlert();
 			await markRead();
 
@@ -683,49 +674,13 @@ describe('Alerts API', () => {
 			expect(isRead()).toBe(0);
 		});
 
-		test('a severity change flips the alert back to unread', async () => {
+		test('marking read after a re-arrival clears the unread state again', async () => {
 			await postAlert();
 			await markRead();
-
-			expect((await postAlert({ severity: 'warning' })).status).toBe(200);
-			expect(isRead()).toBe(0);
-		});
-
-		test('a tag value change flips the alert back to unread', async () => {
 			await postAlert();
-			await markRead();
-
-			expect((await postAlert({ tags: { service: 'api', team: 'checkout' } })).status).toBe(200);
 			expect(isRead()).toBe(0);
-		});
 
-		test('initAlertsTable canonicalizes legacy unsorted tags so the first replay does not re-bold', async () => {
-			// Simulates a row written before serializeTags existed: keys stored in source
-			// order. Without the startup sweep, the first identical replay would compare
-			// unsorted-stored vs sorted-incoming, read as "changed", and re-bold the row.
-			db.prepare(
-				`INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, is_read)
-				 VALUES (?, 'firing', 'Custom', 'critical', 'platform', ?, ?, ?, '', ?, ?, 1)`
-			).run(
-				basePayload.id,
-				JSON.stringify({ team: 'platform', severity: 'critical', service: 'api' }),
-				new Date().toISOString(),
-				new Date().toISOString(),
-				basePayload.alertName,
-				basePayload.summary
-			);
-
-			await new AlertRepository(db).initAlertsTable();
-
-			const stored = (
-				db.prepare('SELECT tags FROM alerts WHERE id = ?').get(basePayload.id) as {
-					tags: string;
-				}
-			).tags;
-			expect(stored).toBe(JSON.stringify({ service: 'api', severity: 'critical', team: 'platform' }));
-
-			// The replay carries the same content; the canonicalized row must stay read.
-			expect((await postAlert()).status).toBe(200);
+			await markRead();
 			expect(isRead()).toBe(1);
 		});
 	});


### PR DESCRIPTION
## What

The alerts table renders a row **bold** while the alert is "unread". Until now `is_read` was only ever set to `0` on **INSERT** (a brand-new alert) — any later arrival of the same alert left the row un-bolded and easy to miss.

Now **every arrival re-bolds the row**: a content update *or* an identical repeat notification. All ingestion is push-based webhooks, so a repeat push is the source deliberately saying "this is still happening" — it deserves the same visual weight as a brand-new alert. Clicking the row clears the bold, as before.

Also bumps the unread weight from `font-bold` (700) to `font-black` (900) — it sat too close to the read rows' `font-medium` to stand out.

## How

- `insertOrUpdateAlert`'s `ON CONFLICT DO UPDATE` now sets `is_read = 0` unconditionally.
- Client: unread rows and the name cell render `font-black`; the content-column width measurement moved to weight 900 so the heavier glyphs don't truncate.

## Behavior

| Event | Row |
|---|---|
| New alert | **bold** |
| Same alert arrives again (identical or updated) | **bold** again |
| Resolve → re-fire | **bold** (new episode) |
| User clicks the row | regular weight |

## Verified

- New `is_read` test suite in `tests/alerts.test.ts` (4 tests, end-to-end through the API): new→unread, identical replay→unread, updated content→unread, mark-read clears again. Full alerts suite: 69/69 pass.
- Live-tested against a running instance via the real webhook: a read alert re-bolded on an identical replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Alerts now reset to unread when they reappear, including identical or updated alerts.
  * Improved unread alert visibility with stronger text emphasis.
  * Alert column sizing now accurately reflects the styling of unread alert content.
  * Read status continues to be restored when an alert is marked as read after reappearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->