### PR TITLE
fix: white-page crash when opening a dashboard from the Dashboards page and changing the time range

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -1,7 +1,7 @@
 // src/App.tsx
 import { Alerts, AuthGuard, MobileWebOverlay, Profile, ThemeProvider } from '@/components';
 import { Dashboards } from '@/components/Dashboards';
-import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { ErrorBoundary, ErrorBoundaryInner } from '@/components/ErrorBoundary';
 import ScrollToTopButton from '@/components/ScrollToTopButton';
 import { UnsavedChangesDialog } from '@/components/shared';
 import { Toaster as Sonner } from '@/components/ui/sonner';
@@ -50,40 +50,46 @@ const App: React.FC = () => {
 				storageKey="theme"
 			>
 				<QueryClientProvider client={queryClient}>
-					<DashboardProvider>
-						<TooltipProvider>
-							<Toaster />
-							<Sonner />
-							<UnsavedChangesDialogWrapper />
+					{/* Router-free outer boundary: DashboardProvider renders ABOVE the
+					    pathname-keyed ErrorBoundary inside BrowserRouter, so a crash in the
+					    provider itself (e.g. a malformed persisted dashboard state) used to
+					    unmount everything into a blank white page with no card. */}
+					<ErrorBoundaryInner>
+						<DashboardProvider>
+							<TooltipProvider>
+								<Toaster />
+								<Sonner />
+								<UnsavedChangesDialogWrapper />
 
-							<BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-								<ErrorBoundary>
-									<AuthGuard>
-										<Routes>
-											<Route path="/" element={<Alerts />} />
-											<Route path="/dashboards" element={<Dashboards />} />
-											<Route path="/integrations" element={<Integrations />} />
-											<Route path="/settings" element={<Settings />} />
-											<Route path="/profile" element={<Profile />} />
-											<Route path="/login" element={<Login />} />
-											<Route path="/register" element={<Register />} />
-											<Route path="/alerts" element={<Alerts />} />
-											<Route path="/mute-policies" element={<MutePolicies />} />
-											<Route path="/oncall" element={<Oncall />} />
-											<Route path="/actions" element={<Actions />} />
-											<Route path="/enrichments" element={<Enrichments />} />
-											<Route path="/forgot-password" element={<ForgotPassword />} />
-											<Route path="/reset-password" element={<ResetPasswordByEmail />} />
-											<Route path="*" element={<NotFound />} />
-										</Routes>
-									</AuthGuard>
-								</ErrorBoundary>
-							</BrowserRouter>
+								<BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+									<ErrorBoundary>
+										<AuthGuard>
+											<Routes>
+												<Route path="/" element={<Alerts />} />
+												<Route path="/dashboards" element={<Dashboards />} />
+												<Route path="/integrations" element={<Integrations />} />
+												<Route path="/settings" element={<Settings />} />
+												<Route path="/profile" element={<Profile />} />
+												<Route path="/login" element={<Login />} />
+												<Route path="/register" element={<Register />} />
+												<Route path="/alerts" element={<Alerts />} />
+												<Route path="/mute-policies" element={<MutePolicies />} />
+												<Route path="/oncall" element={<Oncall />} />
+												<Route path="/actions" element={<Actions />} />
+												<Route path="/enrichments" element={<Enrichments />} />
+												<Route path="/forgot-password" element={<ForgotPassword />} />
+												<Route path="/reset-password" element={<ResetPasswordByEmail />} />
+												<Route path="*" element={<NotFound />} />
+											</Routes>
+										</AuthGuard>
+									</ErrorBoundary>
+								</BrowserRouter>
 
-							<ScrollToTopButton />
-							<MobileWebOverlay />
-						</TooltipProvider>
-					</DashboardProvider>
+								<ScrollToTopButton />
+								<MobileWebOverlay />
+							</TooltipProvider>
+						</DashboardProvider>
+					</ErrorBoundaryInner>
 				</QueryClientProvider>
 			</ThemeProvider>
 		</ChakraProvider>

--- a/apps/client/src/components/Dashboards/Dashboards.tsx
+++ b/apps/client/src/components/Dashboards/Dashboards.tsx
@@ -1,5 +1,6 @@
 import { DashboardLayout } from '@/components/DashboardLayout';
 import { useDashboard } from '@/context/DashboardContext';
+import { deserializeTimeRange } from '@/context/DashboardContext.utils';
 import {
 	useAddTagToDashboard,
 	useDeleteDashboard,
@@ -80,6 +81,11 @@ export const Dashboards = () => {
 
 	const handleDashboardClick = useCallback(
 		(dashboard: Dashboard) => {
+			// Mirrors Alerts.tsx's loader exactly. This used to omit timeRange (the first
+			// time-range change then crashed DashboardProvider's isDirty memo on
+			// serializeTimeRange(undefined) — a blank white page, since the provider sits
+			// above the ErrorBoundary) and wiped columnOrder to [] — discarding the saved
+			// arrangement whenever a dashboard was opened from this page.
 			setInitialState({
 				id: dashboard.id,
 				name: dashboard.name,
@@ -87,9 +93,10 @@ export const Dashboards = () => {
 				description: dashboard.description || '',
 				visibleColumns: dashboard.visibleColumns || [],
 				filters: dashboard.filters || {},
-				columnOrder: [],
+				columnOrder: dashboard.columnOrder || [],
 				groupBy: dashboard.groupBy || [],
 				query: dashboard.query || '',
+				timeRange: deserializeTimeRange(dashboard.timeRange),
 			});
 			navigate(`/alerts${location.search}`);
 		},

--- a/apps/client/src/components/ErrorBoundary/index.ts
+++ b/apps/client/src/components/ErrorBoundary/index.ts
@@ -1,1 +1,2 @@
 export { ErrorBoundary } from './ErrorBoundary';
+export { ErrorBoundaryInner } from './ErrorBoundaryInner';

--- a/apps/client/src/context/DashboardContext.utils.ts
+++ b/apps/client/src/context/DashboardContext.utils.ts
@@ -5,10 +5,13 @@ const logger = new Logger('DashboardContext.utils');
 
 export const DASHBOARD_STORAGE_KEY = 'OpsiMate-active-dashboard';
 
-export const serializeTimeRange = (timeRange: TimeRange): DashboardTimeRange => ({
-	from: timeRange.from?.toISOString() ?? null,
-	to: timeRange.to?.toISOString() ?? null,
-	preset: timeRange.preset,
+// Tolerates a missing timeRange: dashboard states built by older code paths (or persisted
+// before the field existed) can lack it, and this runs inside DashboardProvider — above
+// the router-scoped ErrorBoundary — where an exception used to mean a blank white page.
+export const serializeTimeRange = (timeRange: TimeRange | undefined | null): DashboardTimeRange => ({
+	from: timeRange?.from?.toISOString() ?? null,
+	to: timeRange?.to?.toISOString() ?? null,
+	preset: timeRange?.preset ?? null,
 });
 
 export const deserializeTimeRange = (stored: DashboardTimeRange | undefined): TimeRange => {


### PR DESCRIPTION
## The bug (critical)

Dashboards page → open a dashboard → pick any time preset (e.g. **Last 1 hour**) → **blank white page**, no error card, only a refresh recovers.

## Root cause

`Dashboards.tsx`'s open handler built the dashboard state **without `timeRange`**. The first time-range change flips `hasUserMadeChanges`, the provider's `isDirty` memo runs `serializeTimeRange(initialState.timeRange /* undefined */)` → `TypeError: Cannot read properties of undefined (reading 'from')`. `DashboardProvider` renders **above** the router-scoped ErrorBoundary, so the crash unmounts the entire tree — pure white, no card.

The same loader also passed `columnOrder: []`, silently discarding the saved column arrangement every time a dashboard was opened from this page — the surviving sibling of the old TV-mode column-order bug (#760 fixed persistence; this path still wiped the draft).

## Fixes (three layers, per "fix it everywhere")

1. **Root cause** — the Dashboards-page loader now mirrors `Alerts.tsx`'s: `timeRange: deserializeTimeRange(...)`, `columnOrder` passed through
2. **Defense** — `serializeTimeRange` tolerates `undefined`/`null` (it also runs in the `saveToStorage` effect with the same blast radius); audited all callers and both `setInitialState` sites
3. **Containment** — a router-free `ErrorBoundaryInner` now wraps the provider stack in `App.tsx`, so any future crash above the pathname-keyed boundary renders the error card instead of a blank page

## Verification

Reproduced live on main (exact flow, captured the exception), then replayed the same flow on the fix: renders normally, saved filters intact, no crash. 75/75 client tests, build green; the one typecheck error near touched code is pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability by adding broader error recovery around dashboard-related content.
  * Fixed dashboard loading so saved column layouts and time ranges are restored correctly.
  * Improved compatibility with older dashboards that do not include time range settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->