### PR TITLE
[FIX]: Add severity utility test coverage

### DIFF
--- a/apps/client/src/test/severity.utils.test.ts
+++ b/apps/client/src/test/severity.utils.test.ts
@@ -1,0 +1,45 @@
+import { Alert, AlertSeverity } from '@OpsiMate/shared';
+import {
+	SEVERITY_LABELS,
+	SEVERITY_RANK,
+	SEVERITY_ROW_CLASSES,
+	SEVERITY_TEXT_CLASSES,
+	getAlertSeverity,
+} from '@/components/Alerts/utils/severity.utils';
+import { describe, expect, test } from 'vitest';
+
+describe('getAlertSeverity', () => {
+	test('prefers explicit severity over severity and priority tags', () => {
+		const alert = {
+			severity: AlertSeverity.INFO,
+			tags: { severity: 'critical', priority: 'P1' },
+		} as unknown as Alert;
+
+		expect(getAlertSeverity(alert)).toBe(AlertSeverity.INFO);
+	});
+
+	test('falls back from the severity tag to the priority tag, then the default', () => {
+		expect(getAlertSeverity({ tags: { severity: 'critical', priority: 'P5' } } as unknown as Alert)).toBe(
+			AlertSeverity.CRITICAL
+		);
+		expect(getAlertSeverity({ tags: { priority: 'P1' } } as unknown as Alert)).toBe(AlertSeverity.CRITICAL);
+		expect(getAlertSeverity({ tags: {} } as unknown as Alert)).toBe(AlertSeverity.WARNING);
+		expect(getAlertSeverity({} as unknown as Alert)).toBe(AlertSeverity.WARNING);
+	});
+});
+
+describe('severity display helpers', () => {
+	test('ranks critical above warning above info', () => {
+		expect(SEVERITY_RANK[AlertSeverity.CRITICAL]).toBeGreaterThan(SEVERITY_RANK[AlertSeverity.WARNING]);
+		expect(SEVERITY_RANK[AlertSeverity.WARNING]).toBeGreaterThan(SEVERITY_RANK[AlertSeverity.INFO]);
+	});
+
+	test('defines every exported map for every severity', () => {
+		for (const severity of Object.values(AlertSeverity)) {
+			expect(Object.hasOwn(SEVERITY_RANK, severity)).toBe(true);
+			expect(Object.hasOwn(SEVERITY_LABELS, severity)).toBe(true);
+			expect(Object.hasOwn(SEVERITY_ROW_CLASSES, severity)).toBe(true);
+			expect(Object.hasOwn(SEVERITY_TEXT_CLASSES, severity)).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## Issue Reference

Closes #780

---

## What Was Changed

- Added focused unit coverage for the `getAlertSeverity` fallback precedence.
- Covered severity ranking and completeness of all exported display maps.

---

## Why Was It Changed

The severity helpers had no direct tests, leaving alert ordering and presentation regressions undetected.

---

## Screenshots

Not applicable (test-only change).

---

## Additional Context (Optional)

Validation:
- Targeted Vitest: 4 tests passed
- Full client suite: 79 tests passed
- ESLint and Prettier checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for alert severity resolution and display behavior.
  * Verified severity precedence, fallback handling, default warning behavior, severity ranking, and complete severity-map coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->