### PR TITLE
fix(ci): build release images natively per-arch instead of under QEMU

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,93 +16,129 @@ permissions:
   packages: write
 
 jobs:
-  build-and-release:
+  version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Determine Version Type
+        id: version_type
+        env:
+          INPUT_VERSION_TYPE: ${{ github.event.inputs.version_type }}
+        run: |
+          TYPE="$INPUT_VERSION_TYPE"
+          if [ -z "$TYPE" ]; then
+            TYPE="patch"
+          fi
+          echo "Using version type: $TYPE"
+          echo "type=$TYPE" >> $GITHUB_OUTPUT
+
+      - name: Get and Bump Version
+        id: version
+        run: |
+          LATEST=$(curl -s https://api.github.com/repos/opsimate/opsimate/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
+
+          case "${{ steps.version_type.outputs.type }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch|*)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+
+  # Each architecture builds NATIVELY on its own runner (amd64 on ubuntu-latest,
+  # arm64 on GitHub's free-for-public-repos arm runners) and pushes an arch-suffixed
+  # tag. QEMU emulation is gone on purpose: emulating arm64 made node/V8 crash with
+  # SIGILL (exit 132) during `pnpm install` often enough that releases were a coin
+  # flip — and a current QEMU (setup-qemu-action) did not cure it. Native builds
+  # remove the crash class entirely and are much faster.
+  build:
+    needs: version
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
 
     defaults:
       run:
         shell: bash
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-    - name: Determine Version Type
-      id: version_type
-      env:
-        INPUT_VERSION_TYPE: ${{ github.event.inputs.version_type }}
-      run: |
-        TYPE="$INPUT_VERSION_TYPE"
-        if [ -z "$TYPE" ]; then
-          TYPE="patch"
-        fi
-        echo "Using version type: $TYPE"
-        echo "type=$TYPE" >> $GITHUB_OUTPUT
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          username: opsimate
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Get and Bump Version
-      id: version
-      run: |
-        LATEST=$(curl -s https://api.github.com/repos/opsimate/opsimate/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-        IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-        case "${{ steps.version_type.outputs.type }}" in
-          major)
-            MAJOR=$((MAJOR + 1))
-            MINOR=0
-            PATCH=0
-            ;;
-          minor)
-            MINOR=$((MINOR + 1))
-            PATCH=0
-            ;;
-          patch|*)
-            PATCH=$((PATCH + 1))
-            ;;
-        esac
+      - name: Build and Push Backend Image (${{ matrix.arch }})
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            -t opsimate/backend:${{ needs.version.outputs.version }}-${{ matrix.arch }} \
+            -f Dockerfile.server \
+            --push .
 
-        NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-        echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-        echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+      - name: Build and Push Frontend Image (${{ matrix.arch }})
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            -t opsimate/frontend:${{ needs.version.outputs.version }}-${{ matrix.arch }} \
+            -f Dockerfile.client \
+            --push .
 
-    - name: Docker Login
-      uses: docker/login-action@v4
-      with:
-        username: opsimate
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+  # Stitch the per-arch images into the multi-arch tags users actually pull
+  # (:<version> and :latest). Runs only after BOTH arch builds succeeded, so a
+  # failed arch can never leave a half-populated release tag.
+  release:
+    needs: [version, build]
+    runs-on: ubuntu-latest
 
-    - name: Set up QEMU
-      # Provides the arm64 emulator for the multi-arch build below; a current
-      # QEMU/binfmt avoids the "illegal instruction" crash older emulators hit
-      # during `pnpm install` under emulation.
-      uses: docker/setup-qemu-action@v4
+    steps:
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          username: opsimate
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      - name: Create Multi-Arch Manifests
+        run: |
+          VERSION=${{ needs.version.outputs.version }}
+          for image in backend frontend; do
+            docker buildx imagetools create \
+              -t opsimate/$image:$VERSION \
+              -t opsimate/$image:latest \
+              opsimate/$image:$VERSION-amd64 \
+              opsimate/$image:$VERSION-arm64
+          done
 
-    - name: Build and Push Backend Image
-      run: |
-        docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          -t opsimate/backend:${{ steps.version.outputs.version }} \
-          -t opsimate/backend:latest \
-          -f Dockerfile.server \
-          --push .
-
-    - name: Build and Push Frontend Image
-      run: |
-        docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          -t opsimate/frontend:${{ steps.version.outputs.version }} \
-          -t opsimate/frontend:latest \
-          -f Dockerfile.client \
-          --push .
-
-
-    - name: Update Release Draft
-      uses: release-drafter/release-drafter@v7
-      with:
-        config-name: release-drafter.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update Release Draft
+        uses: release-drafter/release-drafter@v7
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

[Run 30957555608](https://github.com/OpsiMate/OpsiMate/actions/runs/30957555608/job/92154019820) (and several before it) failed with **exit code 132 = SIGILL** during `pnpm install` in the frontend image build. The failure is in the **arm64 leg running under QEMU emulation**, where node/V8's JIT intermittently hits instructions the emulator mishandles. The run history shows it's a coin flip — near-identical pushes alternate success/failure — and the current-QEMU `setup-qemu-action` added earlier didn't cure it.

## Fix

Stop emulating. The workflow now:

1. **`version`** — same bump logic, lifted into its own job so both builds share one number.
2. **`build` (matrix)** — each arch builds **natively**: amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm` (free for public repos). Each pushes an arch-suffixed tag (`:<version>-amd64` / `:<version>-arm64`). No QEMU anywhere.
3. **`release`** — stitches the per-arch images into the `:<version>` and `:latest` multi-arch manifests via `docker buildx imagetools create`, then runs release-drafter. It only runs after **both** arch builds succeed, so a failed arch can never leave a half-populated release tag (an improvement over the old single-command build, which was all-or-nothing anyway but retried everything).

Side benefits: arm64 builds run at native speed (the QEMU leg dominated build time), and the two arches build in parallel.

## Validation

- YAML parses; job graph `version → build[amd64, arm64] → release`.
- The real proof is the first run on main after merge — happy to trigger a `workflow_dispatch` from this branch first if you prefer (note: that publishes real version-bumped images, same as any merge does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)