### PR TITLE
test(client): cover TimeFilter range helper utilities

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.utils.test.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.utils.test.ts
@@ -1,47 +1,42 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import {
-  createEmptyTimeRange,
-  formatTimeRange,
-  isTimeRangeEmpty,
-  resolveTimeRange,
-} from './TimeFilter.utils';
+import { createEmptyTimeRange, formatTimeRange, isTimeRangeEmpty, resolveTimeRange } from './TimeFilter.utils';
 
 describe('TimeFilter.utils', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-06-15T12:00:00.000Z'));
-  });
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2024-06-15T12:00:00.000Z'));
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
-  test('resolveTimeRange materializes rolling preset windows from now', () => {
-    const { from, to } = resolveTimeRange({ from: null, to: null, preset: 'last1h' });
-    expect(to?.toISOString()).toBe('2024-06-15T12:00:00.000Z');
-    expect(from?.toISOString()).toBe('2024-06-15T11:00:00.000Z');
-  });
+	test('resolveTimeRange materializes rolling preset windows from now', () => {
+		const { from, to } = resolveTimeRange({ from: null, to: null, preset: 'last1h' });
+		expect(to?.toISOString()).toBe('2024-06-15T12:00:00.000Z');
+		expect(from?.toISOString()).toBe('2024-06-15T11:00:00.000Z');
+	});
 
-  test('resolveTimeRange passes custom from/to through', () => {
-    const from = new Date('2024-01-01T00:00:00.000Z');
-    const to = new Date('2024-01-02T00:00:00.000Z');
-    const result = resolveTimeRange({ from, to, preset: 'custom' });
-    expect(result.from).toBe(from);
-    expect(result.to).toBe(to);
-  });
+	test('resolveTimeRange passes custom from/to through', () => {
+		const from = new Date('2024-01-01T00:00:00.000Z');
+		const to = new Date('2024-01-02T00:00:00.000Z');
+		const result = resolveTimeRange({ from, to, preset: 'custom' });
+		expect(result.from).toBe(from);
+		expect(result.to).toBe(to);
+	});
 
-  test('formatTimeRange covers empty, preset, range, from-only, to-only', () => {
-    expect(formatTimeRange(createEmptyTimeRange())).toBe('All time');
-    expect(formatTimeRange({ from: null, to: null, preset: 'last1h' })).toBe('Last 1 hour');
-    const from = new Date(2024, 5, 15, 10, 0);
-    const to = new Date(2024, 5, 15, 12, 0);
-    expect(formatTimeRange({ from, to, preset: 'custom' })).toMatch(/06\/15 10:00 - 06\/15 12:00/);
-    expect(formatTimeRange({ from, to: null, preset: 'custom' })).toMatch(/^From /);
-    expect(formatTimeRange({ from: null, to, preset: 'custom' })).toMatch(/^Until /);
-  });
+	test('formatTimeRange covers empty, preset, range, from-only, to-only', () => {
+		expect(formatTimeRange(createEmptyTimeRange())).toBe('All time');
+		expect(formatTimeRange({ from: null, to: null, preset: 'last1h' })).toBe('Last 1 hour');
+		const from = new Date(2024, 5, 15, 10, 0);
+		const to = new Date(2024, 5, 15, 12, 0);
+		expect(formatTimeRange({ from, to, preset: 'custom' })).toMatch(/06\/15 10:00 - 06\/15 12:00/);
+		expect(formatTimeRange({ from, to: null, preset: 'custom' })).toMatch(/^From /);
+		expect(formatTimeRange({ from: null, to, preset: 'custom' })).toMatch(/^Until /);
+	});
 
-  test('createEmptyTimeRange and isTimeRangeEmpty', () => {
-    const empty = createEmptyTimeRange();
-    expect(isTimeRangeEmpty(empty)).toBe(true);
-    expect(isTimeRangeEmpty({ from: new Date(), to: null, preset: null })).toBe(false);
-  });
+	test('createEmptyTimeRange and isTimeRangeEmpty', () => {
+		const empty = createEmptyTimeRange();
+		expect(isTimeRangeEmpty(empty)).toBe(true);
+		expect(isTimeRangeEmpty({ from: new Date(), to: null, preset: null })).toBe(false);
+	});
 });

