### PR TITLE
[FIX]: Align tag length validation message

### DIFF
--- a/apps/client/src/components/ValidationFeedback.constants.ts
+++ b/apps/client/src/components/ValidationFeedback.constants.ts
@@ -1,0 +1,2 @@
+export const TAG_NAME_MAX_LENGTH = 50;
+export const TAG_NAME_MAX_LENGTH_LABEL = `Must be ${TAG_NAME_MAX_LENGTH} characters or less`;

--- a/apps/client/src/components/ValidationFeedback.test.ts
+++ b/apps/client/src/components/ValidationFeedback.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { validationRules } from './ValidationFeedback';
+
+const EXPECTED_TAG_NAME_MAX_LENGTH = 50;
+const EXPECTED_TAG_NAME_MAX_LENGTH_LABEL = 'Must be 50 characters or less';
+
+const tagLengthRule = validationRules.tagName.find((rule) => rule.id === 'tag-length');
+
+if (!tagLengthRule) {
+	throw new Error('Expected the tag-length validation rule to exist');
+}
+
+describe('tag name length validation', () => {
+	it('describes the inclusive 50-character limit', () => {
+		expect(tagLengthRule.label).toBe(EXPECTED_TAG_NAME_MAX_LENGTH_LABEL);
+	});
+
+	it('accepts 50 characters and rejects 51 characters', () => {
+		expect(tagLengthRule.validator('a'.repeat(EXPECTED_TAG_NAME_MAX_LENGTH))).toBe(true);
+		expect(tagLengthRule.validator('a'.repeat(EXPECTED_TAG_NAME_MAX_LENGTH + 1))).toBe(false);
+	});
+});

--- a/apps/client/src/components/ValidationFeedback.tsx
+++ b/apps/client/src/components/ValidationFeedback.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Check, X } from 'lucide-react';
+import { TAG_NAME_MAX_LENGTH, TAG_NAME_MAX_LENGTH_LABEL } from './ValidationFeedback.constants';
 
 export interface ValidationRule {
 	id: string;
@@ -140,8 +141,8 @@ export const validationRules = {
 		},
 		{
 			id: 'tag-length',
-			label: 'Must be less than 50 characters',
-			validator: (value: string) => value.length <= 50,
+			label: TAG_NAME_MAX_LENGTH_LABEL,
+			validator: (value: string) => value.length <= TAG_NAME_MAX_LENGTH,
 		},
 	],
 	color: [


### PR DESCRIPTION
## Issue Reference

Closes #765

---

## What Was Changed

- Updated the tag-length validation copy to say "Must be 50 characters or less".
- Centralized the inclusive 50-character limit and its label.
- Added regression coverage for the label and the 50/51-character boundary.

---

## Why Was It Changed

The validator accepts exactly 50 characters, while the previous message said values must be less than 50 characters. The updated copy now matches the actual inclusive limit, and the shared constant helps keep the validator and message aligned.

---

## Screenshots

Not applicable. The `tagName` validation rule is currently not referenced by a rendered client view, so there is no existing UI flow that can display this message. The regression test verifies the production rule directly.

---

## Additional Context (Optional)

Validation completed:

- `pnpm build` (4/4 workspace packages passed)
- Client test suite (10 files, 62 tests passed)
- Client lint (0 errors; pre-existing warnings only)
- Prettier check and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized tag-name validation to enforce a maximum of 50 characters.
  - Updated the validation message to clearly state the character limit.

- **Tests**
  - Added coverage confirming that 50-character names are accepted and 51-character names are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->