### PR TITLE
fix: unread alert rows render at a real 900 weight instead of clamping to 700

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -12,28 +12,21 @@ export interface AlertNameColumnProps {
 }
 
 export const AlertNameColumn = ({ alert, expanded = false, className, style }: AlertNameColumnProps) => {
-	const isUnread = alert.isRead === false;
 	return (
 		<TableCell style={style} className={cn('py-1 px-2 overflow-hidden', className)}>
-			<div className="flex items-start gap-1.5 min-w-0">
-				{/* Unread dot: font weight alone is easy to miss when scanning, so unread
-				    rows also get a filled dot before the name (the mail-client pattern).
-				    mt-1.5 centers the 8px dot on the first 20px text line, so it stays
-				    top-aligned when the expanded view wraps onto more lines. */}
-				{isUnread && <span aria-hidden className="h-2 w-2 mt-1.5 rounded-full bg-primary shrink-0" />}
-				<span
-					className={cn(
-						'text-sm block text-foreground min-w-0 flex-1',
-						expanded ? 'whitespace-normal wrap-break-word line-clamp-6' : 'truncate',
-						// Unread alerts: render the name at the heaviest weight so it clearly
-						// outweighs the read rows (font-medium) instead of sitting a hair heavier.
-						isUnread ? 'font-black' : 'font-medium'
-					)}
-					title={expanded ? undefined : alert.alertName}
-				>
-					{alert.alertName}
-				</span>
-			</div>
+			<span
+				className={cn(
+					'text-sm block text-foreground',
+					expanded ? 'whitespace-normal wrap-break-word line-clamp-6' : 'truncate',
+					// Unread alerts: render the name at the heaviest weight so it clearly
+					// outweighs the read rows (font-medium). Requires the real 900 face
+					// (loaded in main.tsx) — without it the browser clamps to 700.
+					alert.isRead === false ? 'font-black' : 'font-medium'
+				)}
+				title={expanded ? undefined : alert.alertName}
+			>
+				{alert.alertName}
+			</span>
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -12,20 +12,30 @@ export interface AlertNameColumnProps {
 }
 
 export const AlertNameColumn = ({ alert, expanded = false, className, style }: AlertNameColumnProps) => {
+	const isUnread = alert.isRead === false;
 	return (
 		<TableCell style={style} className={cn('py-1 px-2 overflow-hidden', className)}>
-			<span
-				className={cn(
-					'text-sm block text-foreground',
-					expanded ? 'whitespace-normal wrap-break-word line-clamp-6' : 'truncate',
-					// Unread alerts: render the name at the heaviest weight so it clearly
-					// outweighs the read rows (font-medium) instead of sitting a hair heavier.
-					alert.isRead === false ? 'font-black' : 'font-medium'
+			<div className="flex items-start gap-1.5 min-w-0">
+				{/* Unread dot: font weight alone is easy to miss when scanning, so unread
+				    rows also get a filled dot before the name (the mail-client pattern).
+				    mt-1.5 centers the 8px dot on the first 20px text line, so it stays
+				    top-aligned when the expanded view wraps onto more lines. */}
+				{isUnread && (
+					<span aria-hidden className="h-2 w-2 mt-1.5 rounded-full bg-primary shrink-0" />
 				)}
-				title={expanded ? undefined : alert.alertName}
-			>
-				{alert.alertName}
-			</span>
+				<span
+					className={cn(
+						'text-sm block text-foreground min-w-0 flex-1',
+						expanded ? 'whitespace-normal wrap-break-word line-clamp-6' : 'truncate',
+						// Unread alerts: render the name at the heaviest weight so it clearly
+						// outweighs the read rows (font-medium) instead of sitting a hair heavier.
+						isUnread ? 'font-black' : 'font-medium'
+					)}
+					title={expanded ? undefined : alert.alertName}
+				>
+					{alert.alertName}
+				</span>
+			</div>
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -20,9 +20,7 @@ export const AlertNameColumn = ({ alert, expanded = false, className, style }: A
 				    rows also get a filled dot before the name (the mail-client pattern).
 				    mt-1.5 centers the 8px dot on the first 20px text line, so it stays
 				    top-aligned when the expanded view wraps onto more lines. */}
-				{isUnread && (
-					<span aria-hidden className="h-2 w-2 mt-1.5 rounded-full bg-primary shrink-0" />
-				)}
+				{isUnread && <span aria-hidden className="h-2 w-2 mt-1.5 rounded-full bg-primary shrink-0" />}
 				<span
 					className={cn(
 						'text-sm block text-foreground min-w-0 flex-1',

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
@@ -13,9 +13,6 @@ import { ACTIONS_COLUMN, COLUMN_MIN_WIDTHS } from '../AlertsTable.constants';
 
 // Cell horizontal padding (px-2 both sides).
 const CELL_PADDING_PX = 16;
-// Unread rows prefix the name with a dot (8px) and its gap (6px); reserved for every
-// name so an unread row's longest name doesn't truncate where a read one wouldn't.
-const UNREAD_DOT_PX = 14;
 // Tag values render inside a badge: its padding, border and radius chrome.
 const BADGE_CHROME_PX = 30;
 // Header labels sit next to a sort icon and its gap.
@@ -118,7 +115,7 @@ export const useContentColumnWidths = ({
 					0
 				);
 				desired[col] = Math.min(
-					Math.max(content + CELL_PADDING_PX + UNREAD_DOT_PX, headerWidth, MIN_ALERT_NAME_PX),
+					Math.max(content + CELL_PADDING_PX, headerWidth, MIN_ALERT_NAME_PX),
 					MAX_ALERT_NAME_PX
 				);
 				floors[col] = MIN_ALERT_NAME_PX;

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useContentColumnWidths.ts
@@ -13,6 +13,9 @@ import { ACTIONS_COLUMN, COLUMN_MIN_WIDTHS } from '../AlertsTable.constants';
 
 // Cell horizontal padding (px-2 both sides).
 const CELL_PADDING_PX = 16;
+// Unread rows prefix the name with a dot (8px) and its gap (6px); reserved for every
+// name so an unread row's longest name doesn't truncate where a read one wouldn't.
+const UNREAD_DOT_PX = 14;
 // Tag values render inside a badge: its padding, border and radius chrome.
 const BADGE_CHROME_PX = 30;
 // Header labels sit next to a sort icon and its gap.
@@ -115,7 +118,7 @@ export const useContentColumnWidths = ({
 					0
 				);
 				desired[col] = Math.min(
-					Math.max(content + CELL_PADDING_PX, headerWidth, MIN_ALERT_NAME_PX),
+					Math.max(content + CELL_PADDING_PX + UNREAD_DOT_PX, headerWidth, MIN_ALERT_NAME_PX),
 					MAX_ALERT_NAME_PX
 				);
 				floors[col] = MIN_ALERT_NAME_PX;

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -8,6 +8,10 @@ import App from './App.tsx';
 import '@fontsource/nunito-sans/400.css';
 import '@fontsource/nunito-sans/600.css';
 import '@fontsource/nunito-sans/700.css';
+// 900 backs the unread-alert rows' font-black. Without a real 900 face the browser
+// silently maps font-black down to the heaviest loaded weight (700), which made
+// unread rows nearly indistinguishable from read ones.
+import '@fontsource/nunito-sans/900.css';
 import './index.css';
 
 const logger = new Logger('main');


### PR DESCRIPTION
## Why

Unread ("new"/updated) alert rows render `font-black` (900) — but the app only self-hosts Nunito Sans **400/600/700** (`main.tsx`). CSS font matching silently maps 900 down to the heaviest loaded face, **700**, so the earlier bold→extrabold→black bumps changed nothing on screen: unread sat at 700 vs read at ~400, and new alerts were easy to miss.

## Fix

Load the real 900 face (`@fontsource/nunito-sans/900.css`, already shipped by the package) — `font-black` is now genuinely black, and the column-width measurement font (`900 14px`, already in place) becomes accurate instead of clamped.

(An unread-dot marker was tried and removed by request — weight alone is the cue.)

## Verified live

Side-by-side on the running app: the unread row's name and cells render truly black against adjacent read rows. Clicking still clears it.

Tests 55/55, typecheck, build, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)