--- a/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.utils.test.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/TimeFilter/TimeFilter.utils.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  createEmptyTimeRange,
+  formatTimeRange,
+  isTimeRangeEmpty,
+  resolveTimeRange,
+} from './TimeFilter.utils';
+
+describe('TimeFilter.utils', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00.000Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('resolveTimeRange materializes rolling preset windows from now', () => {
+    const { from, to } = resolveTimeRange({ from: null, to: null, preset: 'last1h' });
+    expect(to?.toISOString()).toBe('2024-06-15T12:00:00.000Z');
+    expect(from?.toISOString()).toBe('2024-06-15T11:00:00.000Z');
+  });
+
+  test('resolveTimeRange passes custom from/to through', () => {
+    const from = new Date('2024-01-01T00:00:00.000Z');
+    const to = new Date('2024-01-02T00:00:00.000Z');
+    const result = resolveTimeRange({ from, to, preset: 'custom' });
+    expect(result.from).toBe(from);
+    expect(result.to).toBe(to);
+  });
+
+  test('formatTimeRange covers empty, preset, range, from-only, to-only', () => {
+    expect(formatTimeRange(createEmptyTimeRange())).toBe('All time');
+    expect(formatTimeRange({ from: null, to: null, preset: 'last1h' })).toBe('Last 1 hour');
+    const from = new Date(2024, 5, 15, 10, 0);
+    const to = new Date(2024, 5, 15, 12, 0);
+    expect(formatTimeRange({ from, to, preset: 'custom' })).toMatch(/06\/15 10:00 - 06\/15 12:00/);
+    expect(formatTimeRange({ from, to: null, preset: 'custom' })).toMatch(/^From /);
+    expect(formatTimeRange({ from: null, to, preset: 'custom' })).toMatch(/^Until /);
+  });
+
+  test('createEmptyTimeRange and isTimeRangeEmpty', () => {
+    const empty = createEmptyTimeRange();
+    expect(isTimeRangeEmpty(empty)).toBe(true);
+    expect(isTimeRangeEmpty({ from: new Date(), to: null, preset: null })).toBe(false);
+  });
+});

--- a/apps/server/tests/toIsoUtc.test.ts
+++ b/apps/server/tests/toIsoUtc.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, test } from 'vitest';
 import { toIsoUtc } from '../src/utils/time';
 
 describe('toIsoUtc', () => {
-  test('treats SQLite CURRENT_TIMESTAMP as UTC and returns Z suffix', () => {
-    expect(toIsoUtc('2024-01-15 12:30:00')).toBe('2024-01-15T12:30:00.000Z');
-  });
+	test('treats SQLite CURRENT_TIMESTAMP as UTC and returns Z suffix', () => {
+		expect(toIsoUtc('2024-01-15 12:30:00')).toBe('2024-01-15T12:30:00.000Z');
+	});
 
-  test('canonicalises already-ISO values', () => {
-    expect(toIsoUtc('2024-01-15T12:30:00.000Z')).toBe('2024-01-15T12:30:00.000Z');
-  });
+	test('canonicalises already-ISO values', () => {
+		expect(toIsoUtc('2024-01-15T12:30:00.000Z')).toBe('2024-01-15T12:30:00.000Z');
+	});
 
-  test('returns empty string unchanged', () => {
-    expect(toIsoUtc('')).toBe('');
-  });
+	test('returns empty string unchanged', () => {
+		expect(toIsoUtc('')).toBe('');
+	});
 
-  test('returns unparseable input unchanged', () => {
-    expect(toIsoUtc('not-a-date')).toBe('not-a-date');
-  });
+	test('returns unparseable input unchanged', () => {
+		expect(toIsoUtc('not-a-date')).toBe('not-a-date');
+	});
 });

--- a/apps/server/tests/toIsoUtc.test.ts
+++ b/apps/server/tests/toIsoUtc.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { toIsoUtc } from '../src/utils/time';
+
+describe('toIsoUtc', () => {
+  test('treats SQLite CURRENT_TIMESTAMP as UTC and returns Z suffix', () => {
+    expect(toIsoUtc('2024-01-15 12:30:00')).toBe('2024-01-15T12:30:00.000Z');
+  });
+
+  test('canonicalises already-ISO values', () => {
+    expect(toIsoUtc('2024-01-15T12:30:00.000Z')).toBe('2024-01-15T12:30:00.000Z');
+  });
+
+  test('returns empty string unchanged', () => {
+    expect(toIsoUtc('')).toBe('');
+  });
+
+  test('returns unparseable input unchanged', () => {
+    expect(toIsoUtc('not-a-date')).toBe('not-a-date');
+  });
+});


### PR DESCRIPTION
## Summary
`TimeFilter.utils.ts` had no unit tests (component tests only).

## Changes
- Vitest coverage for resolve/format/empty helpers with fake timers for rolling presets

Closes #781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for time filter behavior, including rolling and custom ranges, formatting, and empty-range handling.
  * Added coverage for UTC timestamp conversion, ISO formatting, empty values, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->