### PR TITLE
feat: OR matcher groups + match-all for actions, enrichments, and mute policies

### DIFF
--- a/apps/client/src/components/Actions/ActionFormDialog.tsx
+++ b/apps/client/src/components/Actions/ActionFormDialog.tsx
@@ -9,6 +9,7 @@ import {
 	DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { cleanMatcherGroups, MatcherGroupsEditor } from '@/components/shared/MatcherGroupsEditor';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
@@ -69,7 +70,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 
 	// Alert filter (empty = applies to all alerts)
 	const [nameContains, setNameContains] = useState('');
-	const [matchers, setMatchers] = useState<HeaderRow[]>([]);
+	const [matcherGroups, setMatcherGroups] = useState<HeaderRow[][]>([]);
 
 	// Slack
 	const [slackWebhookUrl, setSlackWebhookUrl] = useState('');
@@ -123,7 +124,13 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 			setName(action.name);
 			setType(action.type);
 			setNameContains(action.nameContains ?? '');
-			setMatchers((action.labelMatchers ?? []).map((m) => ({ ...m })));
+			setMatcherGroups(
+				action.labelMatcherGroups?.length
+					? action.labelMatcherGroups.map((g) => g.map((m) => ({ ...m })))
+					: (action.labelMatchers ?? []).length
+						? [(action.labelMatchers ?? []).map((m) => ({ ...m }))]
+						: []
+			);
 			if (action.type === 'slack') {
 				const cfg = action.config as SlackActionConfig;
 				setSlackWebhookUrl(cfg.webhookUrl ?? '');
@@ -154,7 +161,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 			setName('');
 			setType('slack');
 			setNameContains('');
-			setMatchers([]);
+			setMatcherGroups([]);
 		}
 	}, [open, action]);
 
