### PR TITLE
feat: first-class Fix field (manual/auto) with icon column and details badge

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertInfoSection/AlertInfoSection.tsx
@@ -5,8 +5,10 @@ import { useUsers } from '@/hooks/queries/users';
 import { Alert } from '@OpsiMate/shared';
 import { Sparkles } from 'lucide-react';
 import { IntegrationAvatar, resolveAlertIntegration } from '../../IntegrationAvatar';
+import { FixBadge } from '../../FixBadge';
 import { SeverityBadge } from '../../SeverityBadge';
 import { StatusBadge } from '../../StatusBadge';
+import { getAlertFix } from '../../utils/fix.utils';
 import { getAlertSeverity } from '../../utils/severity.utils';
 
 interface AlertInfoSectionProps {
@@ -15,6 +17,7 @@ interface AlertInfoSectionProps {
 
 export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 	const integration = resolveAlertIntegration(alert);
+	const fix = getAlertFix(alert);
 	const { data: users = [] } = useUsers();
 	const { mutate: setOwner } = useSetAlertOwner();
 
@@ -43,6 +46,7 @@ export const AlertInfoSection = ({ alert }: AlertInfoSectionProps) => {
 				    so the owner row stays compact even in a narrow panel. */}
 				<div className="ml-auto flex items-center gap-2">
 					<SeverityBadge severity={getAlertSeverity(alert)} />
+					{fix && <FixBadge fix={fix} />}
 					<StatusBadge alert={alert} />
 					{alert.appliedEnrichments && alert.appliedEnrichments.length > 0 && (
 						<Tooltip>

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/AlertRow.tsx
@@ -10,6 +10,7 @@ import { getAlertSeverity, SEVERITY_ROW_CLASSES } from '../../utils/severity.uti
 import { AlertActionsColumn } from './Columns/AlertActionsColumn';
 import { AlertNameColumn } from './Columns/AlertNameColumn';
 import { AlertOwnerColumn } from './Columns/AlertOwnerColumn';
+import { AlertFixColumn } from './Columns/AlertFixColumn';
 import { AlertSeverityColumn } from './Columns/AlertSeverityColumn';
 import { AlertStartsAtColumn } from './Columns/AlertStartsAtColumn';
 import { AlertStatusColumn } from './Columns/AlertStatusColumn';
@@ -169,6 +170,8 @@ export const AlertRow = ({
 						);
 					case 'severity':
 						return <AlertSeverityColumn key={column} alert={alert} className={COLUMN_WIDTHS.severity} />;
+					case 'fix':
+						return <AlertFixColumn key={column} alert={alert} className={COLUMN_WIDTHS.fix} />;
 					case 'status':
 						return <AlertStatusColumn key={column} alert={alert} className={COLUMN_WIDTHS.status} />;
 					case 'summary':

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertFixColumn/AlertFixColumn.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertFixColumn/AlertFixColumn.tsx
@@ -1,0 +1,21 @@
+import { TableCell } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+import { Alert } from '@OpsiMate/shared';
+import { FixBadge } from '../../../../FixBadge';
+import { getAlertFix } from '../../../../utils/fix.utils';
+
+export interface AlertFixColumnProps {
+	alert: Alert;
+	className?: string;
+}
+
+// Icon-only fix-type cell (wrench = manual, wand = auto); most alerts carry no fix
+// classification and render the empty dash.
+export const AlertFixColumn = ({ alert, className }: AlertFixColumnProps) => {
+	const fix = getAlertFix(alert);
+	return (
+		<TableCell className={cn('py-1 px-2 overflow-hidden', className)}>
+			{fix ? <FixBadge fix={fix} /> : <span className="text-foreground text-xs">-</span>}
+		</TableCell>
+	);
+};

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertFixColumn/index.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/Columns/AlertFixColumn/index.ts
@@ -1,0 +1,2 @@
+export { AlertFixColumn } from './AlertFixColumn';
+export type { AlertFixColumnProps } from './AlertFixColumn';

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_VISIBLE_COLUMNS = ['type', 'severity', 'status', 'alertName
 export const DEFAULT_COLUMN_ORDER = [
 	'type',
 	'severity',
+	'fix',
 	'status',
 	'alertName',
 	'summary',
@@ -29,6 +30,7 @@ export const COLUMN_LABELS: Record<string, string> = {
 	type: 'Type',
 	alertName: 'Alert Name',
 	severity: 'Severity',
+	fix: 'Fix',
 	status: 'Status',
 	summary: 'Summary',
 	lastComment: 'Last Comment',
@@ -48,11 +50,12 @@ export const COLUMN_LABELS: Record<string, string> = {
 // summary column silently collapsed to 0px, letting neighbors paint over it.
 export const COLUMN_WIDTHS: Record<string, string> = {
 	select: 'w-10 min-w-10 max-w-10',
-	// Type, severity and status are icon-only columns (icon-only headers too, names in
+	// Type, severity, fix and status are icon-only columns (icon-only headers too, names in
 	// tooltips).
 	type: 'w-12 min-w-12 max-w-12',
 	alertName: 'w-[240px]',
 	severity: 'w-12 min-w-12 max-w-12',
+	fix: 'w-12 min-w-12 max-w-12',
 	status: 'w-12 min-w-12 max-w-12',
 	summary: 'w-auto',
 	// Fixed like the date columns on purpose — summary must stay the table's single
@@ -72,6 +75,7 @@ export const COLUMN_MIN_WIDTHS: Record<string, number> = {
 	select: 40,
 	type: 48,
 	severity: 48,
+	fix: 48,
 	status: 48,
 	// Shrink floor; the rendered width is content-aware (useContentColumnWidths).
 	alertName: 170,

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -3,7 +3,7 @@ import { TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Activity, Plug, TriangleAlert } from 'lucide-react';
+import { Activity, Plug, TriangleAlert, Wrench } from 'lucide-react';
 import { Fragment, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertsEmptyState } from './AlertsEmptyState';
 import {
@@ -42,6 +42,7 @@ import { VirtualizedAlertList } from './VirtualizedAlertList';
 const HEADER_ICONS: Record<string, ReactNode> = {
 	type: <Plug className="h-3.5 w-3.5" />,
 	severity: <TriangleAlert className="h-3.5 w-3.5" />,
+	fix: <Wrench className="h-3.5 w-3.5" />,
 	status: <Activity className="h-3.5 w-3.5" />,
 };
 

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -358,10 +358,14 @@ export const AlertsTable = ({
 															/>
 														);
 													}
+													// Every base column must be listed here — a column the BODY renders
+													// (AlertRow's switch) but this list omits gets no header at all, so
+													// every header to its right shifts one slot left of its cells.
 													if (
 														[
 															'alertName',
 															'severity',
+															'fix',
 															'status',
 															'startsAt',
 															'updatedAt',

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
@@ -5,6 +5,7 @@ import { getIntegrationLabel, resolveAlertIntegration } from '../IntegrationAvat
 import { createServiceNameLookup } from '../utils';
 import { getAlertTagsString } from '../utils/alertTags.utils';
 import { getOwnerDisplayName, getOwnerSortKey } from '../utils/owner.utils';
+import { getAlertFix, FIX_LABELS, FIX_RANK } from '../utils/fix.utils';
 import { getAlertSeverity, SEVERITY_LABELS, SEVERITY_RANK } from '../utils/severity.utils';
 import { AlertSortField, FlatGroupItem, GroupNode, GroupStatus, SortDirection } from './AlertsTable.types';
 
@@ -48,6 +49,11 @@ const getSortValue = (alert: Alert, sortField: AlertSortField, users: UserInfo[]
 		case 'severity':
 			// Rank-based so desc = critical first, info last.
 			return SEVERITY_RANK[getAlertSeverity(alert)];
+		case 'fix': {
+			// Rank-based so desc = manual first; unclassified alerts sink to rank 0.
+			const fix = getAlertFix(alert);
+			return fix ? FIX_RANK[fix] : 0;
+		}
 		case 'summary':
 			return (alert.summary || '').toLowerCase();
 		case 'lastComment':
@@ -123,6 +129,10 @@ export const getAlertValue = (alert: Alert, field: string, users: UserInfo[] = [
 			return alert.isSilenced ? 'Silenced' : alert.isMuted ? 'Muted' : 'Firing';
 		case 'severity':
 			return SEVERITY_LABELS[getAlertSeverity(alert)];
+		case 'fix': {
+			const fix = getAlertFix(alert);
+			return fix ? FIX_LABELS[fix] : 'No fix type';
+		}
 		case 'summary':
 			return alert.summary || 'Unknown';
 		case 'startsAt':

--- a/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.constants.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.constants.ts
@@ -1,6 +1,9 @@
+// Must stay in sync with the header whitelist in AlertsTable.tsx and AlertRow's column
+// switch — a base column missing here renders a header whose sort click silently no-ops.
 export const BASE_SORT_FIELDS = [
 	'alertName',
 	'severity',
+	'fix',
 	'status',
 	'startsAt',
 	'updatedAt',

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertSorting.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertSorting.ts
@@ -19,8 +19,13 @@ export const useAlertSorting = (filteredAlerts: Alert[]) => {
 			setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
 		} else {
 			setSortField(field);
-			// Time columns: newest first; severity: critical first (desc by rank).
-			setSortDirection(field === 'startsAt' || field === 'updatedAt' || field === 'severity' ? 'desc' : 'asc');
+			// Time columns: newest first; severity: critical first; fix: manual first
+			// (both desc by rank).
+			setSortDirection(
+				field === 'startsAt' || field === 'updatedAt' || field === 'severity' || field === 'fix'
+					? 'desc'
+					: 'asc'
+			);
 		}
 	};
 

--- a/apps/client/src/components/Alerts/FixBadge/FixBadge.tsx
+++ b/apps/client/src/components/Alerts/FixBadge/FixBadge.tsx
@@ -1,0 +1,43 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { AlertFix } from '@OpsiMate/shared';
+import { Wand2, Wrench } from 'lucide-react';
+import { FIX_LABELS } from '../utils/fix.utils';
+
+// Manual = a hand tool (lucide has no screwdriver; the wrench is its tool-icon stand-in),
+// auto = a magic wand.
+const FIX_ICONS: Record<AlertFix, typeof Wrench> = {
+	[AlertFix.MANUAL]: Wrench,
+	[AlertFix.AUTO]: Wand2,
+};
+
+const FIX_TEXT_CLASSES: Record<AlertFix, string> = {
+	[AlertFix.MANUAL]: 'text-orange-500',
+	[AlertFix.AUTO]: 'text-emerald-500',
+};
+
+interface FixBadgeProps {
+	fix: AlertFix;
+	className?: string;
+}
+
+// Icon-only fix-type indicator, mirroring SeverityBadge: the label lives in a styled
+// tooltip and in an aria-label for assistive tech.
+export const FixBadge = ({ fix, className }: FixBadgeProps) => {
+	const Icon = FIX_ICONS[fix];
+	const label = `Fix: ${FIX_LABELS[fix]}`;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span
+					className={cn('inline-flex items-center shrink-0', FIX_TEXT_CLASSES[fix], className)}
+					aria-label={label}
+				>
+					<Icon className="h-3.5 w-3.5" aria-hidden />
+				</span>
+			</TooltipTrigger>
+			<TooltipContent>{label}</TooltipContent>
+		</Tooltip>
+	);
+};

--- a/apps/client/src/components/Alerts/FixBadge/FixBadge.tsx
+++ b/apps/client/src/components/Alerts/FixBadge/FixBadge.tsx
@@ -31,6 +31,7 @@ export const FixBadge = ({ fix, className }: FixBadgeProps) => {
 		<Tooltip>
 			<TooltipTrigger asChild>
 				<span
+					role="img"
 					className={cn('inline-flex items-center shrink-0', FIX_TEXT_CLASSES[fix], className)}
 					aria-label={label}
 				>

--- a/apps/client/src/components/Alerts/FixBadge/index.ts
+++ b/apps/client/src/components/Alerts/FixBadge/index.ts
@@ -1,0 +1,1 @@
+export { FixBadge } from './FixBadge';

--- a/apps/client/src/components/Alerts/SeverityBadge/SeverityBadge.tsx
+++ b/apps/client/src/components/Alerts/SeverityBadge/SeverityBadge.tsx
@@ -25,6 +25,7 @@ export const SeverityBadge = ({ severity, className }: SeverityBadgeProps) => {
 		<Tooltip>
 			<TooltipTrigger asChild>
 				<span
+					role="img"
 					className={cn('inline-flex items-center shrink-0', SEVERITY_TEXT_CLASSES[severity], className)}
 					aria-label={label}
 				>

--- a/apps/client/src/components/Alerts/utils/alertTags.utils.ts
+++ b/apps/client/src/components/Alerts/utils/alertTags.utils.ts
@@ -1,9 +1,10 @@
 import { Alert } from '@OpsiMate/shared';
 
 // Tags kept out of every tag UI (labels section, tag columns, facets, TV cards). The
-// severity tag is an internal mirror of the first-class severity field — users interact
-// with severity through the dedicated column/filter/badges, never the raw tag.
-export const HIDDEN_TAG_KEYS = new Set(['severity']);
+// severity tag is an internal mirror of the first-class severity field, and the fix tag
+// backs the first-class Fix column/badge the same way — users interact with the dedicated
+// column/badges, never the raw tag.
+export const HIDDEN_TAG_KEYS = new Set(['severity', 'fix']);
 
 export const getAlertTagsArray = (alert: Alert): string[] => {
 	if (!alert.tags || typeof alert.tags !== 'object') return [];

--- a/apps/client/src/components/Alerts/utils/fix.utils.ts
+++ b/apps/client/src/components/Alerts/utils/fix.utils.ts
@@ -1,0 +1,17 @@
+import { Alert, AlertFix, normalizeAlertFix } from '@OpsiMate/shared';
+
+export const FIX_LABELS: Record<AlertFix, string> = {
+	[AlertFix.MANUAL]: 'Manual fix',
+	[AlertFix.AUTO]: 'Auto fix',
+};
+
+// Sort rank: higher = needs a human, so a descending sort surfaces manual-fix alerts
+// first; unclassified alerts (null) rank 0 and sink to the end either way.
+export const FIX_RANK: Record<AlertFix, number> = {
+	[AlertFix.MANUAL]: 2,
+	[AlertFix.AUTO]: 1,
+};
+
+// The fix classification rides on a `fix` tag (there is no first-class column like
+// severity's); null when the alert carries no recognizable value.
+export const getAlertFix = (alert: Alert): AlertFix | null => normalizeAlertFix(alert.tags?.['fix']);

--- a/apps/client/src/test/fix.utils.test.ts
+++ b/apps/client/src/test/fix.utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { Alert, AlertFix, normalizeAlertFix } from '@OpsiMate/shared';
+import { getAlertFix } from '@/components/Alerts/utils/fix.utils';
+
+describe('normalizeAlertFix', () => {
+	test('recognizes manual synonyms', () => {
+		for (const v of ['manual', 'Manual Fix', 'MANUALFIX', 'manual_fix', 'manual-fix']) {
+			expect(normalizeAlertFix(v)).toBe(AlertFix.MANUAL);
+		}
+	});
+
+	test('recognizes auto synonyms', () => {
+		for (const v of ['auto', 'Auto Fix', 'autofix', 'AUTOMATIC', 'automated', 'auto_fix']) {
+			expect(normalizeAlertFix(v)).toBe(AlertFix.AUTO);
+		}
+	});
+
+	test('unknown or missing values are null — no default, unlike severity', () => {
+		expect(normalizeAlertFix('sometimes')).toBeNull();
+		expect(normalizeAlertFix('')).toBeNull();
+		expect(normalizeAlertFix(undefined)).toBeNull();
+		expect(normalizeAlertFix(null)).toBeNull();
+	});
+
+	test('prototype keys in user-controlled input do not resolve', () => {
+		expect(normalizeAlertFix('constructor')).toBeNull();
+		expect(normalizeAlertFix('__proto__')).toBeNull();
+	});
+});
+
+describe('getAlertFix', () => {
+	test('reads the fix tag; absent tag is null', () => {
+		expect(getAlertFix({ tags: { fix: 'manual' } } as unknown as Alert)).toBe(AlertFix.MANUAL);
+		expect(getAlertFix({ tags: { fix: 'auto' } } as unknown as Alert)).toBe(AlertFix.AUTO);
+		expect(getAlertFix({ tags: {} } as unknown as Alert)).toBeNull();
+		expect(getAlertFix({} as unknown as Alert)).toBeNull();
+	});
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -187,6 +187,36 @@ export function normalizeAlertSeverity(value?: string | null): AlertSeverity {
 	return Object.hasOwn(SEVERITY_SYNONYMS, key) ? SEVERITY_SYNONYMS[key] : DEFAULT_ALERT_SEVERITY;
 }
 
+// How an alert gets fixed: by hand or by automation. Carried on a `fix` tag; unlike
+// severity there is no default — most alerts have no fix classification and show nothing.
+export enum AlertFix {
+	MANUAL = 'manual',
+	AUTO = 'auto',
+}
+
+const FIX_SYNONYMS: Record<string, AlertFix> = {
+	manual: AlertFix.MANUAL,
+	'manual fix': AlertFix.MANUAL,
+	manualfix: AlertFix.MANUAL,
+	manual_fix: AlertFix.MANUAL,
+	'manual-fix': AlertFix.MANUAL,
+	auto: AlertFix.AUTO,
+	'auto fix': AlertFix.AUTO,
+	autofix: AlertFix.AUTO,
+	auto_fix: AlertFix.AUTO,
+	'auto-fix': AlertFix.AUTO,
+	automatic: AlertFix.AUTO,
+	automated: AlertFix.AUTO,
+};
+
+// Maps a free-form fix string onto the manual/auto pair; unknown or missing values are
+// null — "no classification", rendered as empty. Same hasOwn guard as severity.
+export function normalizeAlertFix(value?: string | null): AlertFix | null {
+	if (!value) return null;
+	const key = value.trim().toLowerCase();
+	return Object.hasOwn(FIX_SYNONYMS, key) ? FIX_SYNONYMS[key] : null;
+}
+
 export interface Alert {
 	id: string;
 	type: AlertType;


### PR DESCRIPTION
## What

A new special field, **Fix**, classifying how an alert gets resolved: **Manual fix** (wrench icon — lucide has no screwdriver; the wrench is the closest tool icon) or **Auto fix** (magic wand). Modeled on severity's hidden-tag architecture.

## Behavior

- The value rides on a `fix` tag in the alert payload; `normalizeAlertFix` accepts free-form synonyms (`manual fix`, `manualfix`, `auto`, `autofix`, `automatic`, `automated`, …)
- **No default** — unlike severity, alerts without the tag show nothing (dash in the table, no badge in details)
- **Table**: icon-only Fix column (orange wrench / green wand), **hidden by default**, toggleable from column settings, ordered right after Severity; sortable (manual first on desc) and groupable ("No fix type" bucket for unclassified)
- **Details panel**: FixBadge appears in the owner row's icon strip between severity and status, with a tooltip label
- The raw `fix` tag joins `HIDDEN_TAG_KEYS` — like the severity tag it never surfaces as a tag column, facet, or label; users interact only with the first-class UI

## Verification

- 71/71 client tests (9 new: synonym normalization, null default, prototype-key guard, tag extraction), 141/141 server tests
- Live: sent two webhook alerts with `fix: manual` / `fix: auto` — default table shows no Fix column; toggling it on shows the wrench/wand between Severity and Status; details owner row shows the badge; LABELS section correctly hides the raw tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added manual and automated fix classifications for alerts.
- Alerts now display fix badges with icons, labels, and tooltips.
- Added a Fix column to the alerts table.
- Fix classifications can be sorted and configured as a table column.
- Missing or unrecognized fix values are handled gracefully.

## Bug Fixes
- Prevented fix classifications from appearing redundantly in alert tag displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->