### PR TITLE
fix: reserve the scrollbar gutter + damp sub-scrollbar width deltas

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -92,7 +92,16 @@ export const AlertsTable = ({
 		resizeObserverRef.current?.disconnect();
 		resizeObserverRef.current = null;
 		if (el) {
-			const observer = new ResizeObserver((entries) => setContainerWidth(entries[0]?.contentRect.width ?? 0));
+			const observer = new ResizeObserver((entries) => {
+				const width = entries[0]?.contentRect.width ?? 0;
+				// Damper against measure feedback: sub-scrollbar-width deltas are noise
+				// from scrollbar/border toggles, and reacting to them can oscillate —
+				// width change -> columns recompute -> overflow flips -> width change...
+				// The scroller reserves its scrollbar gutter (scrollbar-gutter: stable
+				// below) so these deltas shouldn't occur at all; this is the backstop
+				// that keeps a future layout change from reintroducing the freeze.
+				setContainerWidth((prev) => (Math.abs(width - prev) < 16 && prev !== 0 ? prev : width));
+			});
 			observer.observe(el);
 			resizeObserverRef.current = observer;
 		}
@@ -225,12 +234,21 @@ export const AlertsTable = ({
 					)}
 					{/* ONE scroller for both axes. The vertical scrollbar renders at the pane's
 					    edge OUTSIDE the content, so header and rows span the full content width —
-					    no reserved gutter, no dead strip after the actions column, and the
-					    scrollbar is visible regardless of horizontal position. When the pane is
-					    narrower than the table's minimum the whole content (header included)
-					    scrolls sideways as one, so the auto-width summary column never silently
-					    collapses to zero. */}
-					<div ref={observeScroller} className="flex-1 min-h-0 overflow-auto">
+					    no dead strip after the actions column, and the scrollbar is visible
+					    regardless of horizontal position. When the pane is narrower than the
+					    table's minimum the whole content (header included) scrolls sideways as
+					    one, so the auto-width summary column never silently collapses to zero.
+					    scrollbar-gutter: stable — the scrollbar's slot at the pane edge is
+					    ALWAYS reserved, so the scrollbar appearing/disappearing cannot change
+					    the measured content width. Without it, on classic-scrollbar systems a
+					    filter click that flips the overflow state feeds back through the width
+					    observer (width change -> column widths recompute -> overflow flips
+					    again...) and can live-lock the renderer into a white-screen freeze. */}
+					<div
+						ref={observeScroller}
+						className="flex-1 min-h-0 overflow-auto"
+						style={{ scrollbarGutter: 'stable' }}
+					>
 						<div style={{ minWidth: tableMinWidth }}>
 							{/* position: sticky pins the column header vertically while it keeps
 							    moving horizontally with the columns — it cannot scroll on its own.

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -92,14 +92,25 @@ export const AlertsTable = ({
 		resizeObserverRef.current?.disconnect();
 		resizeObserverRef.current = null;
 		if (el) {
+			// The first measurement of each observed element is always accepted:
+			// containerWidth survives in React state across scroller remounts (tab
+			// switches, empty-state flips), and a new element measuring within the
+			// damper's threshold of the STALE value must not be rejected into
+			// distributing column widths from the previous element's geometry.
+			let measured = false;
 			const observer = new ResizeObserver((entries) => {
 				const width = entries[0]?.contentRect.width ?? 0;
+				if (!measured) {
+					measured = true;
+					setContainerWidth(width);
+					return;
+				}
 				// Damper against measure feedback: sub-scrollbar-width deltas are noise
-				// from scrollbar/border toggles, and reacting to them can oscillate —
-				// width change -> columns recompute -> overflow flips -> width change...
+				// from scrollbar/border toggles, and reacting to them re-runs the
+				// content-aware column sizing for no visual gain (and can feed back:
+				// width change -> columns recompute -> overflow flips -> width change).
 				// The scroller reserves its scrollbar gutter (scrollbar-gutter: stable
-				// below) so these deltas shouldn't occur at all; this is the backstop
-				// that keeps a future layout change from reintroducing the freeze.
+				// below) so these deltas shouldn't occur at all; this is the backstop.
 				setContainerWidth((prev) => (Math.abs(width - prev) < 16 && prev !== 0 ? prev : width));
 			});
 			observer.observe(el);
@@ -242,8 +253,8 @@ export const AlertsTable = ({
 					    ALWAYS reserved, so the scrollbar appearing/disappearing cannot change
 					    the measured content width. Without it, on classic-scrollbar systems a
 					    filter click that flips the overflow state feeds back through the width
-					    observer (width change -> column widths recompute -> overflow flips
-					    again...) and can live-lock the renderer into a white-screen freeze. */}
+					    observer (width change -> column widths recompute -> overflow can flip
+					    again), visible as a ~15px column jump and wasted re-renders. */}
 					<div
 						ref={observeScroller}
 						className="flex-1 min-h-0 overflow-auto"


### PR DESCRIPTION
Phase 1 of the white-screen investigation — shipped with an honest reframing after testing.

## What

Two hardening changes to the alerts table's scroll container:

1. **`scrollbar-gutter: stable`** — the vertical scrollbar's slot at the pane edge is always reserved, so the scrollbar appearing/disappearing (e.g. a filter click flipping the overflow state) can no longer change the measured content width. Removes the visible ~15px column-width jump on classic-scrollbar systems and eliminates the width→columns→overflow→width feedback class by construction.
2. **Observer damper** — the width ResizeObserver ignores sub-scrollbar-width (<16px) deltas as an independent backstop.

**UI impact:** a thin reserved strip at the pane's right edge when rows don't overflow (where the scrollbar sits when they do); column widths no longer shift when filtering across the overflow threshold.

## What testing showed (transparency)

The suspected "renderer freeze" behind the reported white screens **did not reproduce**: stress runs (rapid filter toggling, repeated single-filter toggling) recorded max long tasks of **135ms** with flat (non-escalating) per-click cost, stable DOM and heap. Earlier "frozen renderer" readings were traced to a CDP/extension tooling artifact (long-running evaluates time out while the page is demonstrably healthy and the same query answers instantly afterwards).

The white-screen investigation therefore continues through #758's error boundary: the next real occurrence self-diagnoses (error card = exception with details; blank with no card = not an exception). This PR stands on its own merits regardless.

Also noted for a future perf pass: a filter click costs ~70-135ms of main thread with only 9 alerts (3 filtering passes + facets + full table re-render) — worth profiling at production scale.

Tests 55/55, typecheck, build, prettier clean; verified live that the gutter is applied and filtering behaves normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert table resizing to prevent layout shifts and unnecessary scrollbar feedback.
  * Preserved responsiveness to significant width changes while filtering out minor fluctuations.
  * Stabilized scrollbar spacing for smoother horizontal and vertical scrolling.
  * Improved scrolling behavior by maintaining consistent space for the scrollbar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->