### PR TITLE
feat: bold the ENTIRE unread row — tag badges and owner included

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertOwnerColumn/AlertOwnerColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertOwnerColumn/AlertOwnerColumn.tsx
@@ -26,7 +26,9 @@ export const AlertOwnerColumn = ({ alert, className, isResolved = false }: Alert
 
 	return (
 		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
-			<div onClick={(e) => e.stopPropagation()}>
+			{/* PersonPicker's trigger button carries its own font-normal, which blocks the
+			    unread row's inherited font-black — re-apply it so the WHOLE line reads bold. */}
+			<div onClick={(e) => e.stopPropagation()} className={cn(alert.isRead === false && '[&_button]:font-black')}>
 				<PersonPicker
 					selectedUserId={alert.ownerId}
 					users={users}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertTagKeyColumn/AlertTagKeyColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertTagKeyColumn/AlertTagKeyColumn.tsx
@@ -21,7 +21,13 @@ export const AlertTagKeyColumn = ({ alert, tagKey, expanded = false, className, 
 			{value ? (
 				<Badge
 					variant="outline"
-					className={cn('text-xs px-1.5 py-0.5 max-w-full', expanded && 'rounded-md')}
+					className={cn(
+						'text-xs px-1.5 py-0.5 max-w-full',
+						expanded && 'rounded-md',
+						// The badge's own font-semibold blocks the unread row's inherited
+						// font-black; re-apply it so the WHOLE unread line reads bold.
+						alert.isRead === false && 'font-black'
+					)}
 					title={expanded ? undefined : value}
 				>
 					{/* truncate must sit on a child of the badge's inline-flex container


### PR DESCRIPTION
Follow-up to #749 (real 900 face).

## What

The row-level `font-black` on unread rows cascades to plain cells (dates, summary, dashes) but was blocked wherever a component sets its own weight:

- **Tag badges** — the ui `Badge` bakes in `font-semibold`
- **Owner** — the `PersonPicker` trigger button carries `font-normal`

Both now re-apply `font-black` when the alert is unread, so the whole line reads bold end to end, matching the name.

## Verified live

Unread row: name, owner, date, and tag badges (e.g. `Disk Alert: false`) all render black; adjacent read rows stay light. Clicking clears the whole line at once.

Typecheck + prettier clean, tests 55/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual emphasis for unread alerts in the alert list.
  * Unread alert owners and tag badges now appear with bolder text for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->