### PR TITLE
feat: app-level error boundary — render crashes show a card, not a white screen

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,6 +1,7 @@
 // src/App.tsx
 import { Alerts, AuthGuard, MobileWebOverlay, Profile, ThemeProvider } from '@/components';
 import { Dashboards } from '@/components/Dashboards';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import ScrollToTopButton from '@/components/ScrollToTopButton';
 import { UnsavedChangesDialog } from '@/components/shared';
 import { Toaster as Sonner } from '@/components/ui/sonner';
@@ -56,25 +57,27 @@ const App: React.FC = () => {
 							<UnsavedChangesDialogWrapper />
 
 							<BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-								<AuthGuard>
-									<Routes>
-										<Route path="/" element={<Alerts />} />
-										<Route path="/dashboards" element={<Dashboards />} />
-										<Route path="/integrations" element={<Integrations />} />
-										<Route path="/settings" element={<Settings />} />
-										<Route path="/profile" element={<Profile />} />
-										<Route path="/login" element={<Login />} />
-										<Route path="/register" element={<Register />} />
-										<Route path="/alerts" element={<Alerts />} />
-										<Route path="/mute-policies" element={<MutePolicies />} />
-										<Route path="/oncall" element={<Oncall />} />
-										<Route path="/actions" element={<Actions />} />
-										<Route path="/enrichments" element={<Enrichments />} />
-										<Route path="/forgot-password" element={<ForgotPassword />} />
-										<Route path="/reset-password" element={<ResetPasswordByEmail />} />
-										<Route path="*" element={<NotFound />} />
-									</Routes>
-								</AuthGuard>
+								<ErrorBoundary>
+									<AuthGuard>
+										<Routes>
+											<Route path="/" element={<Alerts />} />
+											<Route path="/dashboards" element={<Dashboards />} />
+											<Route path="/integrations" element={<Integrations />} />
+											<Route path="/settings" element={<Settings />} />
+											<Route path="/profile" element={<Profile />} />
+											<Route path="/login" element={<Login />} />
+											<Route path="/register" element={<Register />} />
+											<Route path="/alerts" element={<Alerts />} />
+											<Route path="/mute-policies" element={<MutePolicies />} />
+											<Route path="/oncall" element={<Oncall />} />
+											<Route path="/actions" element={<Actions />} />
+											<Route path="/enrichments" element={<Enrichments />} />
+											<Route path="/forgot-password" element={<ForgotPassword />} />
+											<Route path="/reset-password" element={<ResetPasswordByEmail />} />
+											<Route path="*" element={<NotFound />} />
+										</Routes>
+									</AuthGuard>
+								</ErrorBoundary>
 							</BrowserRouter>
 
 							<ScrollToTopButton />

--- a/apps/client/src/components/ErrorBoundary.tsx
+++ b/apps/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { Button } from '@/components/ui/button';
+import { Logger } from '@OpsiMate/shared';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const logger = new Logger('ErrorBoundary');
+
+interface ErrorBoundaryProps {
+	children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+	error: Error | null;
+}
+
+// Last line of defense for render-time exceptions: without a boundary React unmounts
+// the entire tree and the user gets an unexplained white screen. This renders a
+// readable error card instead (message + component stack) with recovery actions.
+class ErrorBoundaryInner extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+	state: ErrorBoundaryState = { error: null };
+
+	static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+		return { error };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo) {
+		logger.error(`Unhandled render error: ${error.message}\n${info.componentStack ?? ''}`, error);
+	}
+
+	render() {
+		const { error } = this.state;
+		if (!error) {
+			return this.props.children;
+		}
+
+		return (
+			<div className="flex h-screen items-center justify-center bg-background p-6">
+				<div className="w-full max-w-xl rounded-lg border bg-card p-6 shadow-sm">
+					<div className="flex items-center gap-3">
+						<AlertTriangle className="h-6 w-6 shrink-0 text-destructive" />
+						<h1 className="text-lg font-semibold text-foreground">Something went wrong</h1>
+					</div>
+					<p className="mt-2 text-sm text-muted-foreground">
+						The page hit an unexpected error while rendering. You can try again, or reload the app.
+					</p>
+					<pre className="mt-4 max-h-48 overflow-auto rounded-md bg-muted p-3 text-xs text-foreground whitespace-pre-wrap break-words">
+						{error.message}
+						{error.stack ? `\n\n${error.stack.split('\n').slice(1, 6).join('\n')}` : ''}
+					</pre>
+					<div className="mt-4 flex gap-2">
+						<Button onClick={() => window.location.reload()} className="gap-1.5">
+							<RefreshCw className="h-4 w-4" />
+							Reload app
+						</Button>
+						<Button variant="outline" onClick={() => this.setState({ error: null })}>
+							Try again
+						</Button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+// Keyed by pathname so navigating to another page automatically clears a caught error —
+// a crash on one route must not brick the rest of the app.
+export const ErrorBoundary = ({ children }: ErrorBoundaryProps) => {
+	const location = useLocation();
+	return <ErrorBoundaryInner key={location.pathname}>{children}</ErrorBoundaryInner>;
+};

--- a/apps/client/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/client/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+import { ErrorBoundaryInner } from './ErrorBoundaryInner';
+
+// Keyed by pathname so navigating to another page automatically clears a caught error —
+// a crash on one route must not brick the rest of the app.
+export const ErrorBoundary = ({ children }: { children: ReactNode }) => {
+	const location = useLocation();
+	return <ErrorBoundaryInner key={location.pathname}>{children}</ErrorBoundaryInner>;
+};

--- a/apps/client/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/client/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,9 +2,13 @@ import { ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import { ErrorBoundaryInner } from './ErrorBoundaryInner';
 
+interface ErrorBoundaryProps {
+	children: ReactNode;
+}
+
 // Keyed by pathname so navigating to another page automatically clears a caught error —
 // a crash on one route must not brick the rest of the app.
-export const ErrorBoundary = ({ children }: { children: ReactNode }) => {
+export const ErrorBoundary = ({ children }: ErrorBoundaryProps) => {
 	const location = useLocation();
 	return <ErrorBoundaryInner key={location.pathname}>{children}</ErrorBoundaryInner>;
 };

--- a/apps/client/src/components/ErrorBoundary/ErrorBoundaryInner.tsx
+++ b/apps/client/src/components/ErrorBoundary/ErrorBoundaryInner.tsx
@@ -2,25 +2,25 @@ import { Button } from '@/components/ui/button';
 import { Logger } from '@OpsiMate/shared';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { Component, ErrorInfo, ReactNode } from 'react';
-import { useLocation } from 'react-router-dom';
 
 const logger = new Logger('ErrorBoundary');
 
-interface ErrorBoundaryProps {
+export interface ErrorBoundaryInnerProps {
 	children: ReactNode;
 }
 
-interface ErrorBoundaryState {
+interface ErrorBoundaryInnerState {
 	error: Error | null;
 }
 
 // Last line of defense for render-time exceptions: without a boundary React unmounts
 // the entire tree and the user gets an unexplained white screen. This renders a
-// readable error card instead (message + component stack) with recovery actions.
-class ErrorBoundaryInner extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-	state: ErrorBoundaryState = { error: null };
+// readable error card instead, with recovery actions. The full stack goes to the
+// logger; the card shows the message always and the stack only in dev builds.
+export class ErrorBoundaryInner extends Component<ErrorBoundaryInnerProps, ErrorBoundaryInnerState> {
+	state: ErrorBoundaryInnerState = { error: null };
 
-	static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+	static getDerivedStateFromError(error: Error): ErrorBoundaryInnerState {
 		return { error };
 	}
 
@@ -46,7 +46,9 @@ class ErrorBoundaryInner extends Component<ErrorBoundaryProps, ErrorBoundaryStat
 					</p>
 					<pre className="mt-4 max-h-48 overflow-auto rounded-md bg-muted p-3 text-xs text-foreground whitespace-pre-wrap break-words">
 						{error.message}
-						{error.stack ? `\n\n${error.stack.split('\n').slice(1, 6).join('\n')}` : ''}
+						{import.meta.env.DEV && error.stack
+							? `\n\n${error.stack.split('\n').slice(1, 6).join('\n')}`
+							: ''}
 					</pre>
 					<div className="mt-4 flex gap-2">
 						<Button onClick={() => window.location.reload()} className="gap-1.5">
@@ -62,10 +64,3 @@ class ErrorBoundaryInner extends Component<ErrorBoundaryProps, ErrorBoundaryStat
 		);
 	}
 }
-
-// Keyed by pathname so navigating to another page automatically clears a caught error —
-// a crash on one route must not brick the rest of the app.
-export const ErrorBoundary = ({ children }: ErrorBoundaryProps) => {
-	const location = useLocation();
-	return <ErrorBoundaryInner key={location.pathname}>{children}</ErrorBoundaryInner>;
-};

--- a/apps/client/src/components/ErrorBoundary/index.ts
+++ b/apps/client/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
Phase 0 of the white-screen investigation (see below for context).

## What

- New `ErrorBoundary` component wrapping the route tree (inside `BrowserRouter`, outside `AuthGuard`): any unhandled render exception now shows a **readable error card** — message, trimmed stack, **Reload app** (hard reload) and **Try again** (boundary reset) — instead of React unmounting everything into a silent white screen. The component stack is logged.
- Keyed by `location.pathname`, so navigating to a different page automatically clears a caught error — one crashing route can't brick the app.

## Verified live

- Injected a temporary crash (`?boom=1` query param): boundary rendered the card with the exact error + stack, both recovery buttons work, and navigating without the param resumes the app normally. Trigger removed before commit.
- Tests 55/55, typecheck, build, lint, prettier clean.

## Context

Users hit intermittent white screens when clicking filters. Investigation so far: no persisted-state corruption in filters; a filter-click stress test froze the renderer for 45+s (suspected ResizeObserver ↔ scrollbar width-oscillation loop rather than an exception). This boundary (a) permanently fixes the "any rare crash = mystery white screen" class, and (b) turns the remaining reports into a clean diagnostic: card shown → exception (readable); still white with no card → the freeze, confirming Phase 1's target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added error recovery for unexpected application failures.
  * Displays a recovery message with options to retry or reload the app.
  * Automatically resets error state when navigating to a different route.
  * Shows additional technical details during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->