### PR TITLE
[FIX]: Protect external window opens

### DIFF
--- a/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
+++ b/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
@@ -483,7 +483,11 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 						<Button
 							variant="outline"
 							onClick={() =>
-								window.open('https://docs.opsimate.dev/docs/integrations/custom-alerts', '_blank')
+								window.open(
+									'https://docs.opsimate.dev/docs/integrations/custom-alerts',
+									'_blank',
+									'noopener,noreferrer'
+								)
 							}
 							className="gap-2"
 						>

--- a/apps/client/src/components/Integrations/DatadogSetupModal/DatadogSetupModal.tsx
+++ b/apps/client/src/components/Integrations/DatadogSetupModal/DatadogSetupModal.tsx
@@ -142,7 +142,8 @@ export const DatadogSetupModal = ({ open, onOpenChange }: DatadogSetupModalProps
 											onClick={() =>
 												window.open(
 													'https://app.datadoghq.com/account/settings#integrations/webhooks',
-													'_blank'
+													'_blank',
+													'noopener,noreferrer'
 												)
 											}
 										>
@@ -245,7 +246,9 @@ export const DatadogSetupModal = ({ open, onOpenChange }: DatadogSetupModalProps
 								<Button
 									variant="link"
 									className="p-0 h-auto text-blue-600 hover:text-blue-700"
-									onClick={() => window.open(DATADOG_WEBHOOK_DOCS_URL, '_blank')}
+									onClick={() =>
+										window.open(DATADOG_WEBHOOK_DOCS_URL, '_blank', 'noopener,noreferrer')
+									}
 								>
 									<span>Open Datadog Webhooks documentation</span>
 									<ExternalLink className="ml-1 h-3 w-3" />

--- a/apps/client/src/components/Integrations/GCPSetupModal/GCPSetupModal.tsx
+++ b/apps/client/src/components/Integrations/GCPSetupModal/GCPSetupModal.tsx
@@ -100,7 +100,13 @@ export const GCPSetupModal = ({ open, onOpenChange }: GCPSetupModalProps) => {
 										<Button
 											variant="link"
 											className="p-0 h-auto text-blue-600 hover:text-blue-700"
-											onClick={() => window.open('https://console.cloud.google.com/', '_blank')}
+											onClick={() =>
+												window.open(
+													'https://console.cloud.google.com/',
+													'_blank',
+													'noopener,noreferrer'
+												)
+											}
 										>
 											<span>Open Google Cloud Console</span>
 											<ExternalLink className="ml-1 h-3 w-3" />
@@ -116,7 +122,8 @@ export const GCPSetupModal = ({ open, onOpenChange }: GCPSetupModalProps) => {
 											onClick={() =>
 												window.open(
 													'https://console.cloud.google.com/monitoring/alerting/notifications',
-													'_blank'
+													'_blank',
+													'noopener,noreferrer'
 												)
 											}
 										>
@@ -149,7 +156,8 @@ export const GCPSetupModal = ({ open, onOpenChange }: GCPSetupModalProps) => {
 											onClick={() =>
 												window.open(
 													'https://console.cloud.google.com/monitoring/alerting/policies',
-													'_blank'
+													'_blank',
+													'noopener,noreferrer'
 												)
 											}
 										>
@@ -214,7 +222,8 @@ export const GCPSetupModal = ({ open, onOpenChange }: GCPSetupModalProps) => {
 							onClick={() =>
 								window.open(
 									'https://cloud.google.com/monitoring/support/notification-options',
-									'_blank'
+									'_blank',
+									'noopener,noreferrer'
 								)
 							}
 							className="gap-2"

--- a/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
+++ b/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
@@ -158,7 +158,9 @@ export const GrafanaSetupModal = ({ open, onOpenChange }: GrafanaSetupModalProps
 								<Button
 									variant="link"
 									className="p-0 h-auto text-blue-600 hover:text-blue-700"
-									onClick={() => window.open(GRAFANA_CONTACT_POINTS_DOCS_URL, '_blank')}
+									onClick={() =>
+										window.open(GRAFANA_CONTACT_POINTS_DOCS_URL, '_blank', 'noopener,noreferrer')
+									}
 								>
 									<span>Open Grafana contact points documentation</span>
 									<ExternalLink className="ml-1 h-3 w-3" />

--- a/apps/client/src/components/Integrations/UptimeKumaSetupModal/UptimeKumaSetupModal.tsx
+++ b/apps/client/src/components/Integrations/UptimeKumaSetupModal/UptimeKumaSetupModal.tsx
@@ -168,7 +168,11 @@ export const UptimeKumaSetupModal = ({ open, onOpenChange }: UptimeKumaSetupModa
 						<Button
 							variant="outline"
 							onClick={() =>
-								window.open('https://github.com/louislam/uptime-kuma/wiki/Notifications', '_blank')
+								window.open(
+									'https://github.com/louislam/uptime-kuma/wiki/Notifications',
+									'_blank',
+									'noopener,noreferrer'
+								)
 							}
 							className="gap-2"
 						>

--- a/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
+++ b/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
@@ -520,7 +520,8 @@ fi`;
 						onClick={() =>
 							window.open(
 								'https://www.zabbix.com/documentation/current/en/manual/config/notifications/media/webhook',
-								'_blank'
+								'_blank',
+								'noopener,noreferrer'
 							)
 						}
 						className="gap-2"

--- a/apps/client/src/components/LeftSidebar.tsx
+++ b/apps/client/src/components/LeftSidebar.tsx
@@ -158,7 +158,8 @@ export const LeftSidebar = ({ collapsed }: LeftSidebarProps) => {
 											onClick={() =>
 												window.open(
 													'https://join.slack.com/t/opsimate/shared_invite/zt-39bq3x6et-NrVCZzH7xuBGIXmOjJM7gA',
-													'_blank'
+													'_blank',
+													'noopener,noreferrer'
 												)
 											}
 										>
@@ -183,7 +184,11 @@ export const LeftSidebar = ({ collapsed }: LeftSidebarProps) => {
 										<div
 											className="h-8 w-8 p-1 flex items-center justify-center transition-all duration-200 cursor-pointer hover:bg-muted rounded-md"
 											onClick={() =>
-												window.open('https://github.com/opsimate/opsimate', '_blank')
+												window.open(
+													'https://github.com/opsimate/opsimate',
+													'_blank',
+													'noopener,noreferrer'
+												)
 											}
 										>
 											<img

--- a/apps/client/src/pages/Integrations.tsx
+++ b/apps/client/src/pages/Integrations.tsx
@@ -332,7 +332,7 @@ const Integrations = () => {
 	};
 
 	const handleIntegrationButtonClick = () => {
-		window.open('https://github.com/OpsiMate/OpsiMate/issues', '_blank');
+		window.open('https://github.com/OpsiMate/OpsiMate/issues', '_blank', 'noopener,noreferrer');
 	};
 
 	return (
@@ -456,7 +456,13 @@ const Integrations = () => {
 												variant="ghost"
 												size="icon"
 												className="rounded-full h-8 w-8"
-												onClick={() => window.open(integration.documentationUrl, '_blank')}
+												onClick={() =>
+													window.open(
+														integration.documentationUrl,
+														'_blank',
+														'noopener,noreferrer'
+													)
+												}
 											>
 												<ExternalLink className="h-4 w-4" />
 											</Button>
@@ -1001,7 +1007,11 @@ const Integrations = () => {
 													variant="outline"
 													className="w-full justify-start gap-2"
 													onClick={() =>
-														window.open(selectedIntegration.documentationUrl, '_blank')
+														window.open(
+															selectedIntegration.documentationUrl,
+															'_blank',
+															'noopener,noreferrer'
+														)
 													}
 												>
 													<ExternalLink className="h-4 w-4" />


### PR DESCRIPTION
## Issue Reference

Fixes #775

---

## What Was Changed

Added `noopener,noreferrer` to every `window.open` call targeting `_blank` that was missing the feature string. All 22 `_blank` call sites under `apps/client/src` now follow the same protected convention.

---

## Why Was It Changed

Opening an untrusted page in a new tab without `noopener` can expose the opener to reverse-tabnabbing. `noreferrer` also prevents leaking the source URL and matches the convention already used elsewhere in the client.

---

## Screenshots

Not applicable; this change has no visual effect.

---

## Additional Context (Optional)

Validation:
- `pnpm --filter @OpsiMate/client test:run` — 75 tests passed
- `pnpm --filter @OpsiMate/client check` — passed with 0 errors (the existing lint baseline reports 406 warnings)
- `pnpm build` — all four workspace packages built successfully
- TypeScript AST audit — 22 `_blank` calls found, 0 missing `noopener,noreferrer`

AI assistance: the implementation and validation were performed with OpenAI Codex at the contributor direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Improved the safety of external documentation, support, and community links opened in new tabs.
  * External links now prevent the opened page from accessing or modifying the originating application tab.
* **Integrations**
  * Applied the improved link-handling behavior across integration setup guides and related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->