### PR TITLE
feat: copy a table cell's value with one click

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertLastCommentColumn/AlertLastCommentColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertLastCommentColumn/AlertLastCommentColumn.tsx
@@ -1,6 +1,7 @@
 import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
+import { CopyCellButton } from '../../CopyCellButton';
 
 export interface AlertLastCommentColumnProps {
 	alert: Alert;
@@ -13,7 +14,7 @@ export interface AlertLastCommentColumnProps {
 // the full comment thread lives in the details panel's Comments tab.
 export const AlertLastCommentColumn = ({ alert, expanded = false, className }: AlertLastCommentColumnProps) => {
 	return (
-		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell className={cn('relative group/cell py-1 px-2 overflow-hidden', className)}>
 			<span
 				className={cn(
 					'text-sm text-foreground block',
@@ -23,6 +24,7 @@ export const AlertLastCommentColumn = ({ alert, expanded = false, className }: A
 			>
 				{alert.lastComment || '-'}
 			</span>
+			{alert.lastComment && <CopyCellButton value={alert.lastComment} />}
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertNameColumn/AlertNameColumn.tsx
@@ -1,6 +1,7 @@
 import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
+import { CopyCellButton } from '../../CopyCellButton';
 
 export interface AlertNameColumnProps {
 	alert: Alert;
@@ -13,7 +14,7 @@ export interface AlertNameColumnProps {
 
 export const AlertNameColumn = ({ alert, expanded = false, className, style }: AlertNameColumnProps) => {
 	return (
-		<TableCell style={style} className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell style={style} className={cn('relative group/cell py-1 px-2 overflow-hidden', className)}>
 			<span
 				className={cn(
 					'text-sm block text-foreground',
@@ -27,6 +28,7 @@ export const AlertNameColumn = ({ alert, expanded = false, className, style }: A
 			>
 				{alert.alertName}
 			</span>
+			<CopyCellButton value={alert.alertName} />
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertStartsAtColumn/AlertStartsAtColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertStartsAtColumn/AlertStartsAtColumn.tsx
@@ -2,6 +2,7 @@ import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { formatDate } from '../../../AlertsTable.utils';
+import { CopyCellButton } from '../../CopyCellButton';
 
 export interface AlertStartsAtColumnProps {
 	alert: Alert;
@@ -14,10 +15,11 @@ export const AlertStartsAtColumn = ({ alert, className }: AlertStartsAtColumnPro
 	const date = new Date(alert.startsAt);
 	const fullTimestamp = isNaN(date.getTime()) ? undefined : date.toLocaleString();
 	return (
-		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell className={cn('relative group/cell py-1 px-2 overflow-hidden', className)}>
 			<span className="text-xs text-foreground truncate block" title={fullTimestamp}>
 				{formatDate(alert.startsAt)}
 			</span>
+			<CopyCellButton value={fullTimestamp ?? String(alert.startsAt)} />
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSummaryColumn/AlertSummaryColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertSummaryColumn/AlertSummaryColumn.tsx
@@ -2,6 +2,7 @@ import { stripHtml } from '@/components/shared';
 import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
+import { CopyCellButton } from '../../CopyCellButton';
 
 export interface AlertSummaryColumnProps {
 	alert: Alert;
@@ -15,7 +16,7 @@ export const AlertSummaryColumn = ({ alert, expanded = false, className }: Alert
 	// the details panel. Collapsed it is a single truncated line; expanded it wraps but
 	// is capped at 6 lines (line-clamp) so one huge summary can't fill the viewport.
 	return (
-		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell className={cn('relative group/cell py-1 px-2 overflow-hidden', className)}>
 			<span
 				className={cn(
 					'text-sm text-foreground block',
@@ -24,6 +25,7 @@ export const AlertSummaryColumn = ({ alert, expanded = false, className }: Alert
 			>
 				{alert.summary ? stripHtml(alert.summary) : '-'}
 			</span>
+			{alert.summary && <CopyCellButton value={stripHtml(alert.summary)} />}
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertTagKeyColumn/AlertTagKeyColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertTagKeyColumn/AlertTagKeyColumn.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
+import { CopyCellButton } from '../../CopyCellButton';
 
 export interface AlertTagKeyColumnProps {
 	alert: Alert;
@@ -17,7 +18,7 @@ export const AlertTagKeyColumn = ({ alert, tagKey, expanded = false, className, 
 	const value = alert.tags?.[tagKey];
 
 	return (
-		<TableCell style={style} className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell style={style} className={cn('relative group/cell py-1 px-2 overflow-hidden', className)}>
 			{value ? (
 				<Badge
 					variant="outline"
@@ -38,6 +39,7 @@ export const AlertTagKeyColumn = ({ alert, tagKey, expanded = false, className, 
 			) : (
 				<span className="text-foreground text-xs">-</span>
 			)}
+			{value && <CopyCellButton value={value} />}
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertUpdatedAtColumn/AlertUpdatedAtColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertUpdatedAtColumn/AlertUpdatedAtColumn.tsx
@@ -2,6 +2,7 @@ import { TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { formatDate } from '../../../AlertsTable.utils';
+import { CopyCellButton } from '../../CopyCellButton';
 
 export interface AlertUpdatedAtColumnProps {
 	alert: Alert;
@@ -12,10 +13,11 @@ export const AlertUpdatedAtColumn = ({ alert, className }: AlertUpdatedAtColumnP
 	const date = new Date(alert.updatedAt);
 	const fullTimestamp = isNaN(date.getTime()) ? undefined : date.toLocaleString();
 	return (
-		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+		<TableCell className={cn('relative group/cell py-1 px-2 overflow-hidden', className)}>
 			<span className="text-xs text-foreground truncate block" title={fullTimestamp}>
 				{formatDate(alert.updatedAt)}
 			</span>
+			<CopyCellButton value={fullTimestamp ?? String(alert.updatedAt)} />
 		</TableCell>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/CopyCellButton.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/CopyCellButton.tsx
@@ -1,0 +1,68 @@
+import { Check, Copy } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+// The Clipboard API needs a secure context, and self-hosted OpsiMate commonly runs on
+// plain http — fall back to the legacy execCommand path there.
+const copyText = async (text: string): Promise<boolean> => {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {
+			// Permission denied or transient failure — try the fallback below.
+		}
+	}
+	const textarea = document.createElement('textarea');
+	textarea.value = text;
+	textarea.style.position = 'fixed';
+	textarea.style.opacity = '0';
+	document.body.appendChild(textarea);
+	textarea.select();
+	try {
+		return document.execCommand('copy');
+	} finally {
+		textarea.remove();
+	}
+};
+
+export interface CopyCellButtonProps {
+	// The FULL underlying value — not the (possibly truncated/reformatted) display text.
+	value: string;
+	className?: string;
+}
+
+// Hover-revealed copy button for table cells (issue #747). The host cell must carry
+// `relative group/cell` for the reveal and positioning to work. Click/mousedown stop
+// propagation so copying never opens the details panel or starts a drag selection.
+export const CopyCellButton = ({ value, className }: CopyCellButtonProps) => {
+	const [copied, setCopied] = useState(false);
+	const resetTimer = useRef<number>();
+	useEffect(() => () => window.clearTimeout(resetTimer.current), []);
+
+	const handleCopy = async (e: React.MouseEvent) => {
+		e.stopPropagation();
+		if (!(await copyText(value))) return;
+		setCopied(true);
+		window.clearTimeout(resetTimer.current);
+		resetTimer.current = window.setTimeout(() => setCopied(false), 1500);
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			onMouseDown={(e) => e.stopPropagation()}
+			aria-label={copied ? 'Copied' : 'Copy value'}
+			title={copied ? 'Copied!' : 'Copy value'}
+			className={cn(
+				'absolute right-0.5 top-1/2 -translate-y-1/2 rounded border bg-background p-0.5 shadow-sm',
+				'opacity-0 transition-opacity group-hover/cell:opacity-100 focus-visible:opacity-100',
+				'text-muted-foreground hover:bg-muted hover:text-foreground',
+				className
+			)}
+		>
+			{copied ? <Check className="h-3 w-3 text-secondary" /> : <Copy className="h-3 w-3" />}
+		</button>
+	);
+};


### PR DESCRIPTION
Closes #747.

## What

Hovering any text-bearing cell in the alerts table reveals a copy button at the cell's right edge; one click copies the cell's full value.

Covered columns: **alert name, summary, last comment, tag-key values, started at, updated at**. Skipped: owner (the cell is an interactive picker) and the icon-only type/severity/status columns.

## Acceptance criteria

- ✅ Cell value copied without selecting text — hover icon, single click
- ✅ Full underlying value — truncated cells copy the complete string; the date columns copy the full timestamp (`toLocaleString()`), not the time-only display
- ✅ Visual feedback — icon flips to a green check for 1.5s with a "Copied!" tooltip

## Details

- One shared `CopyCellButton`; host cells add `relative group/cell` for the hover reveal
- `click`/`mousedown` stop propagation so copying never opens the details panel or starts a checkbox drag-selection
- Clipboard API requires a secure context and self-hosted deployments often run plain http — falls back to `execCommand('copy')` there
- Verified live: copied a cell, pasted the exact full value, row click stayed suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)