@@ -193,11 +200,11 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 
 	const buildPayload = (): ActionPayload => {
 		const trimmedName = name.trim();
+		const cleanedGroups = cleanMatcherGroups(matcherGroups);
 		const match = {
 			nameContains: nameContains.trim() || null,
-			labelMatchers: matchers
-				.map((m) => ({ key: m.key.trim(), value: m.value.trim() }))
-				.filter((m) => m.key && m.value),
+			labelMatchers: cleanedGroups[0] ?? [],
+			labelMatcherGroups: cleanedGroups,
 		};
 		switch (type) {
 			case 'slack':
@@ -650,67 +657,13 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 							/>
 						</div>
 
-						<div className="space-y-2">
-							<div className="flex items-center justify-between">
-								<Label className="text-xs">Label matchers (key = value)</Label>
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onClick={() => setMatchers((m) => [...m, { key: '', value: '' }])}
-								>
-									<Plus className="h-3.5 w-3.5 mr-1" /> Add
-								</Button>
-							</div>
-							{matchers.length === 0 ? (
-								<p className="text-xs text-muted-foreground italic">
-									No label matchers. Scope by environment, service, severity, etc.
-								</p>
-							) : (
-								<div className="space-y-2">
-									{matchers.map((matcher, idx) => (
-										<div
-											key={idx}
-											className="grid grid-cols-[1fr_auto_1fr_auto] items-center gap-2"
-										>
-											<Input
-												placeholder="key (e.g. severity)"
-												value={matcher.key}
-												onChange={(e) =>
-													setMatchers((m) =>
-														m.map((row, i) =>
-															i === idx ? { ...row, key: e.target.value } : row
-														)
-													)
-												}
-											/>
-											<span className="text-muted-foreground text-sm">=</span>
-											<Input
-												placeholder="value (e.g. critical)"
-												value={matcher.value}
-												onChange={(e) =>
-													setMatchers((m) =>
-														m.map((row, i) =>
-															i === idx ? { ...row, value: e.target.value } : row
-														)
-													)
-												}
-											/>
-											<Button
-												type="button"
-												variant="ghost"
-												size="icon"
-												className="h-9 w-9"
-												onClick={() => setMatchers((m) => m.filter((_, i) => i !== idx))}
-												aria-label="Remove matcher"
-											>
-												<Trash2 className="h-4 w-4" />
-											</Button>
-										</div>
-									))}
-								</div>
-							)}
-						</div>
+						<MatcherGroupsEditor
+							groups={matcherGroups}
+							onChange={setMatcherGroups}
+							keyPlaceholder="key (e.g. severity)"
+							valuePlaceholder="value (e.g. critical)"
+							emptyText="No label matchers. Scope by environment, service, severity, etc."
+						/>
 					</div>
 				</div>
 

--- a/apps/client/src/components/Actions/ActionFormDialog.tsx
+++ b/apps/client/src/components/Actions/ActionFormDialog.tsx
@@ -642,7 +642,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 						</div>
 						<p className="text-xs text-muted-foreground -mt-2">
 							Leave empty to show this action on every alert. Add criteria to show it only on matching
-							alerts (name contains AND all labels match).
+							alerts (name contains AND any matcher group matches).
 						</p>
 
 						<div className="space-y-2">

--- a/apps/client/src/components/Alerts/AlertDetails/AlertActionsSection/AlertActions.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertActionsSection/AlertActions.tsx
@@ -1,7 +1,7 @@
 import { ActionTypeIcon } from '@/components/Actions/ActionTypeIcon';
 import { Button } from '@/components/ui/button';
 import { useActions } from '@/hooks/queries/actions';
-import { Action, Alert } from '@OpsiMate/shared';
+import { anyMatcherGroupMatchesTags, getLabelMatcherGroups, Action, Alert } from '@OpsiMate/shared';
 import { ChevronDown, ChevronRight, Zap } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -12,18 +12,16 @@ interface AlertActionsProps {
 }
 
 // An action shows on an alert when it has no filter, or when its filter matches:
-// the alert name contains nameContains (if set) AND every label matcher matches a tag.
+// the alert name contains nameContains (if set) AND any matcher GROUP fully matches
+// (OR between groups, AND within a group; a legacy flat matcher list is one group).
 const actionMatchesAlert = (action: Action, alert: Alert): boolean => {
 	const hasName = !!action.nameContains && action.nameContains.trim().length > 0;
-	const matchers = action.labelMatchers ?? [];
-	if (!hasName && matchers.length === 0) return true;
+	const groups = getLabelMatcherGroups(action);
+	if (!hasName && groups.length === 0) return true;
 	if (hasName && !alert.alertName?.toLowerCase().includes(action.nameContains!.trim().toLowerCase())) {
 		return false;
 	}
-	for (const m of matchers) {
-		const tagValue = alert.tags?.[m.key];
-		if (tagValue === undefined || String(tagValue) !== m.value) return false;
-	}
+	if (groups.length > 0 && !anyMatcherGroupMatchesTags(groups, alert.tags)) return false;
 	return true;
 };
 

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -380,6 +380,7 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 								id="enrichment-nameContains"
 								placeholder="e.g. Disk, HighCPU, prod-db"
 								value={nameContains}
+								disabled={matchAll}
 								onChange={(e) => setNameContains(e.target.value)}
 							/>
 						</div>

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -7,7 +7,9 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
+import { cleanMatcherGroups, MatcherGroupsEditor } from '@/components/shared/MatcherGroupsEditor';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
@@ -193,7 +195,8 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 
 	const [name, setName] = useState('');
 	const [nameContains, setNameContains] = useState('');
-	const [matchers, setMatchers] = useState<KeyValue[]>([]);
+	const [matcherGroups, setMatcherGroups] = useState<KeyValue[][]>([]);
+	const [matchAll, setMatchAll] = useState(false);
 	const [addFields, setAddFields] = useState<KeyValue[]>([]);
 	const [addLinks, setAddLinks] = useState<AlertLink[]>([]);
 	const [summaryTemplate, setSummaryTemplate] = useState('');
@@ -234,7 +237,14 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 		if (source) {
 			setName(enrichment ? source.name : `${source.name} (copy)`);
 			setNameContains(source.nameContains ?? '');
-			setMatchers((source.labelMatchers ?? []).map((m) => ({ ...m })));
+			setMatcherGroups(
+				source.labelMatcherGroups?.length
+					? source.labelMatcherGroups.map((g) => g.map((m) => ({ ...m })))
+					: (source.labelMatchers ?? []).length
+						? [(source.labelMatchers ?? []).map((m) => ({ ...m }))]
+						: []
+			);
+			setMatchAll(!!source.matchAll);
 			setAddFields((source.addFields ?? []).map((f) => ({ ...f })));
 			setAddLinks((source.addLinks ?? []).map((l) => ({ ...l })));
 			setSummaryTemplate(source.summaryTemplate ?? '');
@@ -242,7 +252,8 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 		} else {
 			setName('');
 			setNameContains('');
-			setMatchers([]);
+			setMatcherGroups([]);
+			setMatchAll(false);
 			setAddFields([]);
 			setAddLinks([]);
 			// Pre-fill with {{summary}} so the user keeps the existing summary and appends to it.
@@ -254,22 +265,25 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 	const isValid = useMemo(() => {
 		if (!name.trim()) return false;
 		const hasNameMatcher = nameContains.trim().length > 0;
-		const hasLabelMatchers = matchers.some((m) => m.key.trim() && m.value.trim());
-		if (!hasNameMatcher && !hasLabelMatchers) return false;
+		const hasLabelMatchers = matcherGroups.some((g) => g.some((m) => m.key.trim() && m.value.trim()));
+		if (!matchAll && !hasNameMatcher && !hasLabelMatchers) return false;
 		const hasFields = addFields.some((f) => f.key.trim() && f.value.trim());
 		const hasLinks = addLinks.some((l) => l.label.trim() && l.url.trim());
 		const hasSummary = summaryTemplate.trim().length > 0;
 		return hasFields || hasLinks || hasSummary;
-	}, [name, nameContains, matchers, addFields, addLinks, summaryTemplate]);
+	}, [name, nameContains, matcherGroups, matchAll, addFields, addLinks, summaryTemplate]);
 
 	const submit = async () => {
 		const clean = (rows: KeyValue[]) =>
 			rows.map((r) => ({ key: r.key.trim(), value: r.value.trim() })).filter((r) => r.key && r.value);
 
+		const cleanedGroups = matchAll ? [] : cleanMatcherGroups(matcherGroups);
 		const payload: EnrichmentPayload = {
 			name: name.trim(),
-			nameContains: nameContains.trim() || null,
-			labelMatchers: clean(matchers),
+			nameContains: matchAll ? null : nameContains.trim() || null,
+			labelMatchers: cleanedGroups[0] ?? [],
+			labelMatcherGroups: cleanedGroups,
+			matchAll,
 			addFields: clean(addFields),
 			addLinks: addLinks
 				.map((l) => ({ label: l.label.trim(), icon: (l.icon ?? '').trim(), url: l.url.trim() }))
@@ -347,11 +361,18 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 							<h4 className="text-sm font-semibold">Match criteria</h4>
 						</div>
 						<p className="text-xs text-muted-foreground -mt-2">
-							An alert is enriched when its name matches and ALL labels match. At least one criterion is
-							required.
+							An alert is enriched when its name matches and any matcher group matches. At least one
+							criterion (or match-all) is required.
 						</p>
 
-						<div className="space-y-2">
+						<label className="flex items-center gap-2 cursor-pointer">
+							<Checkbox checked={matchAll} onCheckedChange={(v) => setMatchAll(v === true)} />
+							<span className="text-xs font-medium">
+								Apply to all alerts (ignore name and label criteria)
+							</span>
+						</label>
+
+						<div className={matchAll ? 'space-y-2 opacity-50 pointer-events-none' : 'space-y-2'}>
 							<Label htmlFor="enrichment-nameContains" className="text-xs">
 								Alert name contains
 							</Label>
@@ -363,13 +384,12 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 							/>
 						</div>
 
-						<KeyValueRows
-							rows={matchers}
-							onChange={setMatchers}
+						<MatcherGroupsEditor
+							groups={matcherGroups}
+							onChange={setMatcherGroups}
 							keyPlaceholder="key (e.g. severity)"
 							valuePlaceholder="value (e.g. critical)"
-							emptyText="No label matchers. Use these to scope by environment, service, severity, etc."
-							addLabel="Label matchers (key = value)"
+							disabled={matchAll}
 						/>
 					</div>
 

--- a/apps/client/src/components/MutePolicies/MutePolicyFormDialog.tsx
+++ b/apps/client/src/components/MutePolicies/MutePolicyFormDialog.tsx
@@ -262,8 +262,8 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 							<h4 className="text-sm font-semibold">Match criteria</h4>
 						</div>
 						<p className="text-xs text-muted-foreground -mt-2">
-							An alert is muted when its name matches and ALL labels match. At least one criterion is
-							required.
+							An alert is muted when its name matches and ANY matcher group matches (all matchers within a
+							group must match). At least one criterion — or match-all — is required.
 						</p>
 
 						<label className="flex items-center gap-2 cursor-pointer">
@@ -281,6 +281,7 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 								id="mute-policy-nameContains"
 								placeholder="e.g. HighCPU, prod-db, latency"
 								value={nameContains}
+								disabled={matchAll}
 								onChange={(e) => setNameContains(e.target.value)}
 							/>
 						</div>

--- a/apps/client/src/components/MutePolicies/MutePolicyFormDialog.tsx
+++ b/apps/client/src/components/MutePolicies/MutePolicyFormDialog.tsx
@@ -8,7 +8,9 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
+import { cleanMatcherGroups, MatcherGroupsEditor } from '@/components/shared/MatcherGroupsEditor';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
@@ -16,7 +18,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useCreateMutePolicy, useUpdateMutePolicy } from '@/hooks/queries/mute-policies';
 import { MutePolicyPayload } from '@/lib/api';
 import { MutePolicy } from '@OpsiMate/shared';
-import { BellOff, Plus, Tag, Trash2 } from 'lucide-react';
+import { BellOff, Tag } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 type Matcher = { key: string; value: string };
@@ -68,7 +70,8 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 
 	const [name, setName] = useState('');
 	const [nameContains, setNameContains] = useState('');
-	const [matchers, setMatchers] = useState<Matcher[]>([]);
+	const [matcherGroups, setMatcherGroups] = useState<Matcher[][]>([]);
+	const [matchAll, setMatchAll] = useState(false);
 	const [reason, setReason] = useState('');
 	const [mode, setMode] = useState<MutePolicyMode>('one-time');
 	const [hasStart, setHasStart] = useState(false);
@@ -84,7 +87,14 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 		if (mutePolicy) {
 			setName(mutePolicy.name);
 			setNameContains(mutePolicy.nameContains ?? '');
-			setMatchers((mutePolicy.labelMatchers ?? []).map((m) => ({ ...m })));
+			setMatcherGroups(
+				mutePolicy.labelMatcherGroups?.length
+					? mutePolicy.labelMatcherGroups.map((g) => g.map((m) => ({ ...m })))
+					: (mutePolicy.labelMatchers ?? []).length
+						? [(mutePolicy.labelMatchers ?? []).map((m) => ({ ...m }))]
+						: []
+			);
+			setMatchAll(!!mutePolicy.matchAll);
 			setReason(mutePolicy.reason ?? '');
 			if (mutePolicy.schedule) {
 				setMode('recurring');
@@ -108,7 +118,8 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 		} else {
 			setName('');
 			setNameContains('');
-			setMatchers([]);
+			setMatcherGroups([]);
+			setMatchAll(false);
 			setReason('');
 			setMode('one-time');
 			setHasStart(false);
@@ -131,8 +142,8 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 	const isValid = useMemo(() => {
 		if (!name.trim()) return false;
 		const hasNameMatcher = nameContains.trim().length > 0;
-		const hasLabelMatchers = matchers.some((m) => m.key.trim() && m.value.trim());
-		if (!hasNameMatcher && !hasLabelMatchers) return false;
+		const hasLabelMatchers = matcherGroups.some((g) => g.some((m) => m.key.trim() && m.value.trim()));
+		if (!matchAll && !hasNameMatcher && !hasLabelMatchers) return false;
 		if (mode === 'recurring') {
 			if (daysOfWeek.length === 0) return false;
 			if (!recurStartTime || !recurEndTime) return false;
@@ -146,7 +157,8 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 	}, [
 		name,
 		nameContains,
-		matchers,
+		matcherGroups,
+		matchAll,
 		mode,
 		hasStart,
 		hasEnd,
@@ -168,16 +180,16 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 	};
 
 	const submit = async () => {
-		const cleanedMatchers = matchers
-			.map((m) => ({ key: m.key.trim(), value: m.value.trim() }))
-			.filter((m) => m.key && m.value);
+		const cleanedGroups = matchAll ? [] : cleanMatcherGroups(matcherGroups);
 
 		const payload: MutePolicyPayload =
 			mode === 'recurring'
 				? {
 						name: name.trim(),
-						nameContains: nameContains.trim() || null,
-						labelMatchers: cleanedMatchers,
+						nameContains: matchAll ? null : nameContains.trim() || null,
+						labelMatchers: cleanedGroups[0] ?? [],
+						labelMatcherGroups: cleanedGroups,
+						matchAll,
 						startsAt: null,
 						endsAt: null,
 						schedule: {
@@ -189,8 +201,10 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 					}
 				: {
 						name: name.trim(),
-						nameContains: nameContains.trim() || null,
-						labelMatchers: cleanedMatchers,
+						nameContains: matchAll ? null : nameContains.trim() || null,
+						labelMatchers: cleanedGroups[0] ?? [],
+						labelMatcherGroups: cleanedGroups,
+						matchAll,
 						startsAt: hasStart ? fromLocalInputValue(startsAt) : null,
 						endsAt: hasEnd ? fromLocalInputValue(endsAt) : null,
 						schedule: null,
@@ -252,7 +266,14 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 							required.
 						</p>
 
-						<div className="space-y-2">
+						<label className="flex items-center gap-2 cursor-pointer">
+							<Checkbox checked={matchAll} onCheckedChange={(v) => setMatchAll(v === true)} />
+							<span className="text-xs font-medium">
+								Apply to all alerts (ignore name and label criteria)
+							</span>
+						</label>
+
+						<div className={matchAll ? 'space-y-2 opacity-50 pointer-events-none' : 'space-y-2'}>
 							<Label htmlFor="mute-policy-nameContains" className="text-xs">
 								Alert name contains
 							</Label>
@@ -264,67 +285,7 @@ export const MutePolicyFormDialog = ({ open, onOpenChange, mutePolicy }: MutePol
 							/>
 						</div>
 
-						<div className="space-y-2">
-							<div className="flex items-center justify-between">
-								<Label className="text-xs">Label matchers (key = value)</Label>
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onClick={() => setMatchers((m) => [...m, { key: '', value: '' }])}
-								>
-									<Plus className="h-3.5 w-3.5 mr-1" /> Add
-								</Button>
-							</div>
-							{matchers.length === 0 ? (
-								<p className="text-xs text-muted-foreground italic">
-									No label matchers. Use these to scope by environment, service, severity, etc.
-								</p>
-							) : (
-								<div className="space-y-2">
-									{matchers.map((matcher, idx) => (
-										<div
-											key={idx}
-											className="grid grid-cols-[1fr_auto_1fr_auto] items-center gap-2"
-										>
-											<Input
-												placeholder="key (e.g. severity)"
-												value={matcher.key}
-												onChange={(e) =>
-													setMatchers((m) =>
-														m.map((row, i) =>
-															i === idx ? { ...row, key: e.target.value } : row
-														)
-													)
-												}
-											/>
-											<span className="text-muted-foreground text-sm">=</span>
-											<Input
-												placeholder="value (e.g. critical)"
-												value={matcher.value}
-												onChange={(e) =>
-													setMatchers((m) =>
-														m.map((row, i) =>
-															i === idx ? { ...row, value: e.target.value } : row
-														)
-													)
-												}
-											/>
-											<Button
-												type="button"
-												variant="ghost"
-												size="icon"
-												className="h-9 w-9"
-												onClick={() => setMatchers((m) => m.filter((_, i) => i !== idx))}
-												aria-label="Remove matcher"
-											>
-												<Trash2 className="h-4 w-4" />
-											</Button>
-										</div>
-									))}
-								</div>
-							)}
-						</div>
+						<MatcherGroupsEditor groups={matcherGroups} onChange={setMatcherGroups} disabled={matchAll} />
 					</div>
 
 					<div className="rounded-lg border bg-muted/30 p-4 space-y-4">

--- a/apps/client/src/components/shared/MatcherGroupsEditor.tsx
+++ b/apps/client/src/components/shared/MatcherGroupsEditor.tsx
@@ -1,0 +1,175 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import { getLabelMatcherGroups, MatcherCriteria } from '@OpsiMate/shared';
+import { Fragment } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+
+export type MatcherRow = { key: string; value: string };
+
+interface MatcherGroupsEditorProps {
+	// OR groups of AND matchers: the entity matches when ANY group fully matches.
+	groups: MatcherRow[][];
+	onChange: (groups: MatcherRow[][]) => void;
+	keyPlaceholder?: string;
+	valuePlaceholder?: string;
+	emptyText?: string;
+	disabled?: boolean;
+}
+
+// Grouped label-matcher editor shared by mute policies, enrichments, and actions.
+// Within a box every row must match (AND); boxes are alternatives (OR). Removing a
+// group's last row removes the group.
+export const MatcherGroupsEditor = ({
+	groups,
+	onChange,
+	keyPlaceholder = 'key (e.g. env)',
+	valuePlaceholder = 'value (e.g. prod)',
+	emptyText = 'No label matchers. Use these to scope by environment, service, severity, etc.',
+	disabled = false,
+}: MatcherGroupsEditorProps) => {
+	const updateRow = (groupIdx: number, rowIdx: number, patch: Partial<MatcherRow>) =>
+		onChange(
+			groups.map((group, gi) =>
+				gi === groupIdx ? group.map((row, ri) => (ri === rowIdx ? { ...row, ...patch } : row)) : group
+			)
+		);
+
+	const removeRow = (groupIdx: number, rowIdx: number) =>
+		onChange(
+			groups
+				.map((group, gi) => (gi === groupIdx ? group.filter((_, ri) => ri !== rowIdx) : group))
+				.filter((group) => group.length > 0)
+		);
+
+	const addRow = (groupIdx: number) =>
+		onChange(groups.map((group, gi) => (gi === groupIdx ? [...group, { key: '', value: '' }] : group)));
+
+	return (
+		<div className={cn('space-y-2', disabled && 'opacity-50 pointer-events-none')}>
+			<div className="flex items-center justify-between">
+				<Label className="text-xs">Label matchers (key = value)</Label>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() =>
+						groups.length === 0 ? onChange([[{ key: '', value: '' }]]) : addRow(groups.length - 1)
+					}
+				>
+					<Plus className="h-3.5 w-3.5 mr-1" /> Add
+				</Button>
+			</div>
+			{groups.length === 0 ? (
+				<p className="text-xs text-muted-foreground italic">{emptyText}</p>
+			) : (
+				<div className="space-y-2">
+					{groups.map((group, groupIdx) => (
+						<div key={groupIdx}>
+							{groupIdx > 0 && (
+								<div className="flex items-center gap-2 py-1" aria-hidden>
+									<div className="h-px flex-1 bg-border" />
+									<span className="text-[10px] font-semibold text-muted-foreground tracking-wide">
+										OR
+									</span>
+									<div className="h-px flex-1 bg-border" />
+								</div>
+							)}
+							<div className="rounded-md border bg-background/50 p-2 space-y-2">
+								{group.map((row, rowIdx) => (
+									<div key={rowIdx} className="grid grid-cols-[1fr_auto_1fr_auto] items-center gap-2">
+										<Input
+											placeholder={keyPlaceholder}
+											value={row.key}
+											onChange={(e) => updateRow(groupIdx, rowIdx, { key: e.target.value })}
+										/>
+										<span className="text-muted-foreground text-sm">=</span>
+										<Input
+											placeholder={valuePlaceholder}
+											value={row.value}
+											onChange={(e) => updateRow(groupIdx, rowIdx, { value: e.target.value })}
+										/>
+										<Button
+											type="button"
+											variant="ghost"
+											size="icon"
+											className="h-9 w-9"
+											onClick={() => removeRow(groupIdx, rowIdx)}
+											aria-label="Remove matcher"
+										>
+											<Trash2 className="h-4 w-4" />
+										</Button>
+									</div>
+								))}
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="h-7 text-xs text-muted-foreground"
+									onClick={() => addRow(groupIdx)}
+								>
+									<Plus className="h-3 w-3 mr-1" /> AND matcher
+								</Button>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+			{groups.length > 0 && (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="w-full text-xs"
+					onClick={() => onChange([...groups, [{ key: '', value: '' }]])}
+				>
+					<Plus className="h-3.5 w-3.5 mr-1" /> OR group
+				</Button>
+			)}
+			{groups.length > 1 && (
+				<p className="text-xs text-muted-foreground">
+					Matches when ANY group matches; within a group every matcher must match.
+				</p>
+			)}
+		</div>
+	);
+};
+
+// Cleans editor state for submission: trims, drops incomplete rows and empty groups.
+export const cleanMatcherGroups = (groups: MatcherRow[][]): MatcherRow[][] =>
+	groups
+		.map((group) =>
+			group.map((m) => ({ key: m.key.trim(), value: m.value.trim() })).filter((m) => m.key && m.value)
+		)
+		.filter((group) => group.length > 0);
+
+// List-page badges for an entity's matcher groups: k=v badges per group, an OR chip
+// between groups. Callers render their own name-contains / match-all / empty badges.
+export const MatcherGroupBadges = ({ criteria }: { criteria: MatcherCriteria }) => {
+	const groups = getLabelMatcherGroups(criteria);
+	return (
+		<>
+			{groups.map((group, groupIdx) => (
+				<Fragment key={groupIdx}>
+					{groupIdx > 0 && (
+						<span className="text-[10px] font-semibold text-muted-foreground self-center">OR</span>
+					)}
+					{group.map((m, idx) => (
+						<Badge
+							key={`${groupIdx}-${idx}`}
+							variant="outline"
+							className="font-mono text-xs max-w-full whitespace-normal break-all rounded-md"
+						>
+							{m.key}={m.value}
+						</Badge>
+					))}
+				</Fragment>
+			))}
+		</>
+	);
+};
+
+// True when the entity has any complete matcher (used by the pages' empty-state checks).
+export const hasMatcherCriteria = (criteria: MatcherCriteria): boolean => getLabelMatcherGroups(criteria).length > 0;

--- a/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
+++ b/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
@@ -168,7 +168,15 @@ export const MatcherGroupsEditor = ({
 export const cleanMatcherGroups = (groups: MatcherRow[][]): MatcherRow[][] =>
 	groups
 		.map((group) =>
-			group.map((m) => ({ key: m.key.trim(), value: m.value.trim() })).filter((m) => m.key && m.value)
+			group
+				.map((m) => ({
+					key: m.key.trim(),
+					value: m.value.trim(),
+					// The op must survive cleaning — omitting it silently turns every
+					// "contains" matcher back into equals at save time.
+					...(m.op === 'contains' ? { op: 'contains' as const } : {}),
+				}))
+				.filter((m) => m.key && m.value)
 		)
 		.filter((group) => group.length > 0);
 

--- a/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
+++ b/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
@@ -1,13 +1,14 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import { getLabelMatcherGroups, MatcherCriteria } from '@OpsiMate/shared';
 import { Fragment } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 
-export type MatcherRow = { key: string; value: string };
+export type MatcherRow = { key: string; value: string; op?: 'equals' | 'contains' };
 
 interface MatcherGroupsEditorProps {
 	// OR groups of AND matchers: the entity matches when ANY group fully matches.
@@ -83,12 +84,35 @@ export const MatcherGroupsEditor = ({
 										<Input
 											placeholder={keyPlaceholder}
 											value={row.key}
+											disabled={disabled}
 											onChange={(e) => updateRow(groupIdx, rowIdx, { key: e.target.value })}
 										/>
-										<span className="text-muted-foreground text-sm">=</span>
+										{/* Comparison operator: exact equality or case-insensitive
+										    substring ("contains"). */}
+										<Select
+											value={row.op === 'contains' ? 'contains' : 'equals'}
+											onValueChange={(op) =>
+												updateRow(groupIdx, rowIdx, {
+													op: op === 'contains' ? 'contains' : undefined,
+												})
+											}
+											disabled={disabled}
+										>
+											<SelectTrigger
+												className="h-9 w-[110px] shrink-0"
+												aria-label="Comparison operator"
+											>
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												<SelectItem value="equals">=</SelectItem>
+												<SelectItem value="contains">contains</SelectItem>
+											</SelectContent>
+										</Select>
 										<Input
 											placeholder={valuePlaceholder}
 											value={row.value}
+											disabled={disabled}
 											onChange={(e) => updateRow(groupIdx, rowIdx, { value: e.target.value })}
 										/>
 										<Button
@@ -96,6 +120,7 @@ export const MatcherGroupsEditor = ({
 											variant="ghost"
 											size="icon"
 											className="h-9 w-9"
+											disabled={disabled}
 											onClick={() => removeRow(groupIdx, rowIdx)}
 											aria-label="Remove matcher"
 										>
@@ -108,6 +133,7 @@ export const MatcherGroupsEditor = ({
 									variant="ghost"
 									size="sm"
 									className="h-7 text-xs text-muted-foreground"
+									disabled={disabled}
 									onClick={() => addRow(groupIdx)}
 								>
 									<Plus className="h-3 w-3 mr-1" /> AND matcher
@@ -123,6 +149,7 @@ export const MatcherGroupsEditor = ({
 					variant="outline"
 					size="sm"
 					className="w-full text-xs"
+					disabled={disabled}
 					onClick={() => onChange([...groups, [{ key: '', value: '' }]])}
 				>
 					<Plus className="h-3.5 w-3.5 mr-1" /> OR group
@@ -162,7 +189,9 @@ export const MatcherGroupBadges = ({ criteria }: { criteria: MatcherCriteria }) 
 							variant="outline"
 							className="font-mono text-xs max-w-full whitespace-normal break-all rounded-md"
 						>
-							{m.key}={m.value}
+							{m.key}
+							{m.op === 'contains' ? ' ~ ' : '='}
+							{m.value}
 						</Badge>
 					))}
 				</Fragment>

--- a/apps/client/src/components/shared/MatcherGroupsEditor/index.ts
+++ b/apps/client/src/components/shared/MatcherGroupsEditor/index.ts
@@ -1,0 +1,2 @@
+export { cleanMatcherGroups, hasMatcherCriteria, MatcherGroupBadges, MatcherGroupsEditor } from './MatcherGroupsEditor';
+export type { MatcherRow } from './MatcherGroupsEditor';

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -656,6 +656,8 @@ export type MutePolicyPayload = {
 	name: string;
 	nameContains?: string | null;
 	labelMatchers?: { key: string; value: string }[];
+	labelMatcherGroups?: { key: string; value: string }[][];
+	matchAll?: boolean;
 	startsAt?: string | null;
 	endsAt?: string | null;
 	schedule?: { daysOfWeek: number[]; startTime: string; endTime: string } | null;
@@ -691,6 +693,8 @@ export type EnrichmentPayload = {
 	name: string;
 	nameContains?: string | null;
 	labelMatchers?: { key: string; value: string }[];
+	labelMatcherGroups?: { key: string; value: string }[][];
+	matchAll?: boolean;
 	addFields?: { key: string; value: string }[];
 	addLinks?: { label: string; icon?: string; url: string }[];
 	summaryTemplate?: string | null;
@@ -712,6 +716,7 @@ export type ActionPayload = {
 	config: ActionConfig;
 	nameContains?: string | null;
 	labelMatchers?: { key: string; value: string }[];
+	labelMatcherGroups?: { key: string; value: string }[][];
 };
 
 export const actionsApi = {

--- a/apps/client/src/pages/Actions.tsx
+++ b/apps/client/src/pages/Actions.tsx
@@ -26,6 +26,7 @@ import {
 	TeamsActionConfig,
 } from '@OpsiMate/shared';
 import { Globe, Loader2, MessageSquare, Pencil, Play, Plus, Search, Ticket, Trash2, Zap } from 'lucide-react';
+import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { useMemo, useState } from 'react';
 
 const TYPE_META: Record<
@@ -66,8 +67,7 @@ const TypeBadge = ({ type }: { type: ActionType }) => {
 
 const AppliesTo = ({ action }: { action: Action }) => {
 	const hasName = !!action.nameContains && action.nameContains.trim().length > 0;
-	const matchers = action.labelMatchers ?? [];
-	if (!hasName && matchers.length === 0) {
+	if (!hasName && !hasMatcherCriteria(action)) {
 		return (
 			<Badge variant="secondary" className="text-xs">
 				All alerts
@@ -81,11 +81,7 @@ const AppliesTo = ({ action }: { action: Action }) => {
 					name ~ "{action.nameContains}"
 				</Badge>
 			)}
-			{matchers.map((m, idx) => (
-				<Badge key={idx} variant="outline" className="font-mono text-xs">
-					{m.key}={m.value}
-				</Badge>
-			))}
+			<MatcherGroupBadges criteria={action} />
 		</div>
 	);
 };

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -18,6 +18,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
 import { AlertEnrichment } from '@OpsiMate/shared';
+import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { Copy, FileText, Link2, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
@@ -28,16 +29,13 @@ const MatchBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
 				name ~ "{enrichment.nameContains}"
 			</Badge>
 		)}
-		{(enrichment.labelMatchers ?? []).map((m, idx) => (
-			<Badge
-				key={idx}
-				variant="outline"
-				className="font-mono text-xs max-w-full whitespace-normal break-all rounded-md"
-			>
-				{m.key}={m.value}
+		{enrichment.matchAll && (
+			<Badge variant="secondary" className="text-xs rounded-md">
+				All alerts
 			</Badge>
-		))}
-		{!enrichment.nameContains && (enrichment.labelMatchers ?? []).length === 0 && (
+		)}
+		{!enrichment.matchAll && <MatcherGroupBadges criteria={enrichment} />}
+		{!enrichment.matchAll && !enrichment.nameContains && !hasMatcherCriteria(enrichment) && (
 			<span className="text-xs text-muted-foreground italic">no matchers</span>
 		)}
 	</div>
@@ -96,7 +94,11 @@ const Enrichments: React.FC = () => {
 			if (e.name.toLowerCase().includes(q)) return true;
 			if (e.nameContains?.toLowerCase().includes(q)) return true;
 			if (e.summaryTemplate?.toLowerCase().includes(q)) return true;
-			if (e.labelMatchers?.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q)))
+			if (
+				(e.labelMatcherGroups ?? [e.labelMatchers ?? []])
+					.flat()
+					.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q))
+			)
 				return true;
 			if (e.addFields?.some((f) => f.key.toLowerCase().includes(q) || f.value.toLowerCase().includes(q)))
 				return true;

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -17,7 +17,7 @@ import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
-import { AlertEnrichment } from '@OpsiMate/shared';
+import { AlertEnrichment, getLabelMatcherGroups } from '@OpsiMate/shared';
 import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { Copy, FileText, Link2, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -95,7 +95,7 @@ const Enrichments: React.FC = () => {
 			if (e.nameContains?.toLowerCase().includes(q)) return true;
 			if (e.summaryTemplate?.toLowerCase().includes(q)) return true;
 			if (
-				(e.labelMatcherGroups ?? [e.labelMatchers ?? []])
+				getLabelMatcherGroups(e)
 					.flat()
 					.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q))
 			)

--- a/apps/client/src/pages/MutePolicies.tsx
+++ b/apps/client/src/pages/MutePolicies.tsx
@@ -17,7 +17,7 @@ import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteMutePolicy, useMutePolicies } from '@/hooks/queries/mute-policies';
-import { MutePolicy } from '@OpsiMate/shared';
+import { getLabelMatcherGroups, MutePolicy } from '@OpsiMate/shared';
 import { BellOff, Calendar, CheckCircle2, Clock, Hourglass, Pencil, Plus, Repeat, Search, Trash2 } from 'lucide-react';
 import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { useMemo, useState } from 'react';
@@ -156,7 +156,7 @@ const MutePolicies: React.FC = () => {
 			if (s.name.toLowerCase().includes(q)) return true;
 			if (s.nameContains?.toLowerCase().includes(q)) return true;
 			if (s.reason?.toLowerCase().includes(q)) return true;
-			return (s.labelMatcherGroups ?? [s.labelMatchers ?? []])
+			return getLabelMatcherGroups(s)
 				.flat()
 				.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q));
 		});

--- a/apps/client/src/pages/MutePolicies.tsx
+++ b/apps/client/src/pages/MutePolicies.tsx
@@ -19,6 +19,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useDeleteMutePolicy, useMutePolicies } from '@/hooks/queries/mute-policies';
 import { MutePolicy } from '@OpsiMate/shared';
 import { BellOff, Calendar, CheckCircle2, Clock, Hourglass, Pencil, Plus, Repeat, Search, Trash2 } from 'lucide-react';
+import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { useMemo, useState } from 'react';
 
 type MutePolicyStatus = 'active' | 'scheduled' | 'expired';
@@ -155,7 +156,9 @@ const MutePolicies: React.FC = () => {
 			if (s.name.toLowerCase().includes(q)) return true;
 			if (s.nameContains?.toLowerCase().includes(q)) return true;
 			if (s.reason?.toLowerCase().includes(q)) return true;
-			return s.labelMatchers?.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q));
+			return (s.labelMatcherGroups ?? [s.labelMatchers ?? []])
+				.flat()
+				.some((m) => m.key.toLowerCase().includes(q) || m.value.toLowerCase().includes(q));
 		});
 	}, [mutePolicies, search]);
 
@@ -285,16 +288,13 @@ const MutePolicies: React.FC = () => {
 																name ~ "{s.nameContains}"
 															</Badge>
 														)}
-														{(s.labelMatchers ?? []).map((m, idx) => (
-															<Badge
-																key={idx}
-																variant="outline"
-																className="font-mono text-xs"
-															>
-																{m.key}={m.value}
+														{s.matchAll && (
+															<Badge variant="secondary" className="text-xs">
+																All alerts
 															</Badge>
-														))}
-														{!s.nameContains && (s.labelMatchers ?? []).length === 0 && (
+														)}
+														{!s.matchAll && <MatcherGroupBadges criteria={s} />}
+														{!s.matchAll && !s.nameContains && !hasMatcherCriteria(s) && (
 															<span className="text-xs text-muted-foreground italic">
 																no matchers
 															</span>

--- a/apps/client/src/test/matcherGroups.test.ts
+++ b/apps/client/src/test/matcherGroups.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { cleanMatcherGroups } from '@/components/shared/MatcherGroupsEditor';
+
+describe('cleanMatcherGroups', () => {
+	test('preserves the contains op through cleaning — the exact bug where the UI collected it and the submit stripped it', () => {
+		expect(cleanMatcherGroups([[{ key: ' svc ', value: ' cpu ', op: 'contains' }]])).toEqual([
+			[{ key: 'svc', value: 'cpu', op: 'contains' }],
+		]);
+	});
+
+	test('equals rows stay bare (no op key), keeping stored rows minimal', () => {
+		expect(cleanMatcherGroups([[{ key: 'svc', value: 'x' }]])).toEqual([[{ key: 'svc', value: 'x' }]]);
+		expect(Object.keys(cleanMatcherGroups([[{ key: 'svc', value: 'x', op: 'equals' }]])[0][0])).toEqual([
+			'key',
+			'value',
+		]);
+	});
+
+	test('drops incomplete rows and empty groups', () => {
+		expect(
+			cleanMatcherGroups([
+				[{ key: '', value: 'x' }],
+				[
+					{ key: 'a', value: '1' },
+					{ key: '', value: '' },
+				],
+			])
+		).toEqual([[{ key: 'a', value: '1' }]]);
+	});
+});

--- a/apps/server/src/api/v1/actions/controller.ts
+++ b/apps/server/src/api/v1/actions/controller.ts
@@ -53,6 +53,7 @@ export class ActionController {
 					config: data.config,
 					nameContains: data.nameContains ?? null,
 					labelMatchers: data.labelMatchers ?? [],
+					labelMatcherGroups: data.labelMatcherGroups,
 				},
 				req.user
 			);
@@ -136,6 +137,7 @@ export class ActionController {
 					config: data.config,
 					nameContains: data.nameContains ?? null,
 					labelMatchers: data.labelMatchers ?? [],
+					labelMatcherGroups: data.labelMatcherGroups,
 				},
 				req.user
 			);

--- a/apps/server/src/api/v1/enrichments/controller.ts
+++ b/apps/server/src/api/v1/enrichments/controller.ts
@@ -49,6 +49,8 @@ export class EnrichmentController {
 					name: data.name,
 					nameContains: data.nameContains ?? null,
 					labelMatchers: data.labelMatchers ?? [],
+					labelMatcherGroups: data.labelMatcherGroups,
+					matchAll: data.matchAll ?? false,
 					addFields: data.addFields ?? [],
 					addLinks: data.addLinks ?? [],
 					summaryTemplate: data.summaryTemplate ?? null,

--- a/apps/server/src/api/v1/mute-policies/controller.ts
+++ b/apps/server/src/api/v1/mute-policies/controller.ts
@@ -42,6 +42,8 @@ export class MutePolicyController {
 				name: data.name,
 				nameContains: data.nameContains ?? null,
 				labelMatchers: data.labelMatchers ?? [],
+				labelMatcherGroups: data.labelMatcherGroups,
+				matchAll: data.matchAll ?? false,
 				startsAt: data.startsAt ?? null,
 				endsAt: data.endsAt ?? null,
 				schedule: data.schedule ?? null,

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -2,6 +2,8 @@ import {
 	Alert,
 	AlertEnrichment,
 	AlertLink,
+	anyMatcherGroupMatchesTags,
+	getLabelMatcherGroups,
 	AppliedEnrichment,
 	AuditActionType,
 	AuditResourceType,
@@ -72,6 +74,8 @@ export class EnrichmentBL {
 			data.name !== undefined ||
 			data.nameContains !== undefined ||
 			data.labelMatchers !== undefined ||
+			data.labelMatcherGroups !== undefined ||
+			data.matchAll !== undefined ||
 			data.addFields !== undefined ||
 			data.addLinks !== undefined ||
 			data.summaryTemplate !== undefined ||
@@ -104,21 +108,21 @@ export class EnrichmentBL {
 	// Same matching semantics as mute policies: nameContains is a case-insensitive substring match
 	// on the alert name, and every label matcher must equal the alert's tag value.
 	static enrichmentMatchesAlert(enrichment: AlertEnrichment, alert: Alert): boolean {
-		const hasName = !!enrichment.nameContains && enrichment.nameContains.trim().length > 0;
-		const matchers = enrichment.labelMatchers ?? [];
+		// A match-all rule decorates every alert.
+		if (enrichment.matchAll) return true;
 
-		if (!hasName && matchers.length === 0) return false;
+		const hasName = !!enrichment.nameContains && enrichment.nameContains.trim().length > 0;
+		// OR groups: any group fully matching suffices; a legacy flat matcher list is one group.
+		const groups = getLabelMatcherGroups(enrichment);
+
+		if (!hasName && groups.length === 0) return false;
 
 		if (hasName) {
 			const needle = enrichment.nameContains!.trim().toLowerCase();
 			if (!alert.alertName?.toLowerCase().includes(needle)) return false;
 		}
 
-		for (const matcher of matchers) {
-			const tagValue = alert.tags?.[matcher.key];
-			if (tagValue === undefined) return false;
-			if (String(tagValue) !== matcher.value) return false;
-		}
+		if (groups.length > 0 && !anyMatcherGroupMatchesTags(groups, alert.tags)) return false;
 		return true;
 	}
 

--- a/apps/server/src/bl/mute-policies/mutePolicy.bl.ts
+++ b/apps/server/src/bl/mute-policies/mutePolicy.bl.ts
@@ -1,4 +1,4 @@
-import { Alert, MutePolicy, Logger } from '@OpsiMate/shared';
+import { anyMatcherGroupMatchesTags, getLabelMatcherGroups, Alert, MutePolicy, Logger } from '@OpsiMate/shared';
 import { MutePolicyRepository, CreateMutePolicyInput, UpdateMutePolicyInput } from '../../dal/mutePolicyRepository';
 
 const logger = new Logger('bl/mutePolicy.bl');
@@ -53,21 +53,21 @@ export class MutePolicyBL {
 	}
 
 	static mutePolicyMatchesAlert(mutePolicy: MutePolicy, alert: Alert): boolean {
-		const hasName = !!mutePolicy.nameContains && mutePolicy.nameContains.trim().length > 0;
-		const matchers = mutePolicy.labelMatchers ?? [];
+		// A match-all policy mutes every alert (subject to its active window).
+		if (mutePolicy.matchAll) return true;
 
-		if (!hasName && matchers.length === 0) return false;
+		const hasName = !!mutePolicy.nameContains && mutePolicy.nameContains.trim().length > 0;
+		// OR groups: any group fully matching suffices; a legacy flat matcher list is one group.
+		const groups = getLabelMatcherGroups(mutePolicy);
+
+		if (!hasName && groups.length === 0) return false;
 
 		if (hasName) {
 			const needle = mutePolicy.nameContains!.trim().toLowerCase();
 			if (!alert.alertName?.toLowerCase().includes(needle)) return false;
 		}
 
-		for (const matcher of matchers) {
-			const tagValue = alert.tags?.[matcher.key];
-			if (tagValue === undefined) return false;
-			if (String(tagValue) !== matcher.value) return false;
-		}
+		if (groups.length > 0 && !anyMatcherGroupMatchesTags(groups, alert.tags)) return false;
 		return true;
 	}
 

--- a/apps/server/src/dal/actionRepository.ts
+++ b/apps/server/src/dal/actionRepository.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
-import { Action, ActionConfig, ActionLabelMatcher, ActionType } from '@OpsiMate/shared';
+import { Action, ActionConfig, ActionType } from '@OpsiMate/shared';
 import { runAsync } from './db';
+import { parseMatcherColumn, serializeMatcherColumn } from './matcherColumn';
 
 interface ActionRow {
 	id: number;
@@ -29,15 +30,7 @@ export class ActionRepository {
 				config = {} as ActionConfig;
 			}
 		}
-		let labelMatchers: ActionLabelMatcher[] = [];
-		if (row.label_matchers) {
-			try {
-				const parsed: unknown = JSON.parse(row.label_matchers);
-				if (Array.isArray(parsed)) labelMatchers = parsed as ActionLabelMatcher[];
-			} catch {
-				labelMatchers = [];
-			}
-		}
+		const { labelMatchers, labelMatcherGroups } = parseMatcherColumn(row.label_matchers);
 		return {
 			id: row.id,
 			name: row.name,
@@ -45,6 +38,7 @@ export class ActionRepository {
 			config,
 			nameContains: row.name_contains,
 			labelMatchers,
+			labelMatcherGroups,
 			createdAt: row.created_at,
 			updatedAt: row.updated_at,
 		};
@@ -90,7 +84,7 @@ export class ActionRepository {
 				data.type,
 				JSON.stringify(data.config ?? {}),
 				data.nameContains ?? null,
-				JSON.stringify(data.labelMatchers ?? [])
+				serializeMatcherColumn(data)
 			);
 			return { lastID: result.lastInsertRowid as number };
 		});
@@ -123,7 +117,7 @@ export class ActionRepository {
 					data.type,
 					JSON.stringify(data.config ?? {}),
 					data.nameContains ?? null,
-					JSON.stringify(data.labelMatchers ?? []),
+					serializeMatcherColumn(data),
 					id
 				);
 		});

--- a/apps/server/src/dal/enrichmentRepository.ts
+++ b/apps/server/src/dal/enrichmentRepository.ts
@@ -1,5 +1,6 @@
 import Database from 'better-sqlite3';
-import { AlertEnrichment, AlertEnrichmentField, AlertLink, MutePolicyLabelMatcher } from '@OpsiMate/shared';
+import { AlertEnrichment, AlertEnrichmentField, AlertLink } from '@OpsiMate/shared';
+import { parseMatcherColumn, serializeMatcherColumn } from './matcherColumn';
 import { runAsync } from './db';
 
 interface EnrichmentRow {
@@ -7,6 +8,7 @@ interface EnrichmentRow {
 	name: string;
 	name_contains: string | null;
 	label_matchers: string | null;
+	match_all?: number | null;
 	add_fields: string | null;
 	add_links: string | null;
 	summary_template: string | null;
@@ -37,7 +39,8 @@ export class EnrichmentRepository {
 		id: row.id,
 		name: row.name,
 		nameContains: row.name_contains,
-		labelMatchers: parseJsonArray<MutePolicyLabelMatcher>(row.label_matchers),
+		...parseMatcherColumn(row.label_matchers),
+		matchAll: !!row.match_all,
 		addFields: parseJsonArray<AlertEnrichmentField>(row.add_fields),
 		addLinks: parseJsonArray<AlertLink>(row.add_links),
 		summaryTemplate: row.summary_template,
@@ -58,6 +61,7 @@ export class EnrichmentRepository {
 						name             TEXT NOT NULL,
 						name_contains    TEXT,
 						label_matchers   TEXT,
+						match_all        INTEGER DEFAULT 0,
 						add_fields       TEXT,
 						add_links        TEXT,
 						summary_template TEXT,
@@ -86,19 +90,23 @@ export class EnrichmentRepository {
 			if (!hasColumn('add_links')) {
 				this.db.prepare(`ALTER TABLE alert_enrichments ADD COLUMN add_links TEXT`).run();
 			}
+			if (!hasColumn('match_all')) {
+				this.db.prepare(`ALTER TABLE alert_enrichments ADD COLUMN match_all INTEGER DEFAULT 0`).run();
+			}
 		});
 	}
 
 	async createEnrichment(data: CreateEnrichmentInput, actor?: string | null): Promise<{ lastID: number }> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(
-				`INSERT INTO alert_enrichments (name, name_contains, label_matchers, add_fields, add_links, summary_template, priority, created_by, last_modified_by)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO alert_enrichments (name, name_contains, label_matchers, match_all, add_fields, add_links, summary_template, priority, created_by, last_modified_by)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			);
 			const result = stmt.run(
 				data.name,
 				data.nameContains ?? null,
-				JSON.stringify(data.labelMatchers ?? []),
+				serializeMatcherColumn(data),
+				data.matchAll ? 1 : 0,
 				JSON.stringify(data.addFields ?? []),
 				JSON.stringify(data.addLinks ?? []),
 				data.summaryTemplate ?? null,
@@ -140,9 +148,13 @@ export class EnrichmentRepository {
 				updates.push('name_contains = ?');
 				values.push(data.nameContains);
 			}
-			if (data.labelMatchers !== undefined) {
+			if (data.labelMatchers !== undefined || data.labelMatcherGroups !== undefined) {
 				updates.push('label_matchers = ?');
-				values.push(JSON.stringify(data.labelMatchers));
+				values.push(serializeMatcherColumn(data));
+			}
+			if (data.matchAll !== undefined) {
+				updates.push('match_all = ?');
+				values.push(data.matchAll ? 1 : 0);
 			}
 			if (data.addFields !== undefined) {
 				updates.push('add_fields = ?');

--- a/apps/server/src/dal/matcherColumn.ts
+++ b/apps/server/src/dal/matcherColumn.ts
@@ -1,0 +1,34 @@
+import { getLabelMatcherGroups, LabelMatcherGroups, MutePolicyLabelMatcher } from '@OpsiMate/shared';
+
+// The label_matchers columns hold either a legacy FLAT matcher list or OR GROUPS (an
+// array of arrays). A single group serializes flat, so rows written by this version
+// stay readable by older code as long as no OR group is actually used.
+export const parseMatcherColumn = (
+	raw: string | null
+): { labelMatchers: MutePolicyLabelMatcher[]; labelMatcherGroups: LabelMatcherGroups } => {
+	if (!raw) return { labelMatchers: [], labelMatcherGroups: [] };
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed) || parsed.length === 0) return { labelMatchers: [], labelMatcherGroups: [] };
+		if (Array.isArray(parsed[0])) {
+			const groups = parsed as LabelMatcherGroups;
+			// labelMatchers mirrors the first group so legacy consumers see SOMETHING
+			// sensible; the groups field is the source of truth.
+			return { labelMatchers: groups[0] ?? [], labelMatcherGroups: groups };
+		}
+		const flat = parsed as MutePolicyLabelMatcher[];
+		return { labelMatchers: flat, labelMatcherGroups: [flat] };
+	} catch {
+		return { labelMatchers: [], labelMatcherGroups: [] };
+	}
+};
+
+export const serializeMatcherColumn = (criteria: {
+	labelMatchers?: MutePolicyLabelMatcher[] | null;
+	labelMatcherGroups?: LabelMatcherGroups | null;
+}): string => {
+	const groups = getLabelMatcherGroups(criteria);
+	if (groups.length === 0) return JSON.stringify([]);
+	if (groups.length === 1) return JSON.stringify(groups[0]);
+	return JSON.stringify(groups);
+};

--- a/apps/server/src/dal/mutePolicyRepository.ts
+++ b/apps/server/src/dal/mutePolicyRepository.ts
@@ -1,5 +1,6 @@
 import Database from 'better-sqlite3';
-import { MutePolicy, MutePolicyLabelMatcher, MutePolicySchedule } from '@OpsiMate/shared';
+import { MutePolicy, MutePolicySchedule } from '@OpsiMate/shared';
+import { parseMatcherColumn, serializeMatcherColumn } from './matcherColumn';
 import { runAsync } from './db';
 
 interface MutePolicyRow {
@@ -7,6 +8,7 @@ interface MutePolicyRow {
 	name: string;
 	name_contains: string | null;
 	label_matchers: string | null;
+	match_all?: number | null;
 	starts_at: string | null;
 	ends_at: string | null;
 	schedule: string | null;
@@ -22,15 +24,7 @@ export class MutePolicyRepository {
 	constructor(private db: Database.Database) {}
 
 	private toShared = (row: MutePolicyRow): MutePolicy => {
-		let labelMatchers: MutePolicyLabelMatcher[] = [];
-		if (row.label_matchers) {
-			try {
-				const parsed: unknown = JSON.parse(row.label_matchers);
-				if (Array.isArray(parsed)) labelMatchers = parsed as MutePolicyLabelMatcher[];
-			} catch {
-				labelMatchers = [];
-			}
-		}
+		const { labelMatchers, labelMatcherGroups } = parseMatcherColumn(row.label_matchers);
 		let schedule: MutePolicySchedule | null = null;
 		if (row.schedule) {
 			try {
@@ -53,6 +47,8 @@ export class MutePolicyRepository {
 			name: row.name,
 			nameContains: row.name_contains,
 			labelMatchers,
+			labelMatcherGroups,
+			matchAll: !!row.match_all,
 			startsAt: row.starts_at,
 			endsAt: row.ends_at,
 			schedule,
@@ -81,6 +77,7 @@ export class MutePolicyRepository {
 						name            TEXT NOT NULL,
 						name_contains   TEXT,
 						label_matchers  TEXT,
+						match_all       INTEGER DEFAULT 0,
 						starts_at       DATETIME,
 						ends_at         DATETIME,
 						schedule        TEXT,
@@ -96,19 +93,23 @@ export class MutePolicyRepository {
 			if (!columns.some((c) => c.name === 'schedule')) {
 				this.db.prepare(`ALTER TABLE alert_mute_policies ADD COLUMN schedule TEXT`).run();
 			}
+			if (!columns.some((c) => c.name === 'match_all')) {
+				this.db.prepare(`ALTER TABLE alert_mute_policies ADD COLUMN match_all INTEGER DEFAULT 0`).run();
+			}
 		});
 	}
 
 	async createMutePolicy(data: CreateMutePolicyInput): Promise<{ lastID: number }> {
 		return runAsync(() => {
 			const stmt = this.db.prepare(
-				`INSERT INTO alert_mute_policies (name, name_contains, label_matchers, starts_at, ends_at, schedule, reason)
-				 VALUES (?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO alert_mute_policies (name, name_contains, label_matchers, match_all, starts_at, ends_at, schedule, reason)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 			);
 			const result = stmt.run(
 				data.name,
 				data.nameContains ?? null,
-				JSON.stringify(data.labelMatchers ?? []),
+				serializeMatcherColumn(data),
+				data.matchAll ? 1 : 0,
 				data.startsAt ?? null,
 				data.endsAt ?? null,
 				data.schedule ? JSON.stringify(data.schedule) : null,
@@ -148,9 +149,13 @@ export class MutePolicyRepository {
 				updates.push('name_contains = ?');
 				values.push(data.nameContains);
 			}
-			if (data.labelMatchers !== undefined) {
+			if (data.labelMatchers !== undefined || data.labelMatcherGroups !== undefined) {
 				updates.push('label_matchers = ?');
-				values.push(JSON.stringify(data.labelMatchers));
+				values.push(serializeMatcherColumn(data));
+			}
+			if (data.matchAll !== undefined) {
+				updates.push('match_all = ?');
+				values.push(data.matchAll ? 1 : 0);
 			}
 			if (data.startsAt !== undefined) {
 				updates.push('starts_at = ?');

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -793,6 +793,59 @@ describe('Alerts API', () => {
 				.set('Authorization', `Bearer ${jwtToken}`);
 		});
 
+		test("a 'contains' matcher matches by case-insensitive substring", async () => {
+			await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id: 'contains-a', tags: { service: 'CPU-worker-3' }, alertName: 'Contains A' });
+			await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id: 'contains-b', tags: { service: 'db-primary' }, alertName: 'Contains B' });
+
+			const created = await app
+				.post('/api/v1/mute-policies')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					name: 'contains policy',
+					labelMatcherGroups: [[{ key: 'service', value: 'cpu', op: 'contains' }]],
+				});
+			expect(created.status).toBe(201);
+
+			const list = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+			const byId = Object.fromEntries(list.body.data.alerts.map((a: { id: string }) => [a.id, a]));
+			expect(byId['contains-a'].isMuted).toBe(true);
+			expect(byId['contains-b'].isMuted).toBeUndefined();
+
+			await app
+				.delete(`/api/v1/mute-policies/${created.body.data.id}`)
+				.set('Authorization', `Bearer ${jwtToken}`);
+		});
+
+		test('enrichment updates preserve labelMatcherGroups and matchAll', async () => {
+			const created = await app
+				.post('/api/v1/enrichments')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					name: 'update keeps groups',
+					labelMatcherGroups: [[{ key: 'a', value: '1' }], [{ key: 'b', value: '2' }]],
+					addFields: [{ key: 'x', value: 'y' }],
+				});
+			expect(created.status).toBe(201);
+
+			const updated = await app
+				.put(`/api/v1/enrichments/${created.body.data.id}`)
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					labelMatcherGroups: [[{ key: 'c', value: '3', op: 'contains' }]],
+					matchAll: false,
+				});
+			expect(updated.status).toBe(200);
+			expect(updated.body.data.labelMatcherGroups).toEqual([[{ key: 'c', value: '3', op: 'contains' }]]);
+
+			await app.delete(`/api/v1/enrichments/${created.body.data.id}`).set('Authorization', `Bearer ${jwtToken}`);
+		});
+
 		test('a match-all mute policy needs no criteria and mutes everything', async () => {
 			const created = await app
 				.post('/api/v1/mute-policies')

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -754,6 +754,88 @@ describe('Alerts API', () => {
 		});
 	});
 
+	describe('OR matcher groups and match-all', () => {
+		test('a mute policy with OR groups mutes alerts matching ANY group', async () => {
+			await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id: 'or-mute-a', tags: { env: 'prod' }, alertName: 'OR Mute A' });
+			await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id: 'or-mute-b', tags: { team: 'db' }, alertName: 'OR Mute B' });
+			await app
+				.post('/api/v1/alerts/custom')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id: 'or-mute-c', tags: { env: 'dev' }, alertName: 'OR Mute C' });
+
+			const created = await app
+				.post('/api/v1/mute-policies')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					name: 'or groups policy',
+					labelMatcherGroups: [[{ key: 'env', value: 'prod' }], [{ key: 'team', value: 'db' }]],
+				});
+			expect(created.status).toBe(201);
+			expect(created.body.data.labelMatcherGroups).toEqual([
+				[{ key: 'env', value: 'prod' }],
+				[{ key: 'team', value: 'db' }],
+			]);
+
+			const list = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+			const byId = Object.fromEntries(list.body.data.alerts.map((a: { id: string }) => [a.id, a]));
+			expect(byId['or-mute-a'].isMuted).toBe(true);
+			expect(byId['or-mute-b'].isMuted).toBe(true);
+			expect(byId['or-mute-c'].isMuted).toBeUndefined();
+
+			await app
+				.delete(`/api/v1/mute-policies/${created.body.data.id}`)
+				.set('Authorization', `Bearer ${jwtToken}`);
+		});
+
+		test('a match-all mute policy needs no criteria and mutes everything', async () => {
+			const created = await app
+				.post('/api/v1/mute-policies')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ name: 'global mute', matchAll: true });
+			expect(created.status).toBe(201);
+			expect(created.body.data.matchAll).toBe(true);
+
+			const list = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+			expect(list.body.data.alerts.length).toBeGreaterThan(0);
+			for (const alert of list.body.data.alerts) {
+				expect(alert.isMuted).toBe(true);
+			}
+
+			await app
+				.delete(`/api/v1/mute-policies/${created.body.data.id}`)
+				.set('Authorization', `Bearer ${jwtToken}`);
+		});
+
+		test('a match-all enrichment decorates every alert', async () => {
+			const created = await app
+				.post('/api/v1/enrichments')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ name: 'global tagger', matchAll: true, addFields: [{ key: 'org', value: 'opsimate' }] });
+			expect(created.status).toBe(201);
+
+			const list = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+			for (const alert of list.body.data.alerts) {
+				expect(alert.tags.org).toBe('opsimate');
+			}
+
+			await app.delete(`/api/v1/enrichments/${created.body.data.id}`).set('Authorization', `Bearer ${jwtToken}`);
+		});
+
+		test('a policy with neither criteria nor matchAll is rejected', async () => {
+			const response = await app
+				.post('/api/v1/mute-policies')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ name: 'no criteria' });
+			expect(response.status).toBe(400);
+		});
+	});
+
 	describe('enrichment links', () => {
 		test('a matching rule appends templated links, materializing legacy alertUrl first', async () => {
 			await app

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -322,10 +322,20 @@ const mutePolicyTimeRefinement = (data: { startsAt?: string | null; endsAt?: str
 	return true;
 };
 
-const mutePolicyMatchersRefinement = (data: { nameContains?: string | null; labelMatchers?: unknown[] }) => {
+// OR groups: array of AND-groups, each a non-empty matcher list.
+const labelMatcherGroupsSchema = z.array(z.array(labelMatcherSchema).min(1).max(20)).max(20);
+
+const mutePolicyMatchersRefinement = (data: {
+	nameContains?: string | null;
+	labelMatchers?: unknown[];
+	labelMatcherGroups?: unknown[];
+	matchAll?: boolean;
+}) => {
+	if (data.matchAll) return true;
 	const hasName = !!data.nameContains && data.nameContains.trim().length > 0;
 	const hasMatchers = Array.isArray(data.labelMatchers) && data.labelMatchers.length > 0;
-	return hasName || hasMatchers;
+	const hasGroups = Array.isArray(data.labelMatcherGroups) && data.labelMatcherGroups.length > 0;
+	return hasName || hasMatchers || hasGroups;
 };
 
 const mutePolicyScheduleExclusivityRefinement = (data: {
@@ -342,6 +352,8 @@ export const CreateMutePolicySchema = z
 		name: z.string().min(1, 'Name is required').max(200),
 		nameContains: z.string().max(500).optional().nullable(),
 		labelMatchers: z.array(labelMatcherSchema).max(20).optional().default([]),
+		labelMatcherGroups: labelMatcherGroupsSchema.optional(),
+		matchAll: z.boolean().optional().default(false),
 		startsAt: z.string().datetime({ offset: true }).optional().nullable(),
 		endsAt: z.string().datetime({ offset: true }).optional().nullable(),
 		schedule: mutePolicyScheduleSchema.optional().nullable(),
@@ -349,7 +361,7 @@ export const CreateMutePolicySchema = z
 	})
 	.refine(mutePolicyTimeRefinement, { message: 'End time must be after start time', path: ['endsAt'] })
 	.refine(mutePolicyMatchersRefinement, {
-		message: 'Provide at least a name match or one label matcher',
+		message: 'Provide at least a name match, one label matcher, or enable match-all',
 		path: ['nameContains'],
 	})
 	.refine(mutePolicyScheduleExclusivityRefinement, {
@@ -362,6 +374,8 @@ export const UpdateMutePolicySchema = z
 		name: z.string().min(1).max(200).optional(),
 		nameContains: z.string().max(500).optional().nullable(),
 		labelMatchers: z.array(labelMatcherSchema).max(20).optional(),
+		labelMatcherGroups: labelMatcherGroupsSchema.optional(),
+		matchAll: z.boolean().optional(),
 		startsAt: z.string().datetime({ offset: true }).optional().nullable(),
 		endsAt: z.string().datetime({ offset: true }).optional().nullable(),
 		schedule: mutePolicyScheduleSchema.optional().nullable(),
@@ -415,13 +429,15 @@ export const CreateAlertEnrichmentSchema = z
 		name: z.string().min(1, 'Name is required').max(200),
 		nameContains: z.string().max(500).optional().nullable(),
 		labelMatchers: z.array(labelMatcherSchema).max(20).optional().default([]),
+		labelMatcherGroups: labelMatcherGroupsSchema.optional(),
+		matchAll: z.boolean().optional().default(false),
 		addFields: z.array(enrichmentFieldSchema).max(20).optional().default([]),
 		addLinks: z.array(enrichmentLinkSchema).max(20).optional().default([]),
 		summaryTemplate: z.string().max(5000).optional().nullable(),
 		priority: z.number().int().min(0).max(1000).optional().default(0),
 	})
 	.refine(mutePolicyMatchersRefinement, {
-		message: 'Provide at least a name match or one label matcher',
+		message: 'Provide at least a name match, one label matcher, or enable match-all',
 		path: ['nameContains'],
 	})
 	.refine(enrichmentEffectRefinement, {
@@ -490,6 +506,7 @@ const httpActionConfigSchema = z.object({
 const actionMatchFields = {
 	nameContains: z.string().max(500).optional().nullable(),
 	labelMatchers: z.array(labelMatcherSchema).max(20).optional().default([]),
+	labelMatcherGroups: labelMatcherGroupsSchema.optional(),
 };
 
 export const CreateActionSchema = z.discriminatedUnion('type', [

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -300,6 +300,7 @@ export const UpdateCommentSchema = z.object({
 const labelMatcherSchema = z.object({
 	key: z.string().min(1, 'Label key is required').max(200),
 	value: z.string().min(1, 'Label value is required').max(500),
+	op: z.enum(['equals', 'contains']).optional(),
 });
 
 const timeOfDayRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
@@ -451,6 +452,8 @@ export const UpdateAlertEnrichmentSchema = z.object({
 	name: z.string().min(1).max(200).optional(),
 	nameContains: z.string().max(500).optional().nullable(),
 	labelMatchers: z.array(labelMatcherSchema).max(20).optional(),
+	labelMatcherGroups: labelMatcherGroupsSchema.optional(),
+	matchAll: z.boolean().optional(),
 	addFields: z.array(enrichmentFieldSchema).max(20).optional(),
 	addLinks: z.array(enrichmentLinkSchema).max(20).optional(),
 	summaryTemplate: z.string().max(5000).optional().nullable(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -424,6 +424,10 @@ export interface AlertComment {
 export interface MutePolicyLabelMatcher {
 	key: string;
 	value: string;
+	// How the value compares against the alert's tag: exact equality (default) or
+	// case-insensitive substring. Absent = equals, so every stored row keeps meaning
+	// what it meant.
+	op?: 'equals' | 'contains';
 }
 
 // OR groups of label matchers: an entity matches an alert when ANY group matches, and a
@@ -448,11 +452,16 @@ export const getLabelMatcherGroups = (criteria: MatcherCriteria): LabelMatcherGr
 	return flat.length > 0 ? [flat] : [];
 };
 
+const matcherMatchesTagValue = (m: MutePolicyLabelMatcher, tagValue: string | undefined): boolean => {
+	if (tagValue === undefined) return false;
+	if (m.op === 'contains') return String(tagValue).toLowerCase().includes(m.value.toLowerCase());
+	return String(tagValue) === m.value;
+};
+
 export const anyMatcherGroupMatchesTags = (
 	groups: LabelMatcherGroups,
 	tags: Record<string, string> | undefined
-): boolean =>
-	groups.some((group) => group.every((m) => tags?.[m.key] !== undefined && String(tags[m.key]) === m.value));
+): boolean => groups.some((group) => group.every((m) => matcherMatchesTagValue(m, tags?.[m.key])));
 
 // Recurring weekly schedule, evaluated in server local time.
 // daysOfWeek: 0=Sunday … 6=Saturday (matches Date.prototype.getDay()).

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -426,6 +426,34 @@ export interface MutePolicyLabelMatcher {
 	value: string;
 }
 
+// OR groups of label matchers: an entity matches an alert when ANY group matches, and a
+// group matches when EVERY matcher in it equals the alert's tag value (AND within a
+// group, OR between groups). The legacy flat labelMatchers list is equivalent to a
+// single group; helpers below normalize both shapes.
+export type LabelMatcherGroups = MutePolicyLabelMatcher[][];
+
+export interface MatcherCriteria {
+	labelMatchers?: MutePolicyLabelMatcher[] | null;
+	labelMatcherGroups?: LabelMatcherGroups | null;
+}
+
+// The entity's effective OR groups: explicit groups win; a legacy flat list folds into
+// one group; empty rows are dropped so blank editor lines never block a match.
+export const getLabelMatcherGroups = (criteria: MatcherCriteria): LabelMatcherGroups => {
+	const groups = (criteria.labelMatcherGroups ?? [])
+		.map((group) => (group ?? []).filter((m) => m && m.key))
+		.filter((group) => group.length > 0);
+	if (groups.length > 0) return groups;
+	const flat = (criteria.labelMatchers ?? []).filter((m) => m && m.key);
+	return flat.length > 0 ? [flat] : [];
+};
+
+export const anyMatcherGroupMatchesTags = (
+	groups: LabelMatcherGroups,
+	tags: Record<string, string> | undefined
+): boolean =>
+	groups.some((group) => group.every((m) => tags?.[m.key] !== undefined && String(tags[m.key]) === m.value));
+
 // Recurring weekly schedule, evaluated in server local time.
 // daysOfWeek: 0=Sunday … 6=Saturday (matches Date.prototype.getDay()).
 // startTime/endTime: "HH:MM" 24h. endTime must be strictly greater than startTime
@@ -441,6 +469,11 @@ export interface MutePolicy {
 	name: string;
 	nameContains?: string | null;
 	labelMatchers: MutePolicyLabelMatcher[];
+	// OR groups (see LabelMatcherGroups); when present they supersede labelMatchers,
+	// which then carries the first group for backward compatibility.
+	labelMatcherGroups?: LabelMatcherGroups;
+	// Match every alert, ignoring name/label criteria entirely.
+	matchAll?: boolean;
 	startsAt?: string | null;
 	endsAt?: string | null;
 	schedule?: MutePolicySchedule | null;
@@ -463,6 +496,10 @@ export interface AlertEnrichment {
 	name: string;
 	nameContains?: string | null;
 	labelMatchers: MutePolicyLabelMatcher[];
+	// OR groups (see LabelMatcherGroups); when present they supersede labelMatchers.
+	labelMatcherGroups?: LabelMatcherGroups;
+	// Match every alert, ignoring name/label criteria entirely.
+	matchAll?: boolean;
 	addFields: AlertEnrichmentField[];
 	// Links appended to matching alerts' link collection. Label and url are templated
 	// like field values ({{label.<key>}} etc.); icon is a slug from the integration
@@ -532,6 +569,8 @@ export interface Action {
 	// (when set) AND whose tags match every label matcher.
 	nameContains?: string | null;
 	labelMatchers: ActionLabelMatcher[];
+	// OR groups (see LabelMatcherGroups); when present they supersede labelMatchers.
+	labelMatcherGroups?: LabelMatcherGroups;
 	createdAt: string;
 	updatedAt: string;
 }


### PR DESCRIPTION
## What

Two long-requested matching upgrades, applied uniformly to **actions, enrichments, and mute policies**:

1. **OR groups** — criteria used to be a single AND list, so `(label1=value1) OR (label2=value2)` required duplicating the whole rule. The editor now builds groups: AND matchers inside a box, boxes OR'd together (`+ OR group`). An entity matches when ANY group fully matches.
2. **Match all** — enrichments and mute policies gain an "Apply to all alerts" checkbox (global rules with no criteria), matching what actions already had via their empty filter.

## Design

- `labelMatcherGroups: Matcher[][]` on all three entities; the legacy flat `labelMatchers` folds in as one group
- **Zero data migration for groups**: single-group rules keep serializing FLAT into the existing JSON columns — old rows read unchanged, and new single-group rows remain readable by older code. Only `match_all` needed new columns (with standard legacy-DB migrations)
- One pair of shared helpers (`getLabelMatcherGroups` / `anyMatcherGroupMatchesTags`) drives all three evaluators — mute BL, enrichment BL, client action filter — so the semantics can't drift
- One shared `MatcherGroupsEditor` component replaces the three hand-rolled row editors; list pages show `k=v` badges joined by OR chips, plus an "All alerts" badge

## Verification

- 154/154 server tests (4 new: OR-group muting across groups, match-all mute, match-all enrichment, criteria-less rejection), 79/79 client tests, lint clean, builds green
- Live: built a two-group OR mute policy through the UI — the list renders `service_name=links-demo OR service_name=fix-demo`, and alerts from BOTH families were muted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grouped label matching for actions, mute policies, and enrichments.
  * Combine criteria with AND within groups and OR between groups.
  * Added exact-match and case-insensitive “contains” operators.
  * Added “match all alerts” options for mute policies and enrichments.
  * Added clearer matcher editors and badges across management screens.

* **Bug Fixes**
  * Existing matching configurations remain supported when creating, editing, and displaying rules.
  * Improved validation for incomplete or criteria-free policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->