### PR TITLE
[FIX]: Set provider refresh interval to five seconds

### DIFF
--- a/apps/server/src/jobs/refresh-job.ts
+++ b/apps/server/src/jobs/refresh-job.ts
@@ -3,18 +3,19 @@ import { ProviderBL } from '../bl/providers/provider.bl';
 import { Logger, Provider } from '@OpsiMate/shared';
 
 const BATCH_SIZE = 10;
+const REFRESH_INTERVAL_MS = 5 * 1000;
 const logger = new Logger('refresh-job');
 
 export class RefreshJob {
 	constructor(private providerBL: ProviderBL) {}
 
 	startRefreshJob = () => {
-		logger.info('[Job] Starting refreshAllProvidersServices job (every 10 minutes)');
+		logger.info('[Job] Starting refreshAllProvidersServices job (every 5 seconds)');
 
 		// Run immediately on startup (optional)
 		this.refreshAllProvidersServices().catch((err) => logger.error('[Job] Initial run failed:', err));
 
-		// Then run every 10 minutes
+		// Then run every 5 seconds
 		setInterval(async () => {
 			logger.info('[Job] Running refreshAllProvidersServices');
 			try {
@@ -22,7 +23,7 @@ export class RefreshJob {
 			} catch (err) {
 				logger.error('[Job] Failed to refresh services:', err);
 			}
-		}, 10 * 1000);
+		}, REFRESH_INTERVAL_MS);
 	};
 
 	private refreshAllProvidersServices = async () => {

--- a/apps/server/tests/refresh-job.test.ts
+++ b/apps/server/tests/refresh-job.test.ts
@@ -1,0 +1,23 @@
+import type { ProviderBL } from '../src/bl/providers/provider.bl';
+import { RefreshJob } from '../src/jobs/refresh-job';
+
+describe('RefreshJob', () => {
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	test('schedules provider refresh every 5 seconds', () => {
+		vi.useFakeTimers();
+		const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+		const providerBL = {
+			getAllProviders: vi.fn().mockResolvedValue([]),
+			refreshProviderServices: vi.fn(),
+		} as unknown as ProviderBL;
+
+		new RefreshJob(providerBL).startRefreshJob();
+
+		expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 1000);
+	});
+});


### PR DESCRIPTION
## Issue Reference

Fixes #787

---

## What Was Changed

- Added a named `REFRESH_INTERVAL_MS` constant set to five seconds.
- Updated the provider refresh scheduler to use the constant.
- Aligned the startup log and scheduling comment with the five-second cadence.
- Added a Vitest fake-timer regression test that verifies the interval passed to `setInterval`.

---

## Why Was It Changed

The refresh job's configured cadence and its log/comment were inconsistent with the expected five-second interval. A named constant makes the intended cadence explicit and prevents the implementation and documentation from drifting apart.

---

## Screenshots

Not applicable — backend scheduling change.

---

## Additional Context (Optional)

Validation completed:

- Targeted refresh-job test: 1 passed
- Full server test suite: 148 passed
- ESLint: passed with no warnings
- Prettier check: passed
- Server production build: passed

The optional overlap-prevention guard is intentionally left out to keep this fix focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Provider-service data now refreshes every 5 seconds instead of every 10 seconds.
  * Updated scheduling messages reflect the new refresh interval.

* **Tests**
  * Added coverage to verify the five-second refresh schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->