### PR TITLE
feat: alert links array with labeled, icon-carrying link buttons

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsBody/AlertDetailsBody.tsx
@@ -7,6 +7,7 @@ import { AlertHistorySection } from '../AlertHistorySection';
 import { AlertInfoSection } from '../AlertInfoSection';
 import { AlertLastCommentSection } from '../AlertLastCommentSection';
 import { AlertLinksSection } from '../AlertLinksSection';
+import { getAlertLinks } from '../../utils/links.utils';
 import { AlertSummarySection } from '../AlertSummarySection';
 import { AlertTagsSection } from '../AlertTagsSection';
 import { AlertTeamSection } from '../AlertTeamSection';
@@ -59,7 +60,7 @@ export const AlertDetailsBody = ({ alert, historyData, timeRange, onViewAllComme
 				<AlertTimestampsSection alert={alert} />
 			</CollapsibleSection>
 
-			{(alert.alertUrl || alert.runbookUrl) && (
+			{getAlertLinks(alert).length > 0 && (
 				<CollapsibleSection title="Links" icon={<Link2 className="h-3.5 w-3.5" />} defaultOpen={false}>
 					<AlertLinksSection alert={alert} />
 				</CollapsibleSection>

--- a/apps/client/src/components/Alerts/AlertDetails/AlertLinksSection/AlertLinksSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertLinksSection/AlertLinksSection.tsx
@@ -1,41 +1,42 @@
 import { Button } from '@/components/ui/button';
 import { Alert } from '@OpsiMate/shared';
-import { Book, ExternalLink } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
+import { integrationDefinitions, normalizeIntegration } from '../../IntegrationAvatar';
+import { getAlertLinks } from '../../utils/links.utils';
 
 interface AlertLinksSectionProps {
 	alert: Alert;
 }
 
+// A link's icon slug resolved against the integration icon set; empty or unrecognized
+// slugs get the generic external-link glyph.
+export const AlertLinkIcon = ({ icon, className = 'h-3 w-3 shrink-0' }: { icon?: string; className?: string }) => {
+	const kind = normalizeIntegration(icon);
+	if (kind) return <span className="shrink-0 inline-flex">{integrationDefinitions[kind].render(className)}</span>;
+	return <ExternalLink className={className} />;
+};
+
 export const AlertLinksSection = ({ alert }: AlertLinksSectionProps) => {
-	if (!alert.alertUrl && !alert.runbookUrl) {
+	const links = getAlertLinks(alert);
+	if (links.length === 0) {
 		return null;
 	}
 
 	return (
 		<div className="grid grid-cols-2 gap-2">
-			{alert.alertUrl && (
+			{links.map((link) => (
 				<Button
+					key={`${link.label}-${link.url}`}
 					variant="outline"
 					size="sm"
 					className="w-full justify-start gap-2 text-xs h-8"
-					onClick={() => window.open(alert.alertUrl, '_blank', 'noopener,noreferrer')}
+					title={link.url}
+					onClick={() => window.open(link.url, '_blank', 'noopener,noreferrer')}
 				>
-					<ExternalLink className="h-3 w-3 shrink-0" />
-					<span className="truncate">Source</span>
+					<AlertLinkIcon icon={link.icon} />
+					<span className="truncate">{link.label}</span>
 				</Button>
-			)}
-
-			{alert.runbookUrl && (
-				<Button
-					variant="outline"
-					size="sm"
-					className="w-full justify-start gap-2 text-xs h-8"
-					onClick={() => window.open(alert.runbookUrl, '_blank', 'noopener,noreferrer')}
-				>
-					<Book className="h-3 w-3 shrink-0" />
-					<span className="truncate">Runbook</span>
-				</Button>
-			)}
+			))}
 		</div>
 	);
 };

--- a/apps/client/src/components/Alerts/AlertDetails/AlertLinksSection/AlertLinksSection.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertLinksSection/AlertLinksSection.tsx
@@ -1,20 +1,11 @@
 import { Button } from '@/components/ui/button';
 import { Alert } from '@OpsiMate/shared';
-import { ExternalLink } from 'lucide-react';
-import { integrationDefinitions, normalizeIntegration } from '../../IntegrationAvatar';
+import { AlertLinkIcon } from '../../AlertLinkIcon';
 import { getAlertLinks } from '../../utils/links.utils';
 
 interface AlertLinksSectionProps {
 	alert: Alert;
 }
-
-// A link's icon slug resolved against the integration icon set; empty or unrecognized
-// slugs get the generic external-link glyph.
-export const AlertLinkIcon = ({ icon, className = 'h-3 w-3 shrink-0' }: { icon?: string; className?: string }) => {
-	const kind = normalizeIntegration(icon);
-	if (kind) return <span className="shrink-0 inline-flex">{integrationDefinitions[kind].render(className)}</span>;
-	return <ExternalLink className={className} />;
-};
 
 export const AlertLinksSection = ({ alert }: AlertLinksSectionProps) => {
 	const links = getAlertLinks(alert);

--- a/apps/client/src/components/Alerts/AlertLinkIcon/AlertLinkIcon.tsx
+++ b/apps/client/src/components/Alerts/AlertLinkIcon/AlertLinkIcon.tsx
@@ -1,0 +1,16 @@
+import { ExternalLink } from 'lucide-react';
+import { integrationDefinitions, normalizeIntegration } from '../IntegrationAvatar';
+
+export interface AlertLinkIconProps {
+	icon?: string;
+	className?: string;
+}
+
+// A link's icon slug resolved against the integration icon set; empty or unrecognized
+// slugs get the generic external-link glyph. Shared by the details panel's links
+// section, the row's ⋮ menu, and the services-page alert list.
+export const AlertLinkIcon = ({ icon, className = 'h-3 w-3 shrink-0' }: AlertLinkIconProps) => {
+	const kind = normalizeIntegration(icon);
+	if (kind) return <span className="shrink-0 inline-flex">{integrationDefinitions[kind].render(className)}</span>;
+	return <ExternalLink className={className} />;
+};

--- a/apps/client/src/components/Alerts/AlertLinkIcon/index.ts
+++ b/apps/client/src/components/Alerts/AlertLinkIcon/index.ts
@@ -1,0 +1,2 @@
+export { AlertLinkIcon } from './AlertLinkIcon';
+export type { AlertLinkIconProps } from './AlertLinkIcon';

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Alert } from '@OpsiMate/shared';
 import { BellOff, CheckCircle2, Flame, MoreVertical, RotateCcw, Trash2 } from 'lucide-react';
-import { AlertLinkIcon } from '../../../AlertDetails/AlertLinksSection/AlertLinksSection';
+import { AlertLinkIcon } from '../../../AlertLinkIcon';
 import { getAlertLinks } from '../../../utils/links.utils';
 
 export interface RowActionsProps {

--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/RowActions/RowActions.tsx
@@ -7,7 +7,9 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Alert } from '@OpsiMate/shared';
-import { BellOff, Book, CheckCircle2, ExternalLink, Flame, MoreVertical, RotateCcw, Trash2 } from 'lucide-react';
+import { BellOff, CheckCircle2, Flame, MoreVertical, RotateCcw, Trash2 } from 'lucide-react';
+import { AlertLinkIcon } from '../../../AlertDetails/AlertLinksSection/AlertLinksSection';
+import { getAlertLinks } from '../../../utils/links.utils';
 
 export interface RowActionsProps {
 	alert: Alert;
@@ -25,7 +27,8 @@ export const RowActions = ({
 	onDeleteAlert,
 	onUnresolveAlert,
 }: RowActionsProps) => {
-	const { alertUrl, runbookUrl, isSilenced } = alert;
+	const { isSilenced } = alert;
+	const links = getAlertLinks(alert);
 	// In the combined "All" view a row carries a transient isResolved flag so it can present
 	// resolved behaviour (permanent delete, no silence/resolve) even though the table-level
 	// callbacks are shared across active and resolved rows.
@@ -36,7 +39,7 @@ export const RowActions = ({
 	// Only resolved rows can be moved back to firing (isActive is false on the Resolved tab
 	// and on resolved rows in the All view).
 	const canUnresolve = !isActive && Boolean(onUnresolveAlert);
-	const hasActions = Boolean(alertUrl || runbookUrl || onDeleteAlert || canToggleSilence || canUnresolve);
+	const hasActions = Boolean(links.length > 0 || onDeleteAlert || canToggleSilence || canUnresolve);
 
 	const handleToggleSilence = (event: React.MouseEvent) => {
 		event.stopPropagation();
@@ -78,29 +81,21 @@ export const RowActions = ({
 					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
-					{runbookUrl && (
+					{links.map((link) => (
 						<DropdownMenuItem
+							key={`${link.label}-${link.url}`}
 							onClick={(event) => {
 								event.stopPropagation();
-								handleOpenLink(runbookUrl);
+								handleOpenLink(link.url);
 							}}
 						>
-							<Book className="mr-2 h-3 w-3" />
-							Runbook
+							<span className="mr-2 inline-flex">
+								<AlertLinkIcon icon={link.icon} className="h-3 w-3" />
+							</span>
+							{link.label}
 						</DropdownMenuItem>
-					)}
-					{alertUrl && (
-						<DropdownMenuItem
-							onClick={(event) => {
-								event.stopPropagation();
-								handleOpenLink(alertUrl);
-							}}
-						>
-							<ExternalLink className="mr-2 h-3 w-3" />
-							Source
-						</DropdownMenuItem>
-					)}
-					{(runbookUrl || alertUrl) && (onDeleteAlert || canToggleSilence || canUnresolve) && (
+					))}
+					{links.length > 0 && (onDeleteAlert || canToggleSilence || canUnresolve) && (
 						<DropdownMenuSeparator />
 					)}
 					{canUnresolve && (

--- a/apps/client/src/components/Alerts/IntegrationAvatar.tsx
+++ b/apps/client/src/components/Alerts/IntegrationAvatar.tsx
@@ -2,7 +2,12 @@ import { cn } from '@/lib/utils';
 import { AlertIntegrationKind, iconSizeMap, sizeMap } from './IntegrationAvatar.types';
 import { integrationDefinitions } from './IntegrationAvatar.utils';
 
-export { getIntegrationLabel, resolveAlertIntegration } from './IntegrationAvatar.utils';
+export {
+	getIntegrationLabel,
+	integrationDefinitions,
+	normalizeIntegration,
+	resolveAlertIntegration,
+} from './IntegrationAvatar.utils';
 
 interface IntegrationAvatarProps {
 	integration: AlertIntegrationKind;

--- a/apps/client/src/components/Alerts/IntegrationAvatar.utils.tsx
+++ b/apps/client/src/components/Alerts/IntegrationAvatar.utils.tsx
@@ -54,7 +54,7 @@ export const integrationDefinitions: Record<AlertIntegrationKind, IntegrationDef
 	},
 };
 
-const normalizeIntegration = (value?: string | null): AlertIntegrationKind | undefined => {
+export const normalizeIntegration = (value?: string | null): AlertIntegrationKind | undefined => {
 	if (!value) return undefined;
 	const normalized = value.toLowerCase();
 	if (normalized.includes('grafana')) return 'grafana';

--- a/apps/client/src/components/Alerts/utils/links.utils.ts
+++ b/apps/client/src/components/Alerts/utils/links.utils.ts
@@ -1,0 +1,14 @@
+import { Alert, AlertLink } from '@OpsiMate/shared';
+
+// The alert's effective link collection. `links` is the source of truth when present;
+// otherwise the legacy alertUrl/runbookUrl pair folds in so pre-links alerts (and the
+// built-in integrations, which still populate those fields) keep their buttons. The
+// legacy Source entry carries the alert's type as its icon slug — a Grafana alert's
+// source link IS Grafana.
+export const getAlertLinks = (alert: Alert): AlertLink[] => {
+	if (alert.links?.length) return alert.links;
+	const legacy: AlertLink[] = [];
+	if (alert.alertUrl) legacy.push({ label: 'Source', icon: alert.type, url: alert.alertUrl });
+	if (alert.runbookUrl) legacy.push({ label: 'Runbook', icon: '', url: alert.runbookUrl });
+	return legacy;
+};

--- a/apps/client/src/components/AlertsSection.tsx
+++ b/apps/client/src/components/AlertsSection.tsx
@@ -3,7 +3,9 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Logger, Alert as SharedAlert } from '@OpsiMate/shared';
-import { ExternalLink, X } from 'lucide-react';
+import { X } from 'lucide-react';
+import { AlertLinkIcon } from '@/components/Alerts/AlertDetails/AlertLinksSection/AlertLinksSection';
+import { getAlertLinks } from '@/components/Alerts/utils/links.utils';
 import { useState } from 'react';
 
 const logger = new Logger('AlertsSection');

--- a/apps/client/src/components/AlertsSection.tsx
+++ b/apps/client/src/components/AlertsSection.tsx
@@ -4,7 +4,7 @@ import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Logger, Alert as SharedAlert } from '@OpsiMate/shared';
 import { X } from 'lucide-react';
-import { AlertLinkIcon } from '@/components/Alerts/AlertDetails/AlertLinksSection/AlertLinksSection';
+import { AlertLinkIcon } from '@/components/Alerts/AlertLinkIcon';
 import { getAlertLinks } from '@/components/Alerts/utils/links.utils';
 import { useState } from 'react';
 
@@ -87,29 +87,19 @@ export const AlertsSection = ({ alerts, onAlertSilence, className }: AlertsSecti
 								)}
 							</div>
 							<div className="flex items-center gap-1 shrink-0">
-								{alert.runbookUrl && (
+								{getAlertLinks(alert).map((link) => (
 									<Button
+										key={`${link.label}-${link.url}`}
 										variant="ghost"
 										size="icon"
 										className="h-7 w-7 p-0 text-muted-foreground hover:bg-accent focus:bg-accent focus:ring-2 focus:ring-primary"
-										title="Open Runbook"
-										onClick={() => window.open(alert.runbookUrl, '_blank', 'noopener,noreferrer')}
+										title={link.label}
+										onClick={() => handleAlertClick(link.url)}
 									>
-										<span className="sr-only">Open Runbook</span>
-										📖
+										<span className="sr-only">{link.label}</span>
+										<AlertLinkIcon icon={link.icon} className="h-4 w-4" />
 									</Button>
-								)}
-								{alert.alertUrl && (
-									<Button
-										variant="ghost"
-										size="icon"
-										className="h-7 w-7 p-0 text-muted-foreground hover:bg-accent focus:bg-accent focus:ring-2 focus:ring-primary"
-										title="View in Grafana"
-										onClick={() => handleAlertClick(alert.alertUrl)}
-									>
-										<ExternalLink className="h-4 w-4" />
-									</Button>
-								)}
+								))}
 								{onAlertSilence && (
 									<Button
 										variant="ghost"

--- a/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
+++ b/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
@@ -29,6 +29,8 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
   "tags": { "environment": "production", "team": "backend" },
   "alertName": "High CPU Usage Alert",
   "summary": "CPU usage exceeded 90% threshold",
+  "severity": "critical",
+  "fix": "manual",
   "startsAt": "2024-01-15T10:30:00Z",
   "links": [
     { "label": "OpsiMate demo", "icon": "", "url": "https://demo.opsimate.dev/" },
@@ -202,6 +204,27 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 											</td>
 											<td className="p-3 text-muted-foreground">
 												Key-value pairs for categorization
+											</td>
+										</tr>
+										<tr>
+											<td className="p-3 font-mono text-xs">severity</td>
+											<td className="p-3">
+												<span className="text-muted-foreground">No</span>
+											</td>
+											<td className="p-3 text-muted-foreground">
+												critical / warning / info (free-form synonyms accepted — P1, error,
+												disaster, ...); defaults to warning
+											</td>
+										</tr>
+										<tr>
+											<td className="p-3 font-mono text-xs">fix</td>
+											<td className="p-3">
+												<span className="text-muted-foreground">No</span>
+											</td>
+											<td className="p-3 text-muted-foreground">
+												&quot;manual&quot; or &quot;auto&quot; (synonyms accepted — manual fix,
+												autofix, automated, ...); shows as the Fix column and badge. Empty by
+												default
 											</td>
 										</tr>
 										<tr>

--- a/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
+++ b/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
@@ -27,11 +27,14 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 	const examplePayload = `{
   "id": "unique-alert-id",
   "tags": { "environment": "production", "team": "backend" },
-  "alertUrl": "https://link-to-alert-source",
   "alertName": "High CPU Usage Alert",
   "summary": "CPU usage exceeded 90% threshold",
   "startsAt": "2024-01-15T10:30:00Z",
-  "runbookUrl": "https://docs.example.com/runbooks/cpu-alert"
+  "links": [
+    { "label": "OpsiMate demo", "icon": "", "url": "https://demo.opsimate.dev/" },
+    { "label": "Grafana dashboard", "icon": "grafana", "url": "https://grafana.example.com/d/cpu" },
+    { "label": "Runbook", "icon": "", "url": "https://docs.example.com/runbooks/cpu-alert" }
+  ]
 }`;
 
 	const handleCopy = async (text: string, type: 'url' | 'payload' | 'resolve' | 'delete') => {
@@ -202,11 +205,26 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 											</td>
 										</tr>
 										<tr>
+											<td className="p-3 font-mono text-xs">links</td>
+											<td className="p-3">
+												<span className="text-muted-foreground">No</span>
+											</td>
+											<td className="p-3 text-muted-foreground">
+												Array of {'{ label, icon, url }'} — each renders as a button in the
+												alert&apos;s Links section. icon is an optional slug matched against the
+												integration icons (grafana, uptimekuma, gcp, datadog, zabbix); empty or
+												unknown values get a generic link icon
+											</td>
+										</tr>
+										<tr>
 											<td className="p-3 font-mono text-xs">alertUrl</td>
 											<td className="p-3">
-												<span className="text-red-600 dark:text-red-400 font-medium">Yes</span>
+												<span className="text-muted-foreground">No</span>
 											</td>
-											<td className="p-3 text-muted-foreground">URL to the alert source</td>
+											<td className="p-3 text-muted-foreground">
+												Deprecated — use links. Still accepted; shows as the &quot;Source&quot;
+												link when links is absent
+											</td>
 										</tr>
 										<tr>
 											<td className="p-3 font-mono text-xs">summary</td>
@@ -240,7 +258,10 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 											<td className="p-3">
 												<span className="text-muted-foreground">No</span>
 											</td>
-											<td className="p-3 text-muted-foreground">URL to runbook documentation</td>
+											<td className="p-3 text-muted-foreground">
+												Deprecated — use links. Still accepted; shows as the &quot;Runbook&quot;
+												link when links is absent
+											</td>
 										</tr>
 									</tbody>
 								</table>
@@ -257,7 +278,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
     "id": "alert-123",
     "alertName": "High CPU Usage",
     "tags": {"env": "prod"},
-    "alertUrl": "https://monitoring.example.com/alert/123"
+    "links": [{"label": "Dashboard", "icon": "grafana", "url": "https://monitoring.example.com/alert/123"}]
   }'`}
 							</pre>
 						</div>

--- a/apps/client/src/test/links.utils.test.ts
+++ b/apps/client/src/test/links.utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { Alert } from '@OpsiMate/shared';
+import { getAlertLinks } from '@/components/Alerts/utils/links.utils';
+
+const base = { id: 'a', alertName: 'A', tags: {} } as unknown as Alert;
+
+describe('getAlertLinks', () => {
+	test('links array is the source of truth when present — legacy fields ignored', () => {
+		const alert = {
+			...base,
+			alertUrl: 'https://legacy.example.com',
+			runbookUrl: 'https://runbook.example.com',
+			links: [{ label: 'Grafana demo', icon: 'grafana', url: 'https://demo.grafana.dev/' }],
+		} as Alert;
+		expect(getAlertLinks(alert)).toEqual(alert.links);
+	});
+
+	test('legacy alertUrl/runbookUrl fold in when links is absent', () => {
+		const alert = {
+			...base,
+			type: 'Grafana',
+			alertUrl: 'https://legacy.example.com',
+			runbookUrl: 'https://runbook.example.com',
+		} as Alert;
+		expect(getAlertLinks(alert)).toEqual([
+			{ label: 'Source', icon: 'Grafana', url: 'https://legacy.example.com' },
+			{ label: 'Runbook', icon: '', url: 'https://runbook.example.com' },
+		]);
+	});
+
+	test('an empty links array falls back to legacy fields', () => {
+		const alert = { ...base, type: 'Custom', alertUrl: 'https://x.example.com', links: [] } as Alert;
+		expect(getAlertLinks(alert)).toEqual([{ label: 'Source', icon: 'Custom', url: 'https://x.example.com' }]);
+	});
+
+	test('no links anywhere yields an empty array', () => {
+		expect(getAlertLinks({ ...base, alertUrl: '' } as Alert)).toEqual([]);
+	});
+});

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -503,7 +503,7 @@ export class AlertController {
 				team: alert.team,
 				// The fix field rides on the fix tag (the client's first-class Fix column
 				// reads it from there); an explicit tag wins over the convenience field.
-				tags: alert.fix && !alert.tags['fix'] ? { ...alert.tags, fix: alert.fix } : alert.tags,
+				tags: alert.fix && !('fix' in alert.tags) ? { ...alert.tags, fix: alert.fix } : alert.tags,
 				startsAt: alert.startsAt || new Date().toISOString(),
 				updatedAt: alert.updatedAt || new Date().toISOString(),
 				alertUrl: alert.alertUrl || '',

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -501,7 +501,9 @@ export class AlertController {
 				status: AlertStatus.FIRING,
 				severity: alert.severity,
 				team: alert.team,
-				tags: alert.tags,
+				// The fix field rides on the fix tag (the client's first-class Fix column
+				// reads it from there); an explicit tag wins over the convenience field.
+				tags: alert.fix && !alert.tags['fix'] ? { ...alert.tags, fix: alert.fix } : alert.tags,
 				startsAt: alert.startsAt || new Date().toISOString(),
 				updatedAt: alert.updatedAt || new Date().toISOString(),
 				alertUrl: alert.alertUrl || '',

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import {
 	AlertHistory,
+	AlertLink,
 	AlertStatus,
 	CreateCommentSchema,
 	Logger,
@@ -338,6 +339,12 @@ export class AlertController {
 					alertName: incident.policy_name || 'UNKNOWN',
 					summary: incident.summary || 'No summary provided for this alert.',
 					runbookUrl: incident.documentation?.content,
+					links: AlertController.buildLinks([
+						{ label: 'View incident', icon: 'gcp', url: incident.url },
+						// documentation.content is free-form text; only URL-shaped content
+						// ever produced a working runbook button.
+						{ label: 'Documentation', icon: '', url: incident.documentation?.content },
+					]),
 				});
 			}
 			return res.status(200).json({ success: true, data: { alertId: incident.incident_id } });
@@ -390,6 +397,7 @@ export class AlertController {
 				alertName: payload.title || 'UNKNOWN',
 				summary: payload.message,
 				runbookUrl: undefined,
+				links: AlertController.buildLinks([{ label: 'View in Datadog', icon: 'datadog', url: payload.link }]),
 			});
 
 			return res.status(200).json({ success: true, data: { alertId } });
@@ -417,6 +425,23 @@ export class AlertController {
 	// Stable, collision-resistant id derived from an alert's full label set. Used only as a
 	// fallback when Grafana omits the fingerprint, so distinct instances of the same rule (which
 	// share alertname/rulename but differ in their labels) never collapse onto one alert record.
+	// Builds an alert's links collection from candidate entries: drops empty and
+	// non-http(s) urls, dedupes by url (integrations often repeat the same URL across
+	// payload fields), and returns undefined when nothing survives so the client's
+	// legacy alertUrl/runbookUrl fold-in still applies.
+	private static buildLinks(
+		candidates: Array<{ label: string; icon: string; url?: string | null }>
+	): AlertLink[] | undefined {
+		const seen = new Set<string>();
+		const links: AlertLink[] = [];
+		for (const { label, icon, url } of candidates) {
+			if (!url || !/^https?:\/\//i.test(url) || seen.has(url)) continue;
+			seen.add(url);
+			links.push({ label, icon, url });
+		}
+		return links.length ? links : undefined;
+	}
+
 	private static idFromLabels(labels: Record<string, string>): string {
 		const normalized = Object.keys(labels)
 			.sort()
@@ -466,6 +491,16 @@ export class AlertController {
 					Object.entries(labels).filter(([key]) => !AlertController.GRAFANA_LABELS_TO_IGNORE.has(key))
 				);
 
+				// Grafana sends up to three distinct URLs; the legacy alertUrl kept only the
+				// first non-empty one. The links collection surfaces them all (deduped —
+				// Grafana often repeats the same URL across fields).
+				const links = AlertController.buildLinks([
+					{ label: 'View in Grafana', icon: 'grafana', url: alert.generatorURL },
+					{ label: 'Dashboard', icon: 'grafana', url: alert.dashboardURL },
+					{ label: 'Panel', icon: 'grafana', url: alert.panelURL },
+					{ label: 'Runbook', icon: '', url: alert.annotations?.runbook_url },
+				]);
+
 				await this.alertBL.insertOrUpdateAlert({
 					id: alertId,
 					type: 'Grafana',
@@ -477,6 +512,7 @@ export class AlertController {
 					alertName: labels.rulename || labels.alertname || alert.annotations?.summary || 'Grafana alert',
 					summary: alert.annotations?.summary || alert.annotations?.description || '',
 					runbookUrl: alert.annotations?.runbook_url || '',
+					links,
 				});
 				processedIds.push(alertId);
 			}

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -508,6 +508,7 @@ export class AlertController {
 				alertName: alert.alertName,
 				summary: alert.summary,
 				runbookUrl: alert.runbookUrl,
+				links: alert.links,
 			});
 			return res.status(200).json({ success: true, data: { alertId: alert.id } });
 		} catch (error) {

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -30,15 +30,27 @@ const isoDateString = z.string().refine(
 	}
 );
 
+// Attached links: label + url, with an optional icon slug matched against the client's
+// integration icon set (grafana, uptimekuma, gcp, ...); '' or unknown = generic icon.
+export const AlertLinkSchema = z.object({
+	label: z.string().min(1),
+	icon: z.string().optional(),
+	url: z.string().url(),
+});
+
 export const HttpAlertWebhookSchema = z.object({
 	id: z.string(),
 	tags: z.record(z.string(), z.string()),
 	startsAt: isoDateString.optional(),
 	updatedAt: isoDateString.optional(),
+	// Deprecated in favor of `links` — still accepted; folds into the links UI as the
+	// "Source" entry when `links` is absent.
 	alertUrl: z.string().url().optional(),
 	alertName: z.string(),
 	summary: z.string().optional(),
+	// Deprecated in favor of `links` — still accepted; folds in as the "Runbook" entry.
 	runbookUrl: z.string().url().optional(),
+	links: z.array(AlertLinkSchema).max(20).optional(),
 	createdAt: isoDateString.optional(),
 	// Free-form; normalized onto the fixed critical/warning/info scale at ingestion
 	// (unknown or missing values default to warning).

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -51,6 +51,10 @@ export const HttpAlertWebhookSchema = z.object({
 	// Deprecated in favor of `links` — still accepted; folds in as the "Runbook" entry.
 	runbookUrl: z.string().url().optional(),
 	links: z.array(AlertLinkSchema).max(20).optional(),
+	// Fix classification: manual or auto (free-form synonyms accepted — "manual fix",
+	// "autofix", "automated", ...). Stored on the fix tag; unlike severity there is no
+	// default — alerts without it show no fix classification.
+	fix: z.string().optional(),
 	createdAt: isoDateString.optional(),
 	// Free-form; normalized onto the fixed critical/warning/info scale at ingestion
 	// (unknown or missing values default to warning).

--- a/apps/server/src/dal/alertRepository.ts
+++ b/apps/server/src/dal/alertRepository.ts
@@ -27,8 +27,8 @@ export class AlertRepository {
 			// from the recorded firing time. A new episode (resolve, then re-fire) deletes and
 			// re-inserts the row, which picks up the new starts_at.
 			const stmt = this.db.prepare(`
-				INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, links)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				ON CONFLICT(id) DO UPDATE SET
 											  status=excluded.status,
 											  type=excluded.type,
@@ -40,6 +40,7 @@ export class AlertRepository {
 											  alert_name=excluded.alert_name,
 											  summary=excluded.summary,
 											  runbook_url=excluded.runbook_url,
+											  links=excluded.links,
 											  -- Every arrival re-surfaces the alert: any push for this id — an update
 											  -- OR an identical replay — marks it unread so the row re-bolds. All
 											  -- ingestion here is push-based webhooks, so a repeat notification is the
@@ -85,7 +86,8 @@ export class AlertRepository {
 					alert.alertUrl,
 					alert.alertName,
 					alert.summary || null,
-					alert.runbookUrl || null
+					alert.runbookUrl || null,
+					alert.links?.length ? JSON.stringify(alert.links) : null
 				);
 			});
 			return { changes: upsert().changes };
@@ -110,8 +112,8 @@ export class AlertRepository {
 				this.db
 					.prepare(
 						`
-						INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed, is_read, created_at, owner_id)
-						VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+						INSERT INTO alerts (id, status, type, severity, team, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, links, is_dismissed, is_read, created_at, owner_id)
+						VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
 						ON CONFLICT(id) DO UPDATE SET
 													  status=excluded.status,
 													  updated_at=excluded.updated_at
@@ -130,6 +132,7 @@ export class AlertRepository {
 						alert.alertName,
 						alert.summary || null,
 						alert.runbookUrl || null,
+						alert.links?.length ? JSON.stringify(alert.links) : null,
 						alert.isSilenced ? 1 : 0,
 						alert.createdAt,
 						alert.ownerId != null ? Number(alert.ownerId) : null
@@ -157,6 +160,7 @@ export class AlertRepository {
 					is_dismissed BOOLEAN DEFAULT 0,
 					summary TEXT,
 					runbook_url TEXT,
+					links TEXT,
 					created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 				);
 	
@@ -224,6 +228,12 @@ export class AlertRepository {
 				this.db.prepare(`ALTER TABLE alerts ADD COLUMN severity TEXT`).run();
 			}
 
+			// Backward compatibility: ensure links column exists (JSON array of AlertLink)
+			const hasLinks = columns.some((col: TableInfoRow) => col.name === 'links');
+			if (!hasLinks) {
+				this.db.prepare(`ALTER TABLE alerts ADD COLUMN links TEXT`).run();
+			}
+
 			// Backward compatibility: ensure team column exists
 			const hasTeam = columns.some((col: TableInfoRow) => col.name === 'team');
 			if (!hasTeam) {
@@ -283,6 +293,7 @@ export class AlertRepository {
 			alertName: row.alert_name,
 			summary: row.summary,
 			runbookUrl: row.runbook_url,
+			links: row.links ? (JSON.parse(row.links) as SharedAlert['links']) : undefined,
 			createdAt: row.created_at,
 			isSilenced: row.is_dismissed ? true : false,
 			silencedUntil: row.is_dismissed ? (row.silenced_until ?? null) : null,

--- a/apps/server/src/dal/models.ts
+++ b/apps/server/src/dal/models.ts
@@ -66,6 +66,7 @@ export type AlertRow = {
 	alert_name: string;
 	summary?: string;
 	runbook_url?: string;
+	links?: string | null;
 	created_at: string;
 	is_dismissed: boolean;
 	silenced_until?: string | null;
@@ -87,6 +88,7 @@ export type ResolvedAlertRow = {
 	alert_name: string;
 	summary?: string;
 	runbook_url?: string;
+	links?: string | null;
 	created_at: string;
 	is_dismissed: boolean;
 	archived_at: string;

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -48,6 +48,7 @@ export class ResolvedAlertRepository {
 																	   is_dismissed BOOLEAN DEFAULT 0,
 																	   summary TEXT,
 																	   runbook_url TEXT,
+																	   links TEXT,
 																	   created_at TEXT,
 																	   archived_at DATETIME DEFAULT CURRENT_TIMESTAMP
 						);
@@ -112,6 +113,12 @@ export class ResolvedAlertRepository {
 				this.db.prepare(`ALTER TABLE alerts_resolved ADD COLUMN severity TEXT`).run();
 			}
 
+			// Backward compatibility: ensure links column exists (JSON array of AlertLink)
+			const hasLinks = columns.some((col: TableInfoRow) => col.name === 'links');
+			if (!hasLinks) {
+				this.db.prepare(`ALTER TABLE alerts_resolved ADD COLUMN links TEXT`).run();
+			}
+
 			// Backward compatibility: ensure team column exists
 			const hasTeam = columns.some((col: TableInfoRow) => col.name === 'team');
 			if (!hasTeam) {
@@ -124,8 +131,8 @@ export class ResolvedAlertRepository {
 		return runAsync(() => {
 			const stmt = this.db.prepare(`
                 INSERT INTO alerts_resolved
-                    (id, status, severity, team, tags, type, starts_at, updated_at, alert_url, alert_name, is_dismissed, summary, runbook_url, created_at, owner_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (id, status, severity, team, tags, type, starts_at, updated_at, alert_url, alert_name, is_dismissed, summary, runbook_url, links, created_at, owner_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     status = excluded.status,
                     severity = excluded.severity,
@@ -139,6 +146,7 @@ export class ResolvedAlertRepository {
                     is_dismissed = excluded.is_dismissed,
                     summary = excluded.summary,
                     runbook_url = excluded.runbook_url,
+                    links = excluded.links,
                     created_at = excluded.created_at,
                     owner_id = excluded.owner_id,
                     archived_at = CURRENT_TIMESTAMP
@@ -159,6 +167,7 @@ export class ResolvedAlertRepository {
 				0,
 				alert.summary || null,
 				alert.runbookUrl || null,
+				alert.links?.length ? JSON.stringify(alert.links) : null,
 				alert.createdAt,
 				alert.ownerId != null ? Number(alert.ownerId) : null
 			);
@@ -186,6 +195,7 @@ export class ResolvedAlertRepository {
 			alertName: row.alert_name,
 			summary: row.summary,
 			runbookUrl: row.runbook_url,
+			links: row.links ? (JSON.parse(row.links) as SharedAlert['links']) : undefined,
 			createdAt: row.created_at,
 			// Resolved alerts are never silenced (legacy rows may still carry is_dismissed=1
 			// from before resolving cleared the flag).

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -482,6 +482,35 @@ describe('Alerts API', () => {
 			expect(alert.links).toEqual(payload.links);
 		});
 
+		test('should fold the fix field into the fix tag', async () => {
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id: 'fix-field-alert', tags: {}, alertName: 'Fix Field Test', fix: 'manual' });
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT tags FROM alerts WHERE id = ?').get('fix-field-alert') as { tags: string };
+			expect(JSON.parse(row.tags).fix).toBe('manual');
+		});
+
+		test('an explicit fix tag wins over the fix field', async () => {
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					id: 'fix-field-tag-wins',
+					tags: { fix: 'auto' },
+					alertName: 'Fix Tag Wins Test',
+					fix: 'manual',
+				});
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT tags FROM alerts WHERE id = ?').get('fix-field-tag-wins') as {
+				tags: string;
+			};
+			expect(JSON.parse(row.tags).fix).toBe('auto');
+		});
+
 		test('should reject a links entry with an invalid url', async () => {
 			const response = await app
 				.post('/api/v1/alerts/custom')

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -457,6 +457,46 @@ describe('Alerts API', () => {
 			expect(row.alert_name).toBe(payload.alertName);
 		});
 
+		test('should persist a links array and serve it back on the alert', async () => {
+			const payload = {
+				id: 'links-alert-1',
+				tags: {},
+				alertName: 'Links Test',
+				links: [
+					{ label: 'OpsiMate demo', icon: '', url: 'https://demo.opsimate.dev/' },
+					{ label: 'Grafana demo', icon: 'grafana', url: 'https://demo.grafana.dev/' },
+				],
+			};
+
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send(payload);
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT links FROM alerts WHERE id = ?').get(payload.id) as { links: string };
+			expect(JSON.parse(row.links)).toEqual(payload.links);
+
+			const list = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+			const alert = list.body.data.alerts.find((a: { id: string }) => a.id === payload.id);
+			expect(alert.links).toEqual(payload.links);
+		});
+
+		test('should reject a links entry with an invalid url', async () => {
+			const response = await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					id: 'links-alert-bad',
+					tags: {},
+					alertName: 'Bad Links Test',
+					links: [{ label: 'nope', url: 'not-a-url' }],
+				});
+
+			expect(response.status).toBe(400);
+			expect(response.body.error).toBe('Validation error');
+		});
+
 		test('should store a normalized explicit severity', async () => {
 			const payload = {
 				id: 'severity-explicit',

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -754,6 +754,66 @@ describe('Alerts API', () => {
 		});
 	});
 
+	describe('POST /api/v1/alerts/custom/grafana links', () => {
+		test('surfaces generator/dashboard/panel/runbook URLs as deduped links', async () => {
+			const response = await app
+				.post('/api/v1/alerts/custom/grafana')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					alerts: [
+						{
+							fingerprint: 'grafana-links-1',
+							status: 'firing',
+							labels: { alertname: 'Grafana Links Test' },
+							annotations: { summary: 'links test', runbook_url: 'https://runbook.example.com/g' },
+							generatorURL: 'https://grafana.example.com/alerting/1',
+							// Duplicates generatorURL on purpose — must dedupe.
+							dashboardURL: 'https://grafana.example.com/alerting/1',
+							panelURL: 'https://grafana.example.com/d/abc?panelId=2',
+						},
+					],
+				});
+
+			expect(response.status).toBe(200);
+			const row = db
+				.prepare('SELECT links, alert_url, runbook_url FROM alerts WHERE id = ?')
+				.get('grafana-links-1') as {
+				links: string;
+				alert_url: string;
+				runbook_url: string;
+			};
+			expect(JSON.parse(row.links)).toEqual([
+				{ label: 'View in Grafana', icon: 'grafana', url: 'https://grafana.example.com/alerting/1' },
+				{ label: 'Panel', icon: 'grafana', url: 'https://grafana.example.com/d/abc?panelId=2' },
+				{ label: 'Runbook', icon: '', url: 'https://runbook.example.com/g' },
+			]);
+			// Legacy fields stay populated for consumers that still read them.
+			expect(row.alert_url).toBe('https://grafana.example.com/alerting/1');
+			expect(row.runbook_url).toBe('https://runbook.example.com/g');
+		});
+
+		test('omits links entirely when the payload carries no URLs', async () => {
+			const response = await app
+				.post('/api/v1/alerts/custom/grafana')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					alerts: [
+						{
+							fingerprint: 'grafana-links-2',
+							status: 'firing',
+							labels: { alertname: 'Grafana No Links Test' },
+						},
+					],
+				});
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT links FROM alerts WHERE id = ?').get('grafana-links-2') as {
+				links: string | null;
+			};
+			expect(row.links).toBeNull();
+		});
+	});
+
 	describe('POST /api/v1/alerts/custom/datadog', () => {
 		test('should create a new Datadog alert successfully with valid payload', async () => {
 			const alertId = 'alert-id';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -217,6 +217,15 @@ export function normalizeAlertFix(value?: string | null): AlertFix | null {
 	return Object.hasOwn(FIX_SYNONYMS, key) ? FIX_SYNONYMS[key] : null;
 }
 
+// A link attached to an alert. `icon` is a free-form slug matched against the
+// integration icon set (grafana, uptimekuma, gcp, datadog, zabbix, custom); empty or
+// unrecognized values render the generic link icon.
+export interface AlertLink {
+	label: string;
+	icon?: string;
+	url: string;
+}
+
 export interface Alert {
 	id: string;
 	type: AlertType;
@@ -229,10 +238,15 @@ export interface Alert {
 	tags: Record<string, string>;
 	startsAt: string;
 	updatedAt: string;
+	// Legacy single links, superseded by `links`: when `links` is absent they fold into
+	// the links UI as "Source" / "Runbook" entries. Integrations still populate them.
 	alertUrl: string;
 	alertName: string;
 	summary?: string;
 	runbookUrl?: string;
+	// The alert's link collection — each entry renders as a button in the details panel's
+	// links section (and the row's ⋮ menu) with its icon when the slug is recognized.
+	links?: AlertLink[];
 	createdAt: string;
 	isSilenced: boolean;
 	// When the silence auto-expires (ISO); null while silenced means silenced forever.


### PR DESCRIPTION
## What

Replaces the fixed `alertUrl`/`runbookUrl` pair with a **links array** on the alert payload:

```json
"links": [
  { "label": "opsimate demo", "icon": "", "url": "https://demo.opsimate.dev/" },
  { "label": "grafana demo", "icon": "grafana", "url": "https://demo.grafana.dev/" }
]
```

Each entry renders as a button in the details panel's **Links** section (and the row's ⋮ menu) — icon slug matched against the existing integration icon set (`grafana`, `uptimekuma`, `gcp`, `datadog`, `zabbix`); empty/unknown slugs get the generic external-link glyph.

## Backward compatibility

`alertUrl`/`runbookUrl` are **deprecated, not removed**: the built-in integrations still populate them, and when `links` is absent they fold in client-side as "Source" (iconed by the alert's type — a Grafana alert's source link IS Grafana) and "Runbook". Existing alerts keep their buttons with zero data migration.

## Changes

- **shared**: `AlertLink` type, `Alert.links`
- **server**: `AlertLinkSchema` webhook validation (label + valid url, max 20 entries); `links` JSON column on `alerts` and `alerts_resolved` incl. legacy-DB `ALTER TABLE` migrations; persisted through upsert/restore/resolve so links survive the full lifecycle
- **client**: `getAlertLinks` fold-in helper; `AlertLinkIcon` slug resolver; Links section, row ⋮ menu, and services-page alert list all render the collection; webhook setup docs updated (links documented, legacy fields marked deprecated)

## Verification

- 75/75 client tests (4 new: links priority, legacy fold-in, empty-array fallback), 143/143 server tests (2 new: links persist + round-trip through the API, invalid-url rejection)
- Live: sent a webhook alert with 4 links (plain, grafana, uptimekuma, gcp) — all four buttons render with correct icons in the details panel; legacy alerts still show Source/Runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple labeled alert links with optional integration-specific icons.
  * Added optional `fix` classification support for custom alerts.
* **Improvements**
  * Links now appear consistently across alert details and actions.
  * Existing source and runbook URLs remain supported as fallback links.
  * Alert links are validated and persisted for active and resolved alerts.
  * Updated custom alert setup guidance and examples.
* **Bug Fixes**
  * Empty link sections and actions are no longer displayed when alerts have no links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->