### PR TITLE
[FIX]: Make alert sort headers keyboard accessible

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/SortableHeader/SortableHeader.tsx
@@ -52,12 +52,22 @@ export const SortableHeader = ({
 		}
 	};
 
+	const handleKeyDown = (event: React.KeyboardEvent<HTMLTableCellElement>) => {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			handleClick();
+		}
+	};
+
 	return (
 		<TableHead
 			style={style}
 			className={cn('h-8 py-1 px-2 text-xs cursor-pointer hover:bg-muted/50 text-foreground', className)}
 			onClick={handleClick}
+			onKeyDown={handleKeyDown}
+			tabIndex={0}
 			aria-label={label}
+			aria-sort={sortField === column ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
 		>
 			<TooltipProvider>
 				<Tooltip>


### PR DESCRIPTION
## Issue Reference

Closes #774

---

## What Was Changed

- Made sortable alert table headers keyboard-focusable.
- Added Enter and Space activation while reusing the existing sort handler.
- Exposed the active direction through `aria-sort`.

---

## Why Was It Changed

Keyboard and screen-reader users could not operate the sort headers or determine the current sort direction.

---

## Screenshots

Not applicable (keyboard and accessibility semantics only).

---

## Additional Context (Optional)

The change is limited to `SortableHeader.tsx`, matching the issue scope.

Validation:
- Full client suite: 75 tests passed
- Prettier passed
- ESLint completed with 0 errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added keyboard support for sorting table columns using Enter and Space.
  * Table headers are now keyboard-focusable.
  * Current sorting state is communicated to assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->