### PR TITLE
fix: darken muted-foreground text for readability

### DIFF
--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -156,8 +156,8 @@
 
 		--muted: 220 13% 91%;
 		/* Secondary text. Darkened from 45% lightness after readability complaints —
-		   ~7:1 contrast on white (AAA) while staying visibly lighter than --foreground. */
-		--muted-foreground: 220 9% 35%;
+		   ~10.5:1 contrast on white while staying visibly lighter than --foreground. */
+		--muted-foreground: 220 9% 25%;
 
 		--accent: 210 100% 13%; /* Dark Blue from icon */
 		--accent-foreground: 0 0% 100%;

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -155,7 +155,9 @@
 		--info-foreground: 210 40% 98%;
 
 		--muted: 220 13% 91%;
-		--muted-foreground: 220 9% 45%; /* Medium Gray - Foggy */
+		/* Secondary text. Darkened from 45% lightness after readability complaints —
+		   ~7:1 contrast on white (AAA) while staying visibly lighter than --foreground. */
+		--muted-foreground: 220 9% 35%;
 
 		--accent: 210 100% 13%; /* Dark Blue from icon */
 		--accent-foreground: 0 0% 100%;


### PR DESCRIPTION
## Problem

Multiple users report secondary/gray text is hard to read — e.g. the section labels and metadata in the alert details side panel.

## Fix

One design-token change: light theme `--muted-foreground` goes from `220 9% 45%` to `220 9% 35%` lightness.

- Contrast on white: ~4.8:1 → ~7:1 (WCAG AAA for normal text)
- Still clearly lighter than `--foreground` (4.1% lightness), so the primary/secondary type hierarchy is preserved
- Dark theme unchanged (its muted-foreground is already `0 0% 100%`)

Every `text-muted-foreground` usage picks this up — 29 spots in the alert details panel alone, plus tables, toolbars, and form hints app-wide.

Verified live: computed color on the alert details section labels is now `rgb(81, 87, 97)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the contrast of muted text in the light theme for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->