### PR TITLE
feat: Enter confirms the alert-action dialog, Shift+Enter inserts a newline

### DIFF
--- a/apps/client/src/components/Alerts/ConfirmAlertActionDialog/ConfirmAlertActionDialog.tsx
+++ b/apps/client/src/components/Alerts/ConfirmAlertActionDialog/ConfirmAlertActionDialog.tsx
@@ -90,6 +90,13 @@ export const ConfirmAlertActionDialog = ({ pending, onClose }: ConfirmAlertActio
 	}, [pending]);
 
 	const note = comment.trim() || undefined;
+	const confirmDisabled = !!pending?.requireComment && !note;
+
+	const confirm = () => {
+		if (!pending || confirmDisabled) return;
+		pending.run(note, pending.withSilenceDuration ? silencedUntilFor(duration) : undefined);
+		onClose();
+	};
 
 	return (
 		<AlertDialog open={!!pending} onOpenChange={(open) => !open && onClose()}>
@@ -131,21 +138,33 @@ export const ConfirmAlertActionDialog = ({ pending, onClose }: ConfirmAlertActio
 							id="action-comment"
 							value={comment}
 							onChange={(e) => setComment(e.target.value)}
+							onKeyDown={(e) => {
+								// Enter confirms the action with the typed note; Shift+Enter keeps
+								// its usual insert-a-newline meaning. Guarded against IME
+								// composition, where Enter merely commits the composed text.
+								if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+									e.preventDefault();
+									confirm();
+								}
+							}}
 							placeholder={pending.commentPlaceholder ?? 'Add a note for your team'}
 							rows={3}
 							maxLength={5000}
 						/>
+						<p className="text-xs text-muted-foreground">
+							<kbd className="rounded border bg-muted px-1 py-0.5 font-sans text-[10px]">Enter</kbd> to{' '}
+							{pending.confirmLabel.toLowerCase()} ·{' '}
+							<kbd className="rounded border bg-muted px-1 py-0.5 font-sans text-[10px]">Shift+Enter</kbd>{' '}
+							for a new line
+						</p>
 					</div>
 				)}
 
 				<AlertDialogFooter>
 					<AlertDialogCancel>Cancel</AlertDialogCancel>
 					<AlertDialogAction
-						disabled={!!pending?.requireComment && !note}
-						onClick={() => {
-							pending?.run(note, pending.withSilenceDuration ? silencedUntilFor(duration) : undefined);
-							onClose();
-						}}
+						disabled={confirmDisabled}
+						onClick={confirm}
 						className={
 							pending?.destructive
 								? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'


### PR DESCRIPTION
## What

In the resolve / silence / comment confirmation dialog on the alerts page, pressing **Enter** inside the note textarea now **runs the action** with the typed note (e.g. silence with the comment), and **Shift+Enter** inserts a newline. A small `kbd` hint under the textarea explains the behavior.

Scope: only this dialog — it's the single page-level confirmation gate used by the alert table's row menu, details footer, and bulk bar.

## Details

- Enter respects `requireComment`: while confirm is disabled (bulk-comment with an empty note), Enter does nothing.
- IME-safe: Enter during composition just commits the composed text (`isComposing` guard).
- The confirm logic is extracted and shared by the button and the key handler — one code path.

## Verified live

Silence dialog on a real alert: typed line 1 → **Shift+Enter** → typed line 2 (no submit) → **Enter** → dialog closed, alert silenced, and the stored comment carries both lines (`line 1\nline 2` confirmed in the DB). Test state cleaned up afterwards.

Tests 55/55, typecheck, build, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Confirmation actions now remain disabled until required comments are provided.
  * Pressing Enter confirms an action, while Shift+Enter adds a new line.
  * Improved handling of text input during composition.

* **Usability Improvements**
  * Added keyboard guidance beneath the comment field.
  * Confirmation actions now correctly apply optional notes and silence durations before closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->