### PR TITLE
feat: bulk "Unsilence all" when every selected alert is silenced

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -243,6 +243,7 @@ const Alerts = () => {
 		handleDeleteAlert,
 		handleUnresolveAlert,
 		handleSilenceAll,
+		handleUnsilenceAll,
 		handleAssignOwnerAll,
 		handleResolveAll,
 		handleCommentAll,
@@ -327,6 +328,10 @@ const Alerts = () => {
 			confirmResolveAlert(alertId);
 		}
 	};
+
+	// Direct (no confirmation dialog), matching the single-row unsilence: it's
+	// non-destructive and instantly reversible by silencing again.
+	const handleUnsilenceAllSelected = () => void handleUnsilenceAll(selectedAlerts, () => setSelectedAlerts([]));
 
 	const confirmSilenceAllSelected = () =>
 		setPendingAction({
@@ -675,6 +680,7 @@ const Alerts = () => {
 										selectedAlerts={selectedAlerts}
 										onClearSelection={() => setSelectedAlerts([])}
 										onSilenceAll={confirmSilenceAllSelected}
+										onUnsilenceAll={handleUnsilenceAllSelected}
 										onAssignOwnerAll={handleAssignOwnerAllSelected}
 										onResolveAll={confirmResolveAllSelected}
 										onCommentAll={confirmCommentAllSelected}

--- a/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
@@ -12,13 +12,15 @@ import {
 import { Button } from '@/components/ui/button';
 import { useUsers } from '@/hooks/queries/users';
 import { Alert } from '@OpsiMate/shared';
-import { CheckCircle2, MessageSquarePlus, Trash2 } from 'lucide-react';
+import { BellRing, CheckCircle2, MessageSquarePlus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 export interface AlertsSelectionBarProps {
 	selectedAlerts: Alert[];
 	onClearSelection: () => void;
 	onSilenceAll: () => void;
+	// Shown instead of "Silence all" when EVERY selected alert is already silenced.
+	onUnsilenceAll?: () => void;
 	onAssignOwnerAll?: (ownerId: string | null) => void;
 	onResolveAll?: () => void;
 	// Adds the same comment to every selected alert (opens the comment dialog).
@@ -30,6 +32,7 @@ export const AlertsSelectionBar = ({
 	selectedAlerts,
 	onClearSelection,
 	onSilenceAll,
+	onUnsilenceAll,
 	onAssignOwnerAll,
 	onResolveAll,
 	onCommentAll,
@@ -42,7 +45,11 @@ export const AlertsSelectionBar = ({
 		return null;
 	}
 
+	// Silence/unsilence are offered only on uniform selections: all-active gets
+	// "Silence all", all-silenced gets "Unsilence all", a mixed selection gets
+	// neither — the outcome of a bulk action on a mix is too easy to misread.
 	const allNotSilenced = selectedAlerts.every((alert) => !alert.isSilenced);
+	const allSilenced = selectedAlerts.every((alert) => alert.isSilenced);
 
 	const handleAssignOwner = (ownerId: string | null) => {
 		if (onAssignOwnerAll) {
@@ -68,6 +75,12 @@ export const AlertsSelectionBar = ({
 				{allNotSilenced && (
 					<Button variant="outline" size="sm" onClick={onSilenceAll}>
 						Silence all
+					</Button>
+				)}
+				{onUnsilenceAll && allSilenced && (
+					<Button variant="outline" size="sm" onClick={onUnsilenceAll} className="gap-1.5">
+						<BellRing className="h-3.5 w-3.5" />
+						Unsilence all
 					</Button>
 				)}
 				{onResolveAll && (

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -100,6 +100,13 @@ export const useAlertActions = () => {
 		onComplete();
 	};
 
+	// Mirror of handleSilenceAll for the way back: selections of already-silenced
+	// alerts get a one-click bulk unsilence.
+	const handleUnsilenceAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
+		await Promise.allSettled(selectedAlerts.map((alert) => unsilenceAlertMutation.mutateAsync(alert.id)));
+		onComplete();
+	};
+
 	const handleAssignOwnerAll = async (selectedAlerts: Alert[], ownerId: string | null, onComplete: () => void) => {
 		const assignPromises = selectedAlerts.map((alert) =>
 			setAlertOwnerMutation.mutateAsync({ alertId: alert.id, ownerId })
@@ -213,6 +220,7 @@ export const useAlertActions = () => {
 		handleDeleteAlert,
 		handleUnresolveAlert,
 		handleSilenceAll,
+		handleUnsilenceAll,
 		handleAssignOwnerAll,
 		handleResolveAll,
 		handleCommentAll,


### PR DESCRIPTION
## What

The selection bar had "Silence all" for all-active selections, but an all-silenced selection had no bulk way back — each alert had to be unsilenced one by one. Now:

| Selection | Bar offers |
|---|---|
| All active | Silence all (as before) |
| **All silenced** | **Unsilence all** (new) |
| Mixed | Neither (as before — a bulk action on a mix is too easy to misread) |

Runs directly without a confirmation dialog, matching the single-row unsilence — non-destructive and instantly reversible by silencing again. Selection clears on completion.

## Verified live

Silenced two alerts, selected exactly those on the Silenced view → bar showed **Unsilence all** (and no "Silence all") → click → both unsilenced (DB `is_dismissed = 0` confirmed), view updated, selection cleared.

Tests 55/55, typecheck, build, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)