### PR TITLE
test(server): cover toIsoUtc timestamp normalization

### DIFF
--- a/apps/server/tests/toIsoUtc.test.ts
+++ b/apps/server/tests/toIsoUtc.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, test } from 'vitest';
 import { toIsoUtc } from '../src/utils/time';
 
 describe('toIsoUtc', () => {
-  test('treats SQLite CURRENT_TIMESTAMP as UTC and returns Z suffix', () => {
-    expect(toIsoUtc('2024-01-15 12:30:00')).toBe('2024-01-15T12:30:00.000Z');
-  });
+	test('treats SQLite CURRENT_TIMESTAMP as UTC and returns Z suffix', () => {
+		expect(toIsoUtc('2024-01-15 12:30:00')).toBe('2024-01-15T12:30:00.000Z');
+	});
 
-  test('canonicalises already-ISO values', () => {
-    expect(toIsoUtc('2024-01-15T12:30:00.000Z')).toBe('2024-01-15T12:30:00.000Z');
-  });
+	test('canonicalises already-ISO values', () => {
+		expect(toIsoUtc('2024-01-15T12:30:00.000Z')).toBe('2024-01-15T12:30:00.000Z');
+	});
 
-  test('returns empty string unchanged', () => {
-    expect(toIsoUtc('')).toBe('');
-  });
+	test('returns empty string unchanged', () => {
+		expect(toIsoUtc('')).toBe('');
+	});
 
-  test('returns unparseable input unchanged', () => {
-    expect(toIsoUtc('not-a-date')).toBe('not-a-date');
-  });
+	test('returns unparseable input unchanged', () => {
+		expect(toIsoUtc('not-a-date')).toBe('not-a-date');
+	});
 });

--- a/apps/server/tests/toIsoUtc.test.ts
+++ b/apps/server/tests/toIsoUtc.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { toIsoUtc } from '../src/utils/time';
+
+describe('toIsoUtc', () => {
+  test('treats SQLite CURRENT_TIMESTAMP as UTC and returns Z suffix', () => {
+    expect(toIsoUtc('2024-01-15 12:30:00')).toBe('2024-01-15T12:30:00.000Z');
+  });
+
+  test('canonicalises already-ISO values', () => {
+    expect(toIsoUtc('2024-01-15T12:30:00.000Z')).toBe('2024-01-15T12:30:00.000Z');
+  });
+
+  test('returns empty string unchanged', () => {
+    expect(toIsoUtc('')).toBe('');
+  });
+
+  test('returns unparseable input unchanged', () => {
+    expect(toIsoUtc('not-a-date')).toBe('not-a-date');
+  });
+});


### PR DESCRIPTION
## Summary
`toIsoUtc` had no unit tests despite being load-bearing for SQLite timestamps.

## Changes
- Vitest cases for SQLite UTC strings, ISO passthrough, empty, and unparseable input

Closes #782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for UTC timestamp conversion, canonical ISO values, empty strings, and unparseable input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->