### PR TITLE
feat: enrichment rules can add links to alerts

### DIFF
--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -16,7 +16,7 @@ import { useCreateEnrichment, useUpdateEnrichment } from '@/hooks/queries/enrich
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { EnrichmentPayload } from '@/lib/api';
 import { AlertEnrichment, AlertLink } from '@OpsiMate/shared';
-import { Link2, Plus, Sparkles, Tag, Trash2, Wand2 } from 'lucide-react';
+import { Plus, Sparkles, Tag, Trash2, Wand2 } from 'lucide-react';
 import { AlertLinkIcon } from '@/components/Alerts/AlertLinkIcon';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -379,7 +379,7 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 							<h4 className="text-sm font-semibold">Enrichment</h4>
 						</div>
 						<p className="text-xs text-muted-foreground -mt-2">
-							What to change on matching alerts. At least one field or a summary template is required.
+							What to change on matching alerts. At least one field, link, or summary template is required.
 						</p>
 
 						<KeyValueRows

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -379,7 +379,8 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 							<h4 className="text-sm font-semibold">Enrichment</h4>
 						</div>
 						<p className="text-xs text-muted-foreground -mt-2">
-							What to change on matching alerts. At least one field, link, or summary template is required.
+							What to change on matching alerts. At least one field, link, or summary template is
+							required.
 						</p>
 
 						<KeyValueRows

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -13,9 +13,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { useAlerts } from '@/hooks/queries/alerts';
 import { useCreateEnrichment, useUpdateEnrichment } from '@/hooks/queries/enrichments';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { EnrichmentPayload } from '@/lib/api';
