### PR TITLE
fix: portal tooltips so the sticky table header can't cover them

### DIFF
--- a/apps/client/src/components/ui/tooltip.tsx
+++ b/apps/client/src/components/ui/tooltip.tsx
@@ -13,15 +13,21 @@ const TooltipContent = React.forwardRef<
 	React.ElementRef<typeof TooltipPrimitive.Content>,
 	React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-	<TooltipPrimitive.Content
-		ref={ref}
-		sideOffset={sideOffset}
-		className={cn(
-			'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-			className
-		)}
-		{...props}
-	/>
+	// Portaled to <body>: rendered inline, the content lives inside its trigger's
+	// stacking context — a virtualized table row (transform) caps everything at the
+	// row's own level, so the sticky column header (z-10, opaque) paints over the
+	// first row's tooltips no matter how high their own z-index is.
+	<TooltipPrimitive.Portal>
+		<TooltipPrimitive.Content
+			ref={ref}
+			sideOffset={sideOffset}
+			className={cn(
+				'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+				className
+			)}
+			{...props}
+		/>
+	</TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 


### PR DESCRIPTION
## Problem

Hovering an icon on the **first row** of the alerts table (status flame, severity, type avatar, fix wrench…) opened the tooltip upward into the header band, where the sticky column header painted over it — the label was unreadable.

## Root cause

`TooltipContent` rendered `TooltipPrimitive.Content` without `TooltipPrimitive.Portal`, so tooltip content mounted **inline** in the trigger's DOM. The virtualizer positions rows with `transform`, making each row a stacking context: the tooltip's `z-50` only competed *inside its row*, and at the scroller level the whole row (z-auto) loses to the sticky header (`z-10`, opaque `bg-background`).

## Fix

Wrap the content in `TooltipPrimitive.Portal` (the shadcn default) — content mounts at `<body>` level where its `z-50` actually applies. One shared component, so every tooltip in the app benefits; no call-site changes.

Verified live: the first-row tooltip now renders on top of the sticky header, fully readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip rendering by displaying tooltips outside surrounding layout containers.
  * Preserved existing tooltip styling, positioning, and animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->