### PR TITLE
fix: the All tab ignores the status filter entirely

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -202,23 +202,24 @@ const Alerts = () => {
 		filters: dashboardState.filters,
 		timeRange: dashboardState.timeRange,
 	});
-	// Fully-filtered resolved list (status included) — feeds the All view, where a
-	// status filter is meaningful ("Resolved" is one of its options).
-	const filteredResolvedAlerts = useAlertsFiltering(resolvedAlerts, {
-		filters: dashboardState.filters,
-		timeRange: dashboardState.timeRange,
-	});
-	// The Resolved VIEW runs with the status filter suspended — not deleted: an active
-	// status like Firing/Silenced can never match resolved alerts, so applying it would
-	// make the view silently empty, but wiping it (the old behavior) destroyed the
-	// user's stored filter — and dirtied the dashboard — just for peeking at Resolved.
-	// The stored filters stay intact; Active/All keep applying them.
-	const resolvedViewFilters = useMemo(() => {
+	// The Resolved and All VIEWS run with the status filter suspended — not deleted.
+	// Resolved: an active status like Firing/Silenced can never match resolved alerts,
+	// so applying it would make the view silently empty. All: the tab's promise is
+	// every alert regardless of status, so a status filter picked on Active must not
+	// follow the user there. Wiping the filter instead (the old behavior) destroyed
+	// the user's stored filter — and dirtied the dashboard — just for peeking at
+	// another tab; the stored filters stay intact and Active keeps applying them.
+	const statusSuspendedFilters = useMemo(() => {
 		const { status: _status, ...rest } = dashboardState.filters;
 		return rest;
 	}, [dashboardState.filters]);
 	const resolvedViewAlerts = useAlertsFiltering(resolvedAlerts, {
-		filters: resolvedViewFilters,
+		filters: statusSuspendedFilters,
+		timeRange: dashboardState.timeRange,
+	});
+	// Active alerts for the All view — same suspension, all statuses shown.
+	const allViewActiveAlerts = useAlertsFiltering(alerts, {
+		filters: statusSuspendedFilters,
 		timeRange: dashboardState.timeRange,
 	});
 
@@ -230,8 +231,8 @@ const Alerts = () => {
 	// its own actions. resolvedIds lets shared callbacks tell which list an alert belongs to.
 	const resolvedIds = useMemo(() => new Set(resolvedAlerts.map((a) => a.id)), [resolvedAlerts]);
 	const filteredAllAlerts = useMemo(
-		() => [...filteredAlerts, ...filteredResolvedAlerts.map((a) => ({ ...a, isResolved: true }))],
-		[filteredAlerts, filteredResolvedAlerts]
+		() => [...allViewActiveAlerts, ...resolvedViewAlerts.map((a) => ({ ...a, isResolved: true }))],
+		[allViewActiveAlerts, resolvedViewAlerts]
 	);
 
 	const {
@@ -470,7 +471,7 @@ const Alerts = () => {
 	const tabCounts: Record<AlertTab, number> = useMemo(
 		() => ({
 			[AlertTab.Active]: filterAlerts(filteredAlerts, dashboardState.query).length,
-			// Mirrors the Resolved view, which suspends the status filter (see above).
+			// Resolved and All mirror their views, which suspend the status filter (see above).
 			[AlertTab.Resolved]: filterAlerts(resolvedViewAlerts, dashboardState.query).length,
 			[AlertTab.All]: filterAlerts(filteredAllAlerts, dashboardState.query).length,
 		}),
@@ -489,7 +490,7 @@ const Alerts = () => {
 						onFilterChange={handleFilterChange}
 						collapsed={filterPanelCollapsed}
 						tagKeys={tagKeys}
-						isResolved={activeTab === AlertTab.Resolved}
+						hideStatusFilter={activeTab !== AlertTab.Active}
 					/>
 				</FilterSidebar>
 

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -60,6 +60,15 @@ export const AlertsFilterPanel = ({
 		};
 	}, [tagKeys, hideStatusFilter]);
 
+	// The filters the current view actually applies: a hidden status filter is suspended
+	// (see Alerts.tsx), so it must not constrain the other facets' options either —
+	// otherwise the sidebar disagrees with the table it describes.
+	const effectiveFilters = useMemo(() => {
+		if (!hideStatusFilter) return filters;
+		const { status: _status, ...rest } = filters;
+		return rest;
+	}, [filters, hideStatusFilter]);
+
 	const facets: FilterFacets = useMemo(() => {
 		// The value an alert presents for a given filter field, matching useAlertsFiltering's logic.
 		const getFieldValue = (alert: Alert, field: string): string => {
@@ -86,7 +95,7 @@ export const AlertsFilterPanel = ({
 		// Faceted filtering: an alert counts toward a field's facet only if it passes every OTHER
 		// active filter. A facet never constrains itself, so its own options stay fully visible.
 		const passesOtherFilters = (alert: Alert, exceptField: string): boolean => {
-			for (const [field, values] of Object.entries(filters)) {
+			for (const [field, values] of Object.entries(effectiveFilters)) {
 				if (!values || values.length === 0 || field === exceptField) continue;
 				if (!values.includes(getFieldValue(alert, field))) return false;
 			}
@@ -112,7 +121,7 @@ export const AlertsFilterPanel = ({
 		});
 
 		return result;
-	}, [alerts, filterConfig.fields, filters, users]);
+	}, [alerts, filterConfig.fields, effectiveFilters, users]);
 
 	return (
 		<FilterPanel

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -13,7 +13,9 @@ interface AlertsFilterPanelProps {
 	collapsed?: boolean;
 	className?: string;
 	tagKeys?: TagKeyInfo[];
-	isResolved?: boolean;
+	// Hide the status field: the Resolved and All views run with the status filter
+	// suspended (see Alerts.tsx), so offering it there would be a dead control.
+	hideStatusFilter?: boolean;
 }
 
 const BASE_FILTER_FIELDS = ['status', 'severity', 'type', 'alertName', 'owner'];
@@ -33,7 +35,7 @@ export const AlertsFilterPanel = ({
 	collapsed = false,
 	className,
 	tagKeys = [],
-	isResolved = false,
+	hideStatusFilter = false,
 }: AlertsFilterPanelProps) => {
 	const { data: users = [] } = useUsers();
 
@@ -50,13 +52,13 @@ export const AlertsFilterPanel = ({
 			tagKeyLabels[getTagKeyColumnId(tk.key)] = tk.label;
 		});
 
-		const baseFields = isResolved ? BASE_FILTER_FIELDS.filter((f) => f !== 'status') : BASE_FILTER_FIELDS;
+		const baseFields = hideStatusFilter ? BASE_FILTER_FIELDS.filter((f) => f !== 'status') : BASE_FILTER_FIELDS;
 
 		return {
 			fields: [...baseFields, ...tagKeyFields],
 			fieldLabels: { ...BASE_FIELD_LABELS, ...tagKeyLabels },
 		};
-	}, [tagKeys, isResolved]);
+	}, [tagKeys, hideStatusFilter]);
 
 	const facets: FilterFacets = useMemo(() => {
 		// The value an alert presents for a given filter field, matching useAlertsFiltering's logic.


### PR DESCRIPTION
## Bug

Pick a status filter on the **Active** tab (e.g. `Firing`), then switch to the **All** tab: the filter followed you there, so silenced alerts and every resolved alert vanished from a view whose whole point is *all alerts from all statuses*.

## Fix

Extends the suspend-don't-delete pattern the Resolved view already uses (#737) to the All view:

- The All view now builds from a status-suspended active list + the (already status-suspended) resolved list. Every other filter (severity, type, owner, labels, time) still applies.
- The stored filter is **suspended, not wiped** — switch back to Active and it's still there, still applying, no dashboard-dirtying just for peeking at another tab.
- The sidebar hides the Status field on the All tab (as it already did on Resolved) — offering it there would be a dead control. `AlertsFilterPanel`'s `isResolved` prop is renamed `hideStatusFilter` to say what it actually does.
- The status-filtered resolved list existed only to feed the All view, so it's deleted; All reuses the Resolved view's suspended list.

## Verified in the running app

Setup: 8 firing + 1 silenced active, 2 resolved. With `Status: Firing` checked:

| View | Before | After |
|---|---|---|
| Active | 8 | 8 (filter still applies) |
| All | 8 (silenced + resolved hidden) | **11 — everything** |
| Tab counts in the picker | mismatched | match the rendered rows |

Round-trip checked: All → Active restores the filter chip, checkbox state, and 8-row list. Typecheck, build, prettier, and lint all clean (remaining lint warnings pre-date this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Resolved and All alert views to display results independently of the status filter.
  * Preserved saved dashboard filters while temporarily suspending status filtering where appropriate.
  * Updated tab counts to match the revised alert results.
  * Hid the status filter outside the Active alerts tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->