-import { AlertEnrichment } from '@OpsiMate/shared';
-import { Plus, Sparkles, Tag, Trash2, Wand2 } from 'lucide-react';
+import { AlertEnrichment, AlertLink } from '@OpsiMate/shared';
+import { Link2, Plus, Sparkles, Tag, Trash2, Wand2 } from 'lucide-react';
+import { AlertLinkIcon } from '@/components/Alerts/AlertLinkIcon';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 type KeyValue = { key: string; value: string };
@@ -95,6 +97,94 @@ const KeyValueRows = ({
 	</div>
 );
 
+// Icon slugs offered for enrichment links — the integration icon set plus "no icon".
+const LINK_ICON_OPTIONS: { value: string; label: string }[] = [
+	{ value: '', label: 'No icon' },
+	{ value: 'grafana', label: 'Grafana' },
+	{ value: 'uptimekuma', label: 'Uptime Kuma' },
+	{ value: 'gcp', label: 'Google Cloud' },
+	{ value: 'datadog', label: 'Datadog' },
+	{ value: 'zabbix', label: 'Zabbix' },
+	{ value: 'custom', label: 'Bell' },
+];
+
+// Radix Select can't carry an empty-string item value; stand in for "no icon".
+const NO_ICON = '__none__';
+
+const LinkRows = ({ rows, onChange }: { rows: AlertLink[]; onChange: (rows: AlertLink[]) => void }) => (
+	<div className="space-y-2">
+		<div className="flex items-center justify-between">
+			<Label className="text-xs">Links to add</Label>
+			<Button
+				type="button"
+				variant="outline"
+				size="sm"
+				onClick={() => onChange([...rows, { label: '', icon: '', url: '' }])}
+			>
+				<Plus className="h-3.5 w-3.5 mr-1" /> Add
+			</Button>
+		</div>
+		{rows.length === 0 ? (
+			<p className="text-xs text-muted-foreground italic">
+				No links. Added as buttons in the alert&apos;s Links section, next to its existing links.
+			</p>
+		) : (
+			<div className="space-y-2">
+				{rows.map((row, idx) => (
+					<div key={idx} className="grid grid-cols-[1fr_130px_1.5fr_auto] items-center gap-2">
+						<Input
+							placeholder="label (e.g. Dashboard)"
+							value={row.label}
+							onChange={(e) =>
+								onChange(rows.map((r, i) => (i === idx ? { ...r, label: e.target.value } : r)))
+							}
+						/>
+						<Select
+							value={row.icon || NO_ICON}
+							onValueChange={(value) =>
+								onChange(
+									rows.map((r, i) => (i === idx ? { ...r, icon: value === NO_ICON ? '' : value } : r))
+								)
+							}
+						>
+							<SelectTrigger className="h-9">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{LINK_ICON_OPTIONS.map((opt) => (
+									<SelectItem key={opt.value || NO_ICON} value={opt.value || NO_ICON}>
+										<span className="flex items-center gap-2">
+											<AlertLinkIcon icon={opt.value} className="h-3.5 w-3.5" />
+											{opt.label}
+										</span>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<Input
+							placeholder="url (e.g. https://grafana/d/{{label.host}})"
+							value={row.url}
+							onChange={(e) =>
+								onChange(rows.map((r, i) => (i === idx ? { ...r, url: e.target.value } : r)))
+							}
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="h-9 w-9"
+							onClick={() => onChange(rows.filter((_, i) => i !== idx))}
+							aria-label="Remove link"
+						>
+							<Trash2 className="h-4 w-4" />
+						</Button>
+					</div>
+				))}
+			</div>
+		)}
+	</div>
+);
+
 export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicateFrom }: EnrichmentFormDialogProps) => {
 	const isEdit = !!enrichment;
 	const { toast } = useToast();
@@ -105,6 +195,7 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 	const [nameContains, setNameContains] = useState('');
 	const [matchers, setMatchers] = useState<KeyValue[]>([]);
 	const [addFields, setAddFields] = useState<KeyValue[]>([]);
+	const [addLinks, setAddLinks] = useState<AlertLink[]>([]);
 	const [summaryTemplate, setSummaryTemplate] = useState('');
 	const [priority, setPriority] = useState('0');
 
@@ -145,6 +236,7 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 			setNameContains(source.nameContains ?? '');
 			setMatchers((source.labelMatchers ?? []).map((m) => ({ ...m })));
 			setAddFields((source.addFields ?? []).map((f) => ({ ...f })));
+			setAddLinks((source.addLinks ?? []).map((l) => ({ ...l })));
 			setSummaryTemplate(source.summaryTemplate ?? '');
 			setPriority(String(source.priority ?? 0));
 		} else {
@@ -152,6 +244,7 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 			setNameContains('');
 			setMatchers([]);
 			setAddFields([]);
+			setAddLinks([]);
 			// Pre-fill with {{summary}} so the user keeps the existing summary and appends to it.
 			setSummaryTemplate(DEFAULT_SUMMARY_TEMPLATE);
 			setPriority('0');
@@ -164,9 +257,10 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 		const hasLabelMatchers = matchers.some((m) => m.key.trim() && m.value.trim());
 		if (!hasNameMatcher && !hasLabelMatchers) return false;
 		const hasFields = addFields.some((f) => f.key.trim() && f.value.trim());
+		const hasLinks = addLinks.some((l) => l.label.trim() && l.url.trim());
 		const hasSummary = summaryTemplate.trim().length > 0;
-		return hasFields || hasSummary;
-	}, [name, nameContains, matchers, addFields, summaryTemplate]);
+		return hasFields || hasLinks || hasSummary;
+	}, [name, nameContains, matchers, addFields, addLinks, summaryTemplate]);
 
 	const submit = async () => {
 		const clean = (rows: KeyValue[]) =>
@@ -177,6 +271,9 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 			nameContains: nameContains.trim() || null,
 			labelMatchers: clean(matchers),
 			addFields: clean(addFields),
+			addLinks: addLinks
+				.map((l) => ({ label: l.label.trim(), icon: (l.icon ?? '').trim(), url: l.url.trim() }))
+				.filter((l) => l.label && l.url),
 			summaryTemplate: summaryTemplate.trim() || null,
 			priority: Math.max(0, Math.min(1000, parseInt(priority, 10) || 0)),
 		};
@@ -210,8 +307,8 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 						{isEdit ? 'Edit enrichment' : 'New enrichment'}
 					</DialogTitle>
 					<DialogDescription>
-						Automatically add fields or rewrite the summary of alerts that match the criteria below. Applied
-						live whenever alerts are fetched.
+						Automatically add fields, links, or rewrite the summary of alerts that match the criteria below.
+						Applied live whenever alerts are fetched.
 					</DialogDescription>
 				</DialogHeader>
 
