### PR TITLE
chore: drop the uuid dependency — node's crypto.randomUUID covers it

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -39,7 +39,6 @@
 		"node-ssh": "^13.2.1",
 		"nodemailer": "^7.0.13",
 		"sshpk": "^1.18.0",
-		"uuid": "^13.0.2",
 		"vite": "^8.2.0",
 		"vite-plugin-node": "^8.0.0",
 		"zod": "^3.25.76"

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { Request, Response } from 'express';
 import {
 	AlertHistory,
@@ -22,7 +23,6 @@ import {
 	ZabbixWebhookPayload,
 } from './models';
 import { isZodError } from '../../../utils/isZodError.ts';
-import { v4 } from 'uuid';
 import { createHash } from 'crypto';
 import { AuthenticatedRequest } from '../../../middleware/auth.ts';
 
@@ -128,7 +128,7 @@ export class AlertController {
 			if (!payload?.heartbeat || !payload?.monitor) {
 				logger.info('UptimeKuma Test Alert Created');
 				await this.alertBL.insertOrUpdateAlert({
-					id: v4(),
+					id: randomUUID(),
 					type: 'UptimeKuma',
 					status: AlertStatus.FIRING,
 					tags: {},
@@ -200,7 +200,7 @@ export class AlertController {
 			if (!payload.event_id && !payload.trigger_id) {
 				logger.info('Zabbix Test Alert Created');
 				await this.alertBL.insertOrUpdateAlert({
-					id: v4(),
+					id: randomUUID(),
 					type: 'Zabbix',
 					status: AlertStatus.FIRING,
 					tags: {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,9 +357,6 @@ importers:
       sshpk:
         specifier: ^1.18.0
         version: 1.18.0
-      uuid:
-        specifier: ^13.0.2
-        version: 13.0.2
       vite:
         specifier: ^8.2.0
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)
@@ -5424,10 +5421,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@13.0.2:
-    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
-    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -10912,8 +10905,6 @@ snapshots:
       '@types/react': 19.2.18
 
   util-deprecate@1.0.2: {}
-
-  uuid@13.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
Supersedes #806 (uuid 13→14). Per our dependency policy: checked whether the package is needed before bumping — it isn't.

- `uuid` was imported in one file, `apps/server/src/api/v1/alerts/controller.ts`, for two `v4()` calls generating alert ids
- Every runtime is node 20+ (Docker: `node:26-alpine`), where the built-in `crypto.randomUUID()` is RFC-4122 v4 — a drop-in replacement
- uuid 14's breaking change is literally "expect crypto to be global (node 20+)" — i.e. our environment already meets the bar to not need the library at all

150/150 server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating test alerts from Uptime Kuma and Zabbix integrations.
* **Chores**
  * Simplified internal dependency usage without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->