### PR TITLE
fix: satisfy eslint 10's new rules in the server lint (unbreaks CI)

### DIFF
--- a/apps/server/src/bl/actions/actionExecutor.ts
+++ b/apps/server/src/bl/actions/actionExecutor.ts
@@ -228,7 +228,7 @@ const sendJira = async (cfg: JiraActionConfig, summary: string, description: str
 			message: `Jira returned ${res.status}: ${respText || res.statusText}`,
 		};
 	}
-	let key = '';
+	let key: string;
 	try {
 		key = (JSON.parse(respText) as { key?: string }).key ?? '';
 	} catch {

--- a/apps/server/src/bl/providers/provider-connector/vmProviderConnector.ts
+++ b/apps/server/src/bl/providers/provider-connector/vmProviderConnector.ts
@@ -72,7 +72,7 @@ export class VMProviderConnector implements ProviderConnector {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
 			this.logger.error(`Failed to execute bash action '${action.name}': ${errorMessage}`);
-			throw new Error(`Failed to execute bash action '${action.name}': ${errorMessage}`);
+			throw new Error(`Failed to execute bash action '${action.name}': ${errorMessage}`, { cause: error });
 		}
 	}
 

--- a/apps/server/src/bl/providers/provider.bl.ts
+++ b/apps/server/src/bl/providers/provider.bl.ts
@@ -138,7 +138,7 @@ export class ProviderBL {
 			return await providerConnector.discoverServices(provider);
 		} catch (error) {
 			logger.error(`Error discovering services in provider`, error);
-			throw new Error(`Failed to discover services for provider ${providerId}`);
+			throw new Error(`Failed to discover services for provider ${providerId}`, { cause: error });
 		}
 	}
 
@@ -183,7 +183,9 @@ export class ProviderBL {
 			};
 		} catch (error) {
 			logger.error(`Error refreshing provider ${providerId}:`, error);
-			throw new Error(`Failed to refresh provider: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			throw new Error(`Failed to refresh provider: ${error instanceof Error ? error.message : 'Unknown error'}`, {
+				cause: error,
+			});
 		}
 	}
 

--- a/apps/server/src/bl/users/user.bl.ts
+++ b/apps/server/src/bl/users/user.bl.ts
@@ -138,7 +138,7 @@ export class UserBL {
 		} catch (error) {
 			logger.error('Failed to send password reset email', error);
 			await this.passwordResetsRepo.deletePasswordResetsByUserId(user.id);
-			throw new Error('Failed to send password reset email. Please try again later.');
+			throw new Error('Failed to send password reset email. Please try again later.', { cause: error });
 		}
 	}
 

--- a/apps/server/src/dal/sshClient.ts
+++ b/apps/server/src/dal/sshClient.ts
@@ -201,7 +201,7 @@ export async function getServiceLogs(provider: Provider, serviceName: string): P
 		return logs.length > 0 ? logs : ['No error logs found in the last 24 hours'];
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-		throw new Error(`Failed to get logs for service ${serviceName}: ${errorMessage}`);
+		throw new Error(`Failed to get logs for service ${serviceName}: ${errorMessage}`, { cause: error });
 	} finally {
 		ssh.dispose();
 	}
@@ -267,7 +267,7 @@ export async function getSystemServiceLogs(provider: Provider, serviceName: stri
 		return logs.length > 0 ? logs : ['No logs found in the last 24 hours'];
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-		throw new Error(`Failed to get logs for system service ${serviceName}: ${errorMessage}`);
+		throw new Error(`Failed to get logs for system service ${serviceName}: ${errorMessage}`, { cause: error });
 	} finally {
 		ssh.dispose();
 	}


### PR DESCRIPTION
The @eslint/js 10 bump (#804) was merged while its CI re-run was still pending — my mistake during the dependency sweep — and eslint 10's new `preserve-caught-error` + `no-useless-assignment` rules fail `apps/server`'s `--max-warnings=0` lint, which breaks **Run CI for every subsequent PR** (first seen on #809).

All seven findings are real improvements:
- 6 rethrow sites now attach `{ cause: error }` — the original failure travels with the symptom error instead of being logged-and-lost
- `actionExecutor`'s parsed Jira key drops a dead initializer

Server lint exits 0, 150/150 tests, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error details retained across provider discovery, refresh, custom actions, password recovery, and service log retrieval.
  * Enhanced troubleshooting by preserving the original underlying errors when failures are reported.
  * Improved type clarity when processing Jira issue keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->