### PR TITLE
fix: persist the effective column order on dashboard save

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -161,8 +161,12 @@ const Alerts = () => {
 			type: dashboardState.type,
 			description: dashboardState.description,
 			filters: dashboardState.filters,
-			visibleColumns: dashboardState.visibleColumns.filter((col) => col !== ACTIONS_COLUMN),
-			columnOrder: dashboardState.columnOrder.filter((col) => col !== ACTIONS_COLUMN),
+			// Persist the EFFECTIVE columns/order (what's rendered), not the raw state:
+			// the raw state can be empty (render falls back to defaults) or missing the
+			// injected severity / appended tag columns — saving it means the arrangement
+			// on screen is not the arrangement that comes back on the next load.
+			visibleColumns: visibleColumns.filter((col) => col !== ACTIONS_COLUMN),
+			columnOrder: columnOrder.filter((col) => col !== ACTIONS_COLUMN),
 			query: dashboardState.query,
 			groupBy: dashboardState.groupBy,
 			timeRange: serializeTimeRange(dashboardState.timeRange),

--- a/apps/client/src/test/useColumnManagement.test.tsx
+++ b/apps/client/src/test/useColumnManagement.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, test } from 'vitest';
+import { useColumnManagement } from '@/components/Alerts/hooks/useColumnManagement';
+import { DEFAULT_COLUMN_ORDER, DEFAULT_VISIBLE_COLUMNS } from '@/components/Alerts/AlertsTable/AlertsTable.constants';
+import { TagKeyInfo } from '@/types';
+
+const tagKeys: TagKeyInfo[] = [
+	{ key: 'host', label: 'Host' },
+	{ key: 'env', label: 'Env' },
+];
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+// Dashboards save whatever order the table is rendering (the "effective" order), so the
+// arrangement on screen must survive a save -> load round trip unchanged. This pins the
+// bug where TV mode persisted column_order: [] — the render silently fell back to the
+// defaults while every save kept writing the empty array, so the visible arrangement was
+// never the persisted one.
+describe('effectiveColumnOrder round trip', () => {
+	test('empty stored order falls back to defaults, and that fallback round-trips', () => {
+		const first = renderHook(() => useColumnManagement({ tagKeys, visibleColumns: [], columnOrder: [] })).result
+			.current;
+		expect(first.columnOrder).toEqual(DEFAULT_COLUMN_ORDER);
+
+		// Save persists first.columnOrder / first.visibleColumns; a later load feeds them back.
+		const reloaded = renderHook(() =>
+			useColumnManagement({ tagKeys, visibleColumns: first.visibleColumns, columnOrder: first.columnOrder })
+		).result.current;
+		expect(reloaded.columnOrder).toEqual(first.columnOrder);
+		expect(reloaded.visibleColumns).toEqual(first.visibleColumns);
+	});
+
+	test('visible tag columns missing from the stored order append and then round-trip stably', () => {
+		const visibleColumns = [...DEFAULT_VISIBLE_COLUMNS, 'tagKey:host', 'tagKey:env'];
+		const first = renderHook(() =>
+			useColumnManagement({ tagKeys, visibleColumns, columnOrder: [...DEFAULT_COLUMN_ORDER] })
+		).result.current;
+		expect(first.columnOrder).toEqual([...DEFAULT_COLUMN_ORDER, 'tagKey:host', 'tagKey:env']);
+
+		const reloaded = renderHook(() =>
+			useColumnManagement({ tagKeys, visibleColumns: first.visibleColumns, columnOrder: first.columnOrder })
+		).result.current;
+		expect(reloaded.columnOrder).toEqual(first.columnOrder);
+	});
+
+	test('a user-arranged order that interleaves tag columns is preserved verbatim', () => {
+		const columnOrder = [
+			'type',
+			'severity',
+			'tagKey:host',
+			'alertName',
+			'status',
+			'summary',
+			'lastComment',
+			'owner',
+			'startsAt',
+			'updatedAt',
+			'tagKey:env',
+		];
+		const { result } = renderHook(() =>
+			useColumnManagement({ tagKeys, visibleColumns: ['type', 'alertName', 'tagKey:host'], columnOrder })
+		);
+		expect(result.current.columnOrder).toEqual(columnOrder);
+	});
+
+	test('severity injects after type for pre-severity orders, and the injection round-trips', () => {
+		const legacyOrder = ['type', 'status', 'alertName', 'summary', 'owner', 'startsAt'];
+		const first = renderHook(() =>
+			useColumnManagement({ tagKeys, visibleColumns: ['type', 'status'], columnOrder: legacyOrder })
+		).result.current;
+		expect(first.columnOrder).toEqual(['type', 'severity', 'status', 'alertName', 'summary', 'owner', 'startsAt']);
+
+		const reloaded = renderHook(() =>
+			useColumnManagement({ tagKeys, visibleColumns: first.visibleColumns, columnOrder: first.columnOrder })
+		).result.current;
+		expect(reloaded.columnOrder).toEqual(first.columnOrder);
+	});
+
+	test('explicitly hidden severity stays out of the order', () => {
+		localStorage.setItem('opsimate-severity-column-hidden', 'true');
+		const legacyOrder = ['type', 'status', 'alertName'];
+		const { result } = renderHook(() =>
+			useColumnManagement({ tagKeys, visibleColumns: ['type'], columnOrder: legacyOrder })
+		);
+		expect(result.current.columnOrder).toEqual(legacyOrder);
+	});
+});


### PR DESCRIPTION
## Problem

Phase 2 of the white-screen / column-order investigation (follow-up to #758, #759).

"The columns I reorder in some dashboards are not in the same order I saved them."

The table renders the **effective** column lists (`useColumnManagement`):
- an empty stored order silently falls back to `DEFAULT_COLUMN_ORDER`
- `severity` injects after `type` from a per-browser localStorage flag
- visible columns missing from the stored order (new columns, freshly toggled tag columns) append at the end

…but `handleSaveDashboard` persisted the **raw** `dashboardState` lists. A dashboard whose `column_order` was wiped to `[]` (the historical TV-mode exit bug — dashboards "tester" and "idan" still carried it) looked fine on screen while every save re-persisted the empty array. The arrangement on screen was never the arrangement that came back on the next load, and the render-time appends re-derived differently per session → intermittent "wrong order" reports.

## Fix

Save persists exactly what is rendered — the same shape the drag handler already persists on reorder, so the server contract is unchanged.

## Also

- Round-trip regression tests: the effective order fed back as the stored order must be a fixed point (empty→defaults, tag-column appends, severity injection, explicit severity hide).
- The two corrupted DB rows were repaired in place (local DB, no migration needed).

## Verification

- 60/60 client tests (5 new)
- Live: created a draft dashboard (state `[]`/`[]`, the exact corruption shape), saved → DB row contains the full effective `visible_columns` and `column_order` instead of `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard saves now preserve the visible column order and visibility as displayed.
  * Hidden action columns are consistently excluded when saving dashboard settings.
  * Improved handling of severity and dynamic tag columns during column configuration changes.

* **Tests**
  * Added coverage for column visibility, ordering, migrations, fallback behavior, and hidden severity columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->