### PR TITLE
chore: zod 4 + @hookform/resolvers 5 (combined migration)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -31,7 +31,7 @@
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.1",
 		"@fontsource/nunito-sans": "^5.3.0",
-		"@hookform/resolvers": "^3.10.0",
+		"@hookform/resolvers": "^5.7.1",
 		"@radix-ui/react-accordion": "^1.2.20",
 		"@radix-ui/react-alert-dialog": "^1.1.23",
 		"@radix-ui/react-aspect-ratio": "^1.1.15",
@@ -85,7 +85,7 @@
 		"tailwind-merge": "^3.6.0",
 		"tailwindcss-animate": "^1.0.7",
 		"vaul": "^1.1.2",
-		"zod": "^3.25.76"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",

--- a/apps/client/src/components/ProviderSidebar.tsx
+++ b/apps/client/src/components/ProviderSidebar.tsx
@@ -42,7 +42,10 @@ const serverSchema = z
 					message: 'Must be a valid IP address or hostname',
 				}
 			),
-		port: z.coerce.number().min(1).max(65535),
+		// zod 4 types plain coerce input as unknown, which breaks zodResolver's
+		// Resolver generics; pinning <number> keeps the runtime string->number
+		// coercion while inferring a number field for react-hook-form.
+		port: z.coerce.number<number>().min(1).max(65535),
 		username: z
 			.string()
 			.min(1, 'Username is required')

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,7 +41,7 @@
 		"sshpk": "^1.18.0",
 		"vite": "^8.2.0",
 		"vite-plugin-node": "^8.0.0",
-		"zod": "^3.25.76"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@types/bcrypt": "^6.0.0",

