### PR TITLE
fix: pin the group-by/column-toggle header controls to the pane's right edge

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -268,8 +268,13 @@ export const AlertsTable = ({
 																{needsFillerColumn && (
 																	<TableHead aria-hidden className="p-0" />
 																)}
+																{/* Pinned to the scroller's right edge: with many columns the
+																    content is wider than the pane, and without the pin the
+																    group-by/column-toggle buttons sit at the far right of the
+																    SCROLLED content — invisible until the user scrolls all the
+																    way over. Opaque bg so columns slide underneath. */}
 																<TableHead
-																	className={`${TABLE_HEAD_CLASSES} text-xs`}
+																	className={`${TABLE_HEAD_CLASSES} text-xs sticky right-0 z-10 bg-background`}
 																	style={{
 																		width: actionsColumnWidth,
 																		minWidth: actionsColumnWidth,


### PR DESCRIPTION
## Bug

With many columns visible the table scrolls horizontally — and the actions header cell (group-by + column-toggle buttons) lives at the far right of the *scrolled content*, hundreds of pixels off-screen. The controls effectively disappear unless the user happens to scroll all the way right (measured: buttons at x=1873 in a 1440px viewport).

## Fix

`position: sticky; right: 0` on the actions header cell (plus opaque `bg-background` so columns slide underneath, and z-index above sibling headers). Combined with the existing sticky-top header wrapper, the cell is now pinned in **both axes** — the toggle controls are always visible in the table's top-right corner at any scroll position.

Row-level ⋮ menus intentionally keep current behavior: pinning them would require replicating every translucent row state (severity tints, hover, selected, active) under a sticky cell, and all their actions are also reachable from the details panel.

## Verified live

- DOM measurement: actions cell stays flush at the pane's right edge at `scrollLeft` 0 and 300 (previously drifted off-screen)
- The column-toggle dropdown opens correctly anchored under the pinned button while the table is mid-scroll — the exact reported scenario
- tsc, tests 55/55, build, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * The alerts table’s actions column now remains visible while horizontally scrolling.
  * Grouping and column settings controls stay accessible with improved contrast and layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->