@@ -296,6 +393,12 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 						<p className="text-xs text-muted-foreground -mt-2">
 							A value can copy a label, e.g. <code className="text-[11px]">owner={'{{label.team}}'}</code>
 							.
+						</p>
+
+						<LinkRows rows={addLinks} onChange={setAddLinks} />
+						<p className="text-xs text-muted-foreground -mt-2">
+							Label and URL accept the same placeholders, e.g.{' '}
+							<code className="text-[11px]">https://grafana.example.com/d/{'{{label.host}}'}</code>.
 						</p>
 
 						<div className="space-y-2">

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -692,6 +692,7 @@ export type EnrichmentPayload = {
 	nameContains?: string | null;
 	labelMatchers?: { key: string; value: string }[];
 	addFields?: { key: string; value: string }[];
+	addLinks?: { label: string; icon?: string; url: string }[];
 	summaryTemplate?: string | null;
 	priority?: number;
 };

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -18,7 +18,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
 import { AlertEnrichment } from '@OpsiMate/shared';
-import { Copy, FileText, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
+import { Copy, FileText, Link2, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 const MatchBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
@@ -52,6 +52,16 @@ const EffectBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
 				className="font-mono text-xs bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30 max-w-full whitespace-normal break-all rounded-md"
 			>
 				+{f.key}={f.value}
+			</Badge>
+		))}
+		{(enrichment.addLinks ?? []).map((l, idx) => (
+			<Badge
+				key={`link-${idx}`}
+				variant="outline"
+				className="text-xs bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/30 max-w-[260px]"
+			>
+				<Link2 className="h-3 w-3 mr-1 shrink-0" />
+				<span className="truncate">{l.label}</span>
 			</Badge>
 		))}
 		{enrichment.summaryTemplate && (
@@ -88,7 +98,9 @@ const Enrichments: React.FC = () => {
 			if (e.summaryTemplate?.toLowerCase().includes(q)) return true;
 			if (e.labelMatchers?.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q)))
 				return true;
-			return e.addFields?.some((f) => f.key.toLowerCase().includes(q) || f.value.toLowerCase().includes(q));
+			if (e.addFields?.some((f) => f.key.toLowerCase().includes(q) || f.value.toLowerCase().includes(q)))
+				return true;
+			return e.addLinks?.some((l) => l.label.toLowerCase().includes(q) || l.url.toLowerCase().includes(q));
 		});
 	}, [enrichments, search]);
 