--- a/apps/server/src/api/v1/actions/controller.ts
+++ b/apps/server/src/api/v1/actions/controller.ts
@@ -36,7 +36,7 @@ export class ActionController {
 			return res.json({ success: true, data: action });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error getting action', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -59,7 +59,7 @@ export class ActionController {
 			return res.status(201).json({ success: true, data: action, message: 'Action created' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error creating action', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -73,7 +73,7 @@ export class ActionController {
 			return res.json({ success: true, data: result });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error testing action', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -92,7 +92,7 @@ export class ActionController {
 			return res.json({ success: true, data: preview });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error previewing action', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -111,7 +111,7 @@ export class ActionController {
 			return res.json({ success: true, data: result });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error running action on alert', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -142,7 +142,7 @@ export class ActionController {
 			return res.json({ success: true, data: updated, message: 'Action updated' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error updating action', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -160,7 +160,7 @@ export class ActionController {
 			return res.json({ success: true, message: 'Action deleted' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error deleting action', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -70,7 +70,7 @@ export class AlertController {
 			return res.json({ success: true, data: settings });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error updating silence reset settings:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -97,7 +97,7 @@ export class AlertController {
 			return res.json({ success: true, data: { alert } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error silencing alert:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -403,7 +403,7 @@ export class AlertController {
 			return res.status(200).json({ success: true, data: { alertId } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error creating datadog alert:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -520,7 +520,7 @@ export class AlertController {
 			return res.status(200).json({ success: true, data: { processed: processedIds } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error creating grafana alert:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -551,7 +551,7 @@ export class AlertController {
 			return res.status(200).json({ success: true, data: { alertId: alert.id } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error creating integration:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -596,7 +596,7 @@ export class AlertController {
 			return res.json({ success: true, message: 'Alert deleted successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error deleting alert:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -680,7 +680,7 @@ export class AlertController {
 			return res.json({ success: true, data: { alert } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error setting alert owner:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -750,7 +750,7 @@ export class AlertController {
 			return res.status(201).json({ success: true, data: { comment: newComment } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error creating comment:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -777,7 +777,7 @@ export class AlertController {
 			return res.json({ success: true, data: { comment: updatedComment } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error updating comment:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/custom-actions/controller.ts
+++ b/apps/server/src/api/v1/custom-actions/controller.ts
@@ -45,7 +45,7 @@ export class CustomActionsController {
 			return res.status(201).json({ success: true, data: { id } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error creating custom action:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -76,7 +76,7 @@ export class CustomActionsController {
 			return res.status(200).json({ success: true });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error updating custom action:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/custom-fields/controller.ts
+++ b/apps/server/src/api/v1/custom-fields/controller.ts
@@ -39,7 +39,7 @@ export class CustomFieldsController {
 				return res.status(400).json({
 					success: false,
 					error: 'Validation error',
-					details: error.errors,
+					details: error.issues,
 				});
 			} else {
 				logger.error('Error creating custom field:', error);
@@ -127,7 +127,7 @@ export class CustomFieldsController {
 				return res.status(400).json({
 					success: false,
 					error: 'Validation error',
-					details: error.errors,
+					details: error.issues,
 				});
 			} else {
 				logger.error('Error updating custom field:', error);
@@ -185,7 +185,7 @@ export class CustomFieldsController {
 				return res.status(400).json({
 					success: false,
 					error: 'Validation error',
-					details: error.errors,
+					details: error.issues,
 				});
 			} else {
 				logger.error('Error upserting custom field value:', error);

--- a/apps/server/src/api/v1/dashboards/controller.ts
+++ b/apps/server/src/api/v1/dashboards/controller.ts
@@ -33,7 +33,7 @@ export class DashboardController {
 			return res.json({ success: true, data: { id: createdDashboardId } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error saving dashboard:', error);
 			const message = error instanceof Error ? error.message : String(error);
@@ -59,7 +59,7 @@ export class DashboardController {
 			return res.json({ success: true, data: null });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error Updating dashboard:', error);
 			const message = error instanceof Error ? error.message : String(error);
@@ -95,7 +95,7 @@ export class DashboardController {
 			return res.json({ success: true, data: tags });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error getting dashboard tags:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -130,7 +130,7 @@ export class DashboardController {
 			return res.json({ success: true, message: 'Tag added to dashboard successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			const message = error instanceof Error ? error.message : 'Internal server error';
 			if (message.includes('not found')) {
@@ -153,7 +153,7 @@ export class DashboardController {
 			return res.json({ success: true, message: 'Tag removed from dashboard successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			const message = error instanceof Error ? error.message : 'Internal server error';
 			if (message.includes('not found')) {

--- a/apps/server/src/api/v1/enrichments/controller.ts
+++ b/apps/server/src/api/v1/enrichments/controller.ts
@@ -34,7 +34,7 @@ export class EnrichmentController {
 			return res.json({ success: true, data: enrichment });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error getting enrichment', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -59,7 +59,7 @@ export class EnrichmentController {
 			return res.status(201).json({ success: true, data: enrichment, message: 'Enrichment created' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error creating enrichment', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -80,7 +80,7 @@ export class EnrichmentController {
 			return res.json({ success: true, data: updated, message: 'Enrichment updated' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error updating enrichment', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -98,7 +98,7 @@ export class EnrichmentController {
 			return res.json({ success: true, message: 'Enrichment deleted' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error deleting enrichment', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/integrations/controller.ts
+++ b/apps/server/src/api/v1/integrations/controller.ts
@@ -62,7 +62,7 @@ export class IntegrationController {
 			return res.status(201).json({ success: true, data: createdIntegration });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error creating integration:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -87,7 +87,7 @@ export class IntegrationController {
 			});
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error updating integration:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -123,7 +123,7 @@ export class IntegrationController {
 				res.status(400).json({
 					success: false,
 					error: 'Validation error',
-					details: error.errors,
+					details: error.issues,
 				});
 				return;
 			} else {

--- a/apps/server/src/api/v1/mute-policies/controller.ts
+++ b/apps/server/src/api/v1/mute-policies/controller.ts
@@ -28,7 +28,7 @@ export class MutePolicyController {
 			return res.json({ success: true, data: mutePolicy });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error getting mute policy', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -50,7 +50,7 @@ export class MutePolicyController {
 			return res.status(201).json({ success: true, data: mutePolicy, message: 'Mute policy created' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error creating mute policy', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -71,7 +71,7 @@ export class MutePolicyController {
 			return res.json({ success: true, data: updated, message: 'Mute policy updated' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error updating mute policy', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -89,7 +89,7 @@ export class MutePolicyController {
 			return res.json({ success: true, message: 'Mute policy deleted' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error deleting mute policy', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/oncall/controller.ts
+++ b/apps/server/src/api/v1/oncall/controller.ts
@@ -46,7 +46,7 @@ export class OncallController {
 			return res.status(201).json({ success: true, data: { team } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			if (error instanceof DuplicateTeamNameError) {
 				return res.status(409).json({ success: false, error: error.message });
@@ -69,7 +69,7 @@ export class OncallController {
 			return res.json({ success: true, data: { team } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			if (error instanceof DuplicateTeamNameError) {
 				return res.status(409).json({ success: false, error: error.message });
@@ -106,7 +106,7 @@ export class OncallController {
 			return res.json({ success: true, data: { team } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error setting on-call team members', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/providers/controller.ts
+++ b/apps/server/src/api/v1/providers/controller.ts
@@ -71,7 +71,7 @@ export class ProviderController {
 			return res.status(201).json({ success: true, data: createdProvider });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error creating provider:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -99,7 +99,7 @@ export class ProviderController {
 			return res.status(201).json({ success: true, data: { providerIds } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error creating providers in bulk:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -138,7 +138,7 @@ export class ProviderController {
 			}
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error testing provider connection:', error);
 				const errorMessage = error instanceof Error ? error.message : 'Internal server error';
@@ -160,7 +160,7 @@ export class ProviderController {
 			return res.json({ success: true, data: updatedProvider, message: 'Provider updated successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else if (error instanceof ProviderNotFound) {
 				return res.status(404).json({ success: false, error: `Provider ${error.provider} not found` });
 			} else {

--- a/apps/server/src/api/v1/retention/controller.ts
+++ b/apps/server/src/api/v1/retention/controller.ts
@@ -42,7 +42,7 @@ export class RetentionController {
 			return res.json({ success: true, data: config });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error updating retention config', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -58,7 +58,7 @@ export class RetentionController {
 			return res.json({ success: true, data: policy });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error updating retention policy', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/secrets/controller.ts
+++ b/apps/server/src/api/v1/secrets/controller.ts
@@ -58,7 +58,7 @@ export class SecretsController {
 			return res.status(201).json({ success: true, data: { id: createdSecretId } });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error creating secret:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -119,7 +119,7 @@ export class SecretsController {
 			}
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error updating secret:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/services/controller.ts
+++ b/apps/server/src/api/v1/services/controller.ts
@@ -108,7 +108,7 @@ export class ServiceController {
 			});
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else if (error instanceof ProviderNotFound) {
 				return res.status(404).json({ success: false, error: `Provider with ID ${error.provider} not found` });
 			} else if (error instanceof ServiceNotFound) {
@@ -143,7 +143,7 @@ export class ServiceController {
 			return res.json({ success: true, data: enrichedServices[0] });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error getting service:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -172,7 +172,7 @@ export class ServiceController {
 			}
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error updating service:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -205,7 +205,7 @@ export class ServiceController {
 			res.json({ success: true, message: 'Service deleted successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else if (error instanceof ServiceNotFound) {
 				res.status(404).json({ success: false, error: `Service with ID ${error.serviceId} not found` });
 			} else {
@@ -242,7 +242,7 @@ export class ServiceController {
 			}
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error starting service:', error);
 				const message = error instanceof Error ? error.message : String(error);
@@ -278,7 +278,7 @@ export class ServiceController {
 			}
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error stopping service:', error);
 				const message = error instanceof Error ? error.message : String(error);
@@ -307,7 +307,7 @@ export class ServiceController {
 			return res.json({ success: true, data: logs, message: 'Service logs retrieved successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error getting logs:', error);
 				const message = error instanceof Error ? error.message : String(error);
@@ -336,7 +336,7 @@ export class ServiceController {
 			return res.json({ success: true, data: pods, message: 'Service pods retrieved successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error getting pods:', error);
 				const message = error instanceof Error ? error.message : String(error);

--- a/apps/server/src/api/v1/tags/controller.ts
+++ b/apps/server/src/api/v1/tags/controller.ts
@@ -33,7 +33,7 @@ export class TagController {
 			return res.json({ success: true, data: tag });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error getting tag by ID:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -49,7 +49,7 @@ export class TagController {
 			return res.status(201).json({ success: true, data: newTag, message: 'Tag created successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error creating tag:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -73,7 +73,7 @@ export class TagController {
 			return res.json({ success: true, data: updatedTag, message: 'Tag updated successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error updating tag:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -95,7 +95,7 @@ export class TagController {
 			return res.json({ success: true, message: 'Tag deleted successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error deleting tag:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -127,7 +127,7 @@ export class TagController {
 			return res.json({ success: true, message: 'Tag added to service successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error adding tag to service:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -154,7 +154,7 @@ export class TagController {
 			return res.json({ success: true, message: 'Tag removed from service successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error removing tag from service:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });
@@ -178,7 +178,7 @@ export class TagController {
 			return res.json({ success: true, data: tags });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				logger.error('Error getting service tags:', error);
 				return res.status(500).json({ success: false, error: 'Internal server error' });

--- a/apps/server/src/api/v1/users/controller.ts
+++ b/apps/server/src/api/v1/users/controller.ts
@@ -31,7 +31,7 @@ export class UsersController {
 			return res.status(201).json({ success: true, data: result, token });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else if (error instanceof Error && error.message === 'Registration is disabled after first admin') {
 				return res.status(403).json({ success: false, error: error.message });
 			} else if (error instanceof Error && error.message.includes('UNIQUE constraint failed: users.email')) {
@@ -52,7 +52,7 @@ export class UsersController {
 			return res.status(201).json({ success: true, data: result });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else if (error instanceof Error && error.message.includes('UNIQUE constraint failed: users.email')) {
 				return res.status(400).json({ success: false, error: 'Email already registered' });
 			} else {
@@ -71,7 +71,7 @@ export class UsersController {
 			return res.status(200).json({ success: true, message: 'User role updated successfully' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else {
 				return res.status(500).json({ success: false, error: 'Internal server error' });
 			}
@@ -86,7 +86,7 @@ export class UsersController {
 			return res.status(200).json({ success: true, data: user, token });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else if (error instanceof Error && error.message === 'Invalid email or password') {
 				return res.status(401).json({ success: false, error: error.message });
 			} else {
@@ -189,7 +189,7 @@ export class UsersController {
 			return res.status(200).json({ success: true, data: responseData });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			} else if (error instanceof Error && error.message === 'User not found') {
 				return res.status(404).json({ success: false, error: error.message });
 			} else {
@@ -298,7 +298,7 @@ export class UsersController {
 			return res.status(200).json({ success: true, message: 'Password reset email sent' });
 		} catch (error) {
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 
 			logger.error('Error processing forgot password request:', error);
@@ -317,7 +317,7 @@ export class UsersController {
 		} catch (error) {
 			logger.error('Error validating reset password token:', error);
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
@@ -332,7 +332,7 @@ export class UsersController {
 			logger.error('Error resetting password:', error);
 
 			if (isZodError(error)) {
-				return res.status(400).json({ success: false, error: 'Validation error', details: error.errors });
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 
 			if (

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,7 +23,7 @@
 		"fix": "npm run format-fix && npm run lint-fix"
 	},
 	"dependencies": {
-		"zod": "^3.25.76"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@types/node": "^22.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@hookform/resolvers':
-        specifier: ^3.10.0
-        version: 3.10.0(react-hook-form@7.84.0(react@19.2.8))
+        specifier: ^5.7.1
+        version: 5.7.1(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.84.0(react@19.2.8))(zod@4.4.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.20
         version: 1.2.20(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -207,8 +207,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -364,8 +364,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@swc/core@1.15.47(@swc/helpers@0.5.17))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/bcrypt':
         specifier: ^6.0.0
@@ -434,8 +434,8 @@ importers:
   packages/shared:
     dependencies:
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.20.1
@@ -1055,10 +1055,83 @@ packages:
   '@fontsource/nunito-sans@5.3.0':
     resolution: {integrity: sha512-CctNhebQ2YYJUwVMCAkHexQg7yedfz9s8JzaETALyc9QIQuDFRlNTWXux9H5PsNLgptPkrzRDomAdLJt1sDFpQ==}
 
-  '@hookform/resolvers@3.10.0':
-    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+  '@hookform/resolvers@5.7.1':
+    resolution: {integrity: sha512-8wS/P4UDr5sQDe4nFaV51TVyfDPrWgNIXweqG0Bs9Z5LSuzKLb+RQNPvkN2oHM5SRrJyWrVH/F+LOUcFjUyvwQ==}
     peerDependencies:
-      react-hook-form: ^7.0.0
+      '@sinclair/typebox': '>=0.25.24'
+      '@standard-schema/spec': ^1.0.0
+      '@typeschema/main': '>=0.13.7'
+      '@vinejs/vine': ^2.0.0 || ^3.0.0 || ^4.0.0
+      ajv: ^8.12.0
+      ajv-errors: ^3.0.0
+      ajv-formats: ^2.1.1
+      arktype: ^2.0.0
+      ata-validator: ^1.2.0
+      class-transformer: '>=0.4.0'
+      class-validator: '>=0.12.0'
+      computed-types: ^1.0.0
+      effect: ^3.10.3
+      fluentvalidation-ts: ^3.0.0
+      fp-ts: ^2.7.0
+      io-ts: ^2.0.0
+      joi: ^17.0.0
+      nope-validator: '>=0.12.0'
+      react-hook-form: ^7.55.0
+      superstruct: '>=0.12.0'
+      typanion: ^3.3.2
+      valibot: '>=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc'
+      vest: '>=3.0.0'
+      yup: ^1.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@sinclair/typebox':
+        optional: true
+      '@standard-schema/spec':
+        optional: true
+      '@typeschema/main':
+        optional: true
+      '@vinejs/vine':
+        optional: true
+      ajv:
+        optional: true
+      ajv-errors:
+        optional: true
+      ajv-formats:
+        optional: true
+      arktype:
+        optional: true
+      ata-validator:
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+      computed-types:
+        optional: true
+      effect:
+        optional: true
+      fluentvalidation-ts:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      nope-validator:
+        optional: true
+      superstruct:
+        optional: true
+      typanion:
+        optional: true
+      valibot:
+        optional: true
+      vest:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2131,6 +2204,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/core-darwin-arm64@1.15.47':
     resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
@@ -5661,8 +5737,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -6164,9 +6240,14 @@ snapshots:
 
   '@fontsource/nunito-sans@5.3.0': {}
 
-  '@hookform/resolvers@3.10.0(react-hook-form@7.84.0(react@19.2.8))':
+  '@hookform/resolvers@5.7.1(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.84.0(react@19.2.8))(zod@4.4.3)':
     dependencies:
+      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.84.0(react@19.2.8)
+    optionalDependencies:
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.20.0
+      zod: 4.4.3
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7234,6 +7315,8 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/core-darwin-arm64@1.15.47':
     optional: true
@@ -11161,4 +11244,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
Supersedes #802 and #801 — resolvers v3 has no zod-4 support, so the pair moves together.

## Migration notes

- **`.errors` removed from ZodError in v4**: all 15 controllers sent `details: error.errors` in validation responses — would have silently become `undefined`. Swept to `.issues`; verified live (invalid webhook payload → populated `details` array). `isZodError` already duck-typed on `issues`.
- **`z.coerce.number()` input is `unknown` in v4**, breaking `zodResolver`'s generics on the provider form — pinned `z.coerce.number<number>()` (identical runtime coercion).
- `z.nativeEnum` is deprecated-but-working in v4; left as-is for a minimal diff.

## Verification

- 150/150 server tests, 75/75 client tests, client + server builds green, typecheck clean on touched files
- Live probe: `POST /alerts/custom` with an invalid link URL → `{"error":"Validation error","details":[{"code":"invalid_format",...}]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation error handling across actions, alerts, dashboards, integrations, users, and other API areas.
  - Preserved existing response formats and status codes while ensuring validation details remain available after the schema validation update.
  - Fixed server form port validation to reliably convert entered text into a numeric value.

- **Maintenance**
  - Updated validation libraries across the client, server, and shared packages for improved compatibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->