@@ -117,9 +129,9 @@ const Enrichments: React.FC = () => {
 							<h1 className="text-2xl font-semibold tracking-tight">Enrichment</h1>
 						</div>
 						<p className="text-sm text-muted-foreground mt-1">
-							Automatically add fields or rewrite the summary of matching alerts — e.g. tag every "Disk"
-							alert with disk_alert=true and append help-desk instructions to its summary. Rules run in
-							priority order (highest first); on conflicts the higher-priority rule wins.
+							Automatically add fields, links, or rewrite the summary of matching alerts — e.g. tag every
+							"Disk" alert with disk_alert=true and append help-desk instructions to its summary. Rules
+							run in priority order (highest first); on conflicts the higher-priority rule wins.
 						</p>
 					</div>
 					<Button onClick={() => setCreating(true)}>

--- a/apps/server/src/api/v1/enrichments/controller.ts
+++ b/apps/server/src/api/v1/enrichments/controller.ts
@@ -50,6 +50,7 @@ export class EnrichmentController {
 					nameContains: data.nameContains ?? null,
 					labelMatchers: data.labelMatchers ?? [],
 					addFields: data.addFields ?? [],
+					addLinks: data.addLinks ?? [],
 					summaryTemplate: data.summaryTemplate ?? null,
 					priority: data.priority ?? 0,
 				},

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -1,6 +1,7 @@
 import {
 	Alert,
 	AlertEnrichment,
+	AlertLink,
 	AppliedEnrichment,
 	AuditActionType,
 	AuditResourceType,
@@ -72,6 +73,7 @@ export class EnrichmentBL {
 			data.nameContains !== undefined ||
 			data.labelMatchers !== undefined ||
 			data.addFields !== undefined ||
+			data.addLinks !== undefined ||
 			data.summaryTemplate !== undefined ||
 			data.priority !== undefined
 		);
@@ -161,7 +163,31 @@ export class EnrichmentBL {
 			enrichment.summaryTemplate && enrichment.summaryTemplate.trim().length > 0
 				? EnrichmentBL.resolveTemplate(enrichment.summaryTemplate, alert)
 				: alert.summary;
-		return { ...alert, tags, summary, severity };
+		const links = EnrichmentBL.applyLinks(enrichment, alert);
+		return { ...alert, tags, summary, severity, links };
+	}
+
+	// Appends the rule's links to the alert's collection. When the alert has no links of
+	// its own, its legacy alertUrl/runbookUrl materialize first — the client only folds
+	// those in when links is ABSENT, so appending without them would make the enrichment
+	// hide the alert's original buttons. Label and url are templated like field values;
+	// duplicates (by resolved url) are dropped, which also keeps chained rules idempotent.
+	private static applyLinks(enrichment: AlertEnrichment, alert: Alert): AlertLink[] | undefined {
+		if (!enrichment.addLinks?.length) return alert.links;
+		const base: AlertLink[] = alert.links?.length
+			? [...alert.links]
+			: [
+					...(alert.alertUrl ? [{ label: 'Source', icon: alert.type as string, url: alert.alertUrl }] : []),
+					...(alert.runbookUrl ? [{ label: 'Runbook', icon: '', url: alert.runbookUrl }] : []),
+				];
+		const seen = new Set(base.map((l) => l.url));
+		for (const link of enrichment.addLinks) {
+			const url = EnrichmentBL.resolveTemplate(link.url, alert);
+			if (!url || seen.has(url)) continue;
+			seen.add(url);
+			base.push({ label: EnrichmentBL.resolveTemplate(link.label, alert), icon: link.icon ?? '', url });
+		}
+		return base;
 	}
 
 	// Decorate alerts with all matching enrichment rules. Applied at fetch time only —

--- a/apps/server/src/dal/enrichmentRepository.ts
+++ b/apps/server/src/dal/enrichmentRepository.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import { AlertEnrichment, AlertEnrichmentField, MutePolicyLabelMatcher } from '@OpsiMate/shared';
+import { AlertEnrichment, AlertEnrichmentField, AlertLink, MutePolicyLabelMatcher } from '@OpsiMate/shared';
 import { runAsync } from './db';
 
 interface EnrichmentRow {
@@ -8,6 +8,7 @@ interface EnrichmentRow {
 	name_contains: string | null;
 	label_matchers: string | null;
 	add_fields: string | null;
+	add_links: string | null;
 	summary_template: string | null;
 	priority: number | null;
 	created_by: string | null;
@@ -38,6 +39,7 @@ export class EnrichmentRepository {
 		nameContains: row.name_contains,
 		labelMatchers: parseJsonArray<MutePolicyLabelMatcher>(row.label_matchers),
 		addFields: parseJsonArray<AlertEnrichmentField>(row.add_fields),
+		addLinks: parseJsonArray<AlertLink>(row.add_links),
 		summaryTemplate: row.summary_template,
 		priority: row.priority ?? 0,
 		createdBy: row.created_by,
@@ -57,6 +59,7 @@ export class EnrichmentRepository {
 						name_contains    TEXT,
 						label_matchers   TEXT,
 						add_fields       TEXT,
+						add_links        TEXT,
 						summary_template TEXT,
 						priority         INTEGER DEFAULT 0,
 						created_by       TEXT,
@@ -80,20 +83,24 @@ export class EnrichmentRepository {
 			if (!hasColumn('last_modified_by')) {
 				this.db.prepare(`ALTER TABLE alert_enrichments ADD COLUMN last_modified_by TEXT`).run();
 			}
+			if (!hasColumn('add_links')) {
+				this.db.prepare(`ALTER TABLE alert_enrichments ADD COLUMN add_links TEXT`).run();
+			}
 		});
 	}
 
 	async createEnrichment(data: CreateEnrichmentInput, actor?: string | null): Promise<{ lastID: number }> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(
-				`INSERT INTO alert_enrichments (name, name_contains, label_matchers, add_fields, summary_template, priority, created_by, last_modified_by)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO alert_enrichments (name, name_contains, label_matchers, add_fields, add_links, summary_template, priority, created_by, last_modified_by)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			);
 			const result = stmt.run(
 				data.name,
 				data.nameContains ?? null,
 				JSON.stringify(data.labelMatchers ?? []),
 				JSON.stringify(data.addFields ?? []),
+				JSON.stringify(data.addLinks ?? []),
 				data.summaryTemplate ?? null,
 				data.priority ?? 0,
 				actor ?? null,
@@ -140,6 +147,10 @@ export class EnrichmentRepository {
 			if (data.addFields !== undefined) {
 				updates.push('add_fields = ?');
 				values.push(JSON.stringify(data.addFields));
+			}
+			if (data.addLinks !== undefined) {
+				updates.push('add_links = ?');
+				values.push(JSON.stringify(data.addLinks));
 			}
 			if (data.summaryTemplate !== undefined) {
 				updates.push('summary_template = ?');

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -754,6 +754,62 @@ describe('Alerts API', () => {
 		});
 	});
 
+	describe('enrichment links', () => {
+		test('a matching rule appends templated links, materializing legacy alertUrl first', async () => {
+			await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					id: 'enrich-links-1',
+					tags: { host: 'db-7' },
+					alertName: 'Enrich Links Test',
+					alertUrl: 'https://source.example.com/a1',
+				});
+
+			const created = await app
+				.post('/api/v1/enrichments')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					name: 'add host dashboard link',
+					nameContains: 'Enrich Links',
+					addLinks: [
+						{
+							label: '{{label.host}} dashboard',
+							icon: 'grafana',
+							url: 'https://grafana.example.com/d/{{label.host}}',
+						},
+					],
+				});
+			expect(created.status).toBe(201);
+
+			const list = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+			const alert = list.body.data.alerts.find((a: { id: string }) => a.id === 'enrich-links-1');
+			expect(alert.links).toEqual([
+				// The alert's own legacy link materializes so the enrichment doesn't hide it.
+				{ label: 'Source', icon: 'Custom', url: 'https://source.example.com/a1' },
+				{ label: 'db-7 dashboard', icon: 'grafana', url: 'https://grafana.example.com/d/db-7' },
+			]);
+			expect(alert.appliedEnrichments).toHaveLength(1);
+
+			await app.delete(`/api/v1/enrichments/${created.body.data.id}`).set('Authorization', `Bearer ${jwtToken}`);
+		});
+
+		test('a links-only rule is a valid enrichment (no fields, no summary)', async () => {
+			const created = await app
+				.post('/api/v1/enrichments')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					name: 'links only',
+					nameContains: 'whatever',
+					addLinks: [{ label: 'Docs', url: 'https://docs.example.com' }],
+				});
+			expect(created.status).toBe(201);
+			expect(created.body.data.addLinks).toEqual([{ label: 'Docs', icon: '', url: 'https://docs.example.com' }]);
+
+			await app.delete(`/api/v1/enrichments/${created.body.data.id}`).set('Authorization', `Bearer ${jwtToken}`);
+		});
+	});
+
 	describe('POST /api/v1/alerts/custom/grafana links', () => {
 		test('surfaces generator/dashboard/panel/runbook URLs as deduped links', async () => {
 			const response = await app

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -390,11 +390,24 @@ const enrichmentFieldSchema = z.object({
 	value: z.string().min(1, 'Field value is required').max(1000),
 });
 
-// At least one effect: a field to add/override or a summary template.
-const enrichmentEffectRefinement = (data: { addFields?: unknown[]; summaryTemplate?: string | null }) => {
+// Enrichment links: url is NOT z.url() — label and url accept template placeholders
+// ({{label.runbook}}, https://grafana/d/{{label.dashboard}}) resolved per-alert.
+const enrichmentLinkSchema = z.object({
+	label: z.string().min(1, 'Link label is required').max(200),
+	icon: z.string().max(100).optional().default(''),
+	url: z.string().min(1, 'Link URL is required').max(2000),
+});
+
+// At least one effect: a field to add/override, a link to add, or a summary template.
+const enrichmentEffectRefinement = (data: {
+	addFields?: unknown[];
+	addLinks?: unknown[];
+	summaryTemplate?: string | null;
+}) => {
 	const hasFields = Array.isArray(data.addFields) && data.addFields.length > 0;
+	const hasLinks = Array.isArray(data.addLinks) && data.addLinks.length > 0;
 	const hasSummary = !!data.summaryTemplate && data.summaryTemplate.trim().length > 0;
-	return hasFields || hasSummary;
+	return hasFields || hasLinks || hasSummary;
 };
 
 export const CreateAlertEnrichmentSchema = z
@@ -403,6 +416,7 @@ export const CreateAlertEnrichmentSchema = z
 		nameContains: z.string().max(500).optional().nullable(),
 		labelMatchers: z.array(labelMatcherSchema).max(20).optional().default([]),
 		addFields: z.array(enrichmentFieldSchema).max(20).optional().default([]),
+		addLinks: z.array(enrichmentLinkSchema).max(20).optional().default([]),
 		summaryTemplate: z.string().max(5000).optional().nullable(),
 		priority: z.number().int().min(0).max(1000).optional().default(0),
 	})
@@ -411,7 +425,7 @@ export const CreateAlertEnrichmentSchema = z
 		path: ['nameContains'],
 	})
 	.refine(enrichmentEffectRefinement, {
-		message: 'Provide at least one field to add or a summary template',
+		message: 'Provide at least one field to add, a link to add, or a summary template',
 		path: ['addFields'],
 	});
 
@@ -422,6 +436,7 @@ export const UpdateAlertEnrichmentSchema = z.object({
 	nameContains: z.string().max(500).optional().nullable(),
 	labelMatchers: z.array(labelMatcherSchema).max(20).optional(),
 	addFields: z.array(enrichmentFieldSchema).max(20).optional(),
+	addLinks: z.array(enrichmentLinkSchema).max(20).optional(),
 	summaryTemplate: z.string().max(5000).optional().nullable(),
 	priority: z.number().int().min(0).max(1000).optional(),
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -464,6 +464,10 @@ export interface AlertEnrichment {
 	nameContains?: string | null;
 	labelMatchers: MutePolicyLabelMatcher[];
 	addFields: AlertEnrichmentField[];
+	// Links appended to matching alerts' link collection. Label and url are templated
+	// like field values ({{label.<key>}} etc.); icon is a slug from the integration
+	// icon set, '' for the generic link icon.
+	addLinks?: AlertLink[];
 	summaryTemplate?: string | null;
 	// Rank: rules apply highest-priority first. When two rules set the same field the higher
 	// priority wins; summary templates chain in priority order. Ties break by creation order.


### PR DESCRIPTION
## What

Enrichment rules can now add **links** to matching alerts, not just fields and summary rewrites.

- The enrichment dialog gains a **Links to add** editor: label, an icon picker offering the integration icon set (Grafana, Uptime Kuma, GCP, Datadog, Zabbix, bell, or no icon), and URL
- Label and URL are **templated** like field values — `https://grafana.example.com/d/{{label.service_name}}` builds a per-alert dashboard link
- Added links render as buttons in the alert's Links section (and everywhere else the collection shows), appended to the alert's existing links
- A links-only rule is a valid enrichment (effect refinement now accepts fields OR links OR summary)
- The enrichments list shows violet link badges; search matches link labels/urls

## Behavior details

- **Legacy protection**: when the target alert has no `links` of its own, its legacy `alertUrl`/`runbookUrl` materialize as Source/Runbook entries before appending — otherwise the enrichment would make the client's legacy fold-in stop applying and *hide* the alert's original buttons
- Resolved duplicates (by URL) are dropped, so chained rules stay idempotent
- Persisted in a new `add_links` column with a legacy-DB migration

## Verification

- 149/149 server tests (2 new: templated link application incl. legacy materialization, links-only rule validity), 75/75 client tests
- Live: created a rule via the UI with a `{{label.service_name}}` templated Grafana link — the matching alert shows the appended "Service dashboard" button with the Grafana icon next to its own four links, and the enriched-by sparkles indicator lights up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring links in alert enrichments, including labels, URLs, and optional icons.
  * Links can use placeholders and are applied automatically to matching alerts.
  * Added link management when creating, editing, or duplicating enrichment rules.
  * Enrichment listings now display and search configured links.

* **Bug Fixes**
  * Preserved existing alert links and prevented duplicate or empty links when enrichments are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->