### PR TITLE
feat: include/exclude alerts from the filter sidebar with +/− controls

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -212,7 +212,7 @@ const Alerts = () => {
 	// the user's stored filter — and dirtied the dashboard — just for peeking at
 	// another tab; the stored filters stay intact and Active keeps applying them.
 	const statusSuspendedFilters = useMemo(() => {
-		const { status: _status, ...rest } = dashboardState.filters;
+		const { status: _status, ['!status']: _notStatus, ...rest } = dashboardState.filters;
 		return rest;
 	}, [dashboardState.filters]);
 	const resolvedViewAlerts = useAlertsFiltering(resolvedAlerts, {

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -70,11 +70,13 @@ export const AlertsFilterPanel = ({
 	}, [filters, hideStatusFilter]);
 
 	const facets: FilterFacets = useMemo(() => {
-		// The value an alert presents for a given filter field, matching useAlertsFiltering's logic.
-		const getFieldValue = (alert: Alert, field: string): string => {
+		// The value an alert presents for a given filter field, matching useAlertsFiltering's
+		// logic — including null for unknown fields, which never constrain (a stale persisted
+		// filter must not zero out every facet).
+		const getFieldValue = (alert: Alert, field: string): string | null => {
 			if (isTagKeyColumn(field)) {
 				const tagKey = extractTagKeyFromColumnId(field);
-				return tagKey ? alert.tags?.[tagKey] || '' : '';
+				return tagKey ? alert.tags?.[tagKey] || '' : null;
 			}
 			switch (field) {
 				case 'status':
@@ -88,7 +90,7 @@ export const AlertsFilterPanel = ({
 				case 'owner':
 					return getOwnerDisplayName(alert.ownerId, users);
 				default:
-					return '';
+					return null;
 			}
 		};
 
@@ -102,6 +104,7 @@ export const AlertsFilterPanel = ({
 				const field = isExclusion ? key.slice(1) : key;
 				if (field === exceptField) continue;
 				const value = getFieldValue(alert, field);
+				if (value === null) continue;
 				if (isExclusion ? values.includes(value) : !values.includes(value)) return false;
 			}
 			return true;

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -65,7 +65,7 @@ export const AlertsFilterPanel = ({
 	// otherwise the sidebar disagrees with the table it describes.
 	const effectiveFilters = useMemo(() => {
 		if (!hideStatusFilter) return filters;
-		const { status: _status, ...rest } = filters;
+		const { status: _status, ['!status']: _notStatus, ...rest } = filters;
 		return rest;
 	}, [filters, hideStatusFilter]);
 
@@ -93,11 +93,16 @@ export const AlertsFilterPanel = ({
 		};
 
 		// Faceted filtering: an alert counts toward a field's facet only if it passes every OTHER
-		// active filter. A facet never constrains itself, so its own options stay fully visible.
+		// active filter (includes AND "!field" exclusions). A facet never constrains itself —
+		// neither its includes nor its exclusions — so its own options stay fully visible.
 		const passesOtherFilters = (alert: Alert, exceptField: string): boolean => {
-			for (const [field, values] of Object.entries(effectiveFilters)) {
-				if (!values || values.length === 0 || field === exceptField) continue;
-				if (!values.includes(getFieldValue(alert, field))) return false;
+			for (const [key, values] of Object.entries(effectiveFilters)) {
+				if (!values || values.length === 0) continue;
+				const isExclusion = key.startsWith('!');
+				const field = isExclusion ? key.slice(1) : key;
+				if (field === exceptField) continue;
+				const value = getFieldValue(alert, field);
+				if (isExclusion ? values.includes(value) : !values.includes(value)) return false;
 			}
 			return true;
 		};

--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -93,47 +93,42 @@ export const useAlertsFiltering = (
 
 		if (Object.keys(filters).length === 0) return result;
 
+		// The value an alert presents for a filter field; null when the field is unknown
+		// (unknown fields never constrain).
+		const getFieldValue = (alert: Alert, field: string): string | null => {
+			if (isTagKeyColumn(field)) {
+				const tagKey = extractTagKeyFromColumnId(field);
+				return tagKey ? alert.tags?.[tagKey] || '' : null;
+			}
+			switch (field) {
+				case 'status':
+					return alert.isSilenced ? 'Silenced' : alert.isMuted ? 'Muted' : capitalizeFirst(alert.status);
+				case 'severity':
+					return SEVERITY_LABELS[getAlertSeverity(alert)];
+				case 'type':
+					return getAlertType(alert);
+				case 'alertName':
+					return alert.alertName ?? '';
+				case 'owner':
+					return getOwnerDisplayName(alert.ownerId, users);
+				default:
+					return null;
+			}
+		};
+
 		return result.filter((alert) => {
-			for (const [field, values] of Object.entries(filters)) {
+			for (const [key, values] of Object.entries(filters)) {
 				if (values.length === 0) continue;
 
-				if (isTagKeyColumn(field)) {
-					const tagKey = extractTagKeyFromColumnId(field);
-					if (tagKey) {
-						const tagValue = alert.tags?.[tagKey] || '';
-						if (!values.includes(tagValue)) {
-							return false;
-						}
-					}
-					continue;
-				}
+				// "!field" entries are exclusions ("filter out" in the sidebar): an alert
+				// whose value is listed is dropped. Same field-value semantics as the
+				// positive filters, same storage shape — dashboards persist them with no
+				// schema change.
+				const isExclusion = key.startsWith('!');
+				const fieldValue = getFieldValue(alert, isExclusion ? key.slice(1) : key);
+				if (fieldValue === null) continue;
 
-				let fieldValue: string;
-				switch (field) {
-					case 'status':
-						fieldValue = alert.isSilenced
-							? 'Silenced'
-							: alert.isMuted
-								? 'Muted'
-								: capitalizeFirst(alert.status);
-						break;
-					case 'severity':
-						fieldValue = SEVERITY_LABELS[getAlertSeverity(alert)];
-						break;
-					case 'type':
-						fieldValue = getAlertType(alert);
-						break;
-					case 'alertName':
-						fieldValue = alert.alertName ?? '';
-						break;
-					case 'owner':
-						fieldValue = getOwnerDisplayName(alert.ownerId, users);
-						break;
-					default:
-						continue;
-				}
-
-				if (!values.includes(fieldValue)) {
+				if (isExclusion ? values.includes(fieldValue) : !values.includes(fieldValue)) {
 					return false;
 				}
 			}

--- a/apps/client/src/components/shared/FilterPanel.tsx
+++ b/apps/client/src/components/shared/FilterPanel.tsx
@@ -345,7 +345,7 @@ export const FilterPanel = ({
 																	>
 																		<span
 																			className={cn(
-																				'text-xs flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-foreground',
+																				'text-xs flex-1 min-w-0 break-words line-clamp-2 text-foreground',
 																				isIncluded &&
 																					'font-medium text-primary',
 																				isExcluded &&
@@ -355,65 +355,92 @@ export const FilterPanel = ({
 																		>
 																			{label}
 																		</span>
+																		{/* Hover/focus swap: idle rows show only a pinned
+																		    state icon + count so the label keeps the width;
+																		    hovering (or tabbing in — sr-only keeps the
+																		    buttons focusable) replaces them with the +/−
+																		    pair in the same slot. */}
 																		{!isDisabled && (
-																			<button
-																				type="button"
-																				onClick={(e) => {
-																					e.stopPropagation();
-																					handleFilterToggle(field, value);
-																				}}
-																				aria-pressed={isIncluded}
-																				className={cn(
-																					'shrink-0 rounded p-0.5 transition-opacity',
-																					isIncluded
-																						? 'opacity-100 text-primary'
-																						: 'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 text-muted-foreground hover:text-primary'
-																				)}
-																				title={
-																					isIncluded
-																						? 'Remove filter'
-																						: 'Filter'
-																				}
-																				aria-label={
-																					isIncluded
-																						? `Stop filtering ${label}`
-																						: `Filter ${label}`
-																				}
-																			>
-																				<CirclePlus className="h-3.5 w-3.5" />
-																			</button>
+																			<span className="sr-only group-hover/row:not-sr-only group-focus-within/row:not-sr-only flex items-center gap-0.5 shrink-0">
+																				<button
+																					type="button"
+																					onClick={(e) => {
+																						e.stopPropagation();
+																						handleFilterToggle(
+																							field,
+																							value
+																						);
+																					}}
+																					aria-pressed={isIncluded}
+																					className={cn(
+																						'shrink-0 rounded p-0.5',
+																						isIncluded
+																							? 'text-primary'
+																							: 'text-muted-foreground hover:text-primary'
+																					)}
+																					title={
+																						isIncluded
+																							? 'Remove filter'
+																							: 'Filter'
+																					}
+																					aria-label={
+																						isIncluded
+																							? `Stop filtering ${label}`
+																							: `Filter ${label}`
+																					}
+																				>
+																					<CirclePlus className="h-3.5 w-3.5" />
+																				</button>
+																				<button
+																					type="button"
+																					onClick={(e) => {
+																						e.stopPropagation();
+																						handleExcludeToggle(
+																							field,
+																							value
+																						);
+																					}}
+																					aria-pressed={isExcluded}
+																					className={cn(
+																						'shrink-0 rounded p-0.5',
+																						isExcluded
+																							? 'text-destructive'
+																							: 'text-muted-foreground hover:text-destructive'
+																					)}
+																					title={
+																						isExcluded
+																							? 'Stop filtering out'
+																							: 'Filter out'
+																					}
+																					aria-label={
+																						isExcluded
+																							? `Stop filtering out ${label}`
+																							: `Filter out ${label}`
+																					}
+																				>
+																					<CircleMinus className="h-3.5 w-3.5" />
+																				</button>
+																			</span>
 																		)}
-																		{!isDisabled && (
-																			<button
-																				type="button"
-																				onClick={(e) => {
-																					e.stopPropagation();
-																					handleExcludeToggle(field, value);
-																				}}
-																				aria-pressed={isExcluded}
-																				className={cn(
-																					'shrink-0 rounded p-0.5 transition-opacity',
-																					isExcluded
-																						? 'opacity-100 text-destructive'
-																						: 'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 text-muted-foreground hover:text-destructive'
-																				)}
-																				title={
-																					isExcluded
-																						? 'Stop filtering out'
-																						: 'Filter out'
-																				}
-																				aria-label={
-																					isExcluded
-																						? `Stop filtering out ${label}`
-																						: `Filter out ${label}`
-																				}
-																			>
-																				<CircleMinus className="h-3.5 w-3.5" />
-																			</button>
+																		{isIncluded && !isDisabled && (
+																			<CirclePlus
+																				aria-hidden
+																				className="h-3.5 w-3.5 shrink-0 text-primary group-hover/row:hidden group-focus-within/row:hidden"
+																			/>
+																		)}
+																		{isExcluded && !isDisabled && (
+																			<CircleMinus
+																				aria-hidden
+																				className="h-3.5 w-3.5 shrink-0 text-destructive group-hover/row:hidden group-focus-within/row:hidden"
+																			/>
 																		)}
 																		<Badge
 																			variant="outline"
-																			className="text-[10px] px-1 py-0 h-4 min-w-[20px] shrink-0 flex items-center justify-center"
+																			className={cn(
+																				'text-[10px] px-1 py-0 h-4 min-w-[20px] shrink-0 flex items-center justify-center',
+																				!isDisabled &&
+																					'group-hover/row:hidden group-focus-within/row:hidden'
+																			)}
 																		>
 																			{count}
 																		</Badge>

--- a/apps/client/src/components/shared/FilterPanel.tsx
+++ b/apps/client/src/components/shared/FilterPanel.tsx
@@ -1,10 +1,9 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
-import { Filter, RotateCcw } from 'lucide-react';
+import { CircleMinus, CirclePlus, Filter, RotateCcw } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ActiveFiltersSection } from './FilterPanel/ActiveFiltersSection';
 import { FilterSearchInput } from './FilterPanel/FilterSearchInput';
@@ -76,7 +75,10 @@ export const FilterPanel = ({
 	}, [facets]);
 
 	useEffect(() => {
-		Object.entries(filters).forEach(([field, values]) => {
+		Object.entries(filters).forEach(([key, values]) => {
+			// Exclusion keys ("!field") register their values under the plain field, so an
+			// excluded value stays listed as an option even when no alert carries it anymore.
+			const field = key.startsWith('!') ? key.slice(1) : key;
 			if (!allSeenValuesRef.current[field]) {
 				allSeenValuesRef.current[field] = new Set();
 			}
@@ -100,9 +102,30 @@ export const FilterPanel = ({
 			? currentValues.filter((v) => v !== value)
 			: [...currentValues, value];
 
+		// Including a value always clears its exclusion — a value can't be filtered in
+		// and out at the same time.
+		const excludeKey = `!${field}`;
+		const excluded = (filters[excludeKey] || []).filter((v) => v !== value);
+
 		onFilterChange({
 			...filters,
 			[field]: newValues,
+			...(filters[excludeKey] ? { [excludeKey]: excluded } : {}),
+		});
+	};
+
+	// Toggle a value's "filter out" state. Exclusions live in the same filters record
+	// under "!<field>" keys, so persistence needs no schema change. Excluding a value
+	// also removes any include of it (mutually exclusive per value).
+	const handleExcludeToggle = (field: string, value: string) => {
+		const excludeKey = `!${field}`;
+		const currentExcluded = filters[excludeKey] || [];
+		const isExcluded = currentExcluded.includes(value);
+		onFilterChange({
+			...filters,
+			[excludeKey]: isExcluded ? currentExcluded.filter((v) => v !== value) : [...currentExcluded, value],
+			// Only rewrite the include list when one exists — no phantom empty keys.
+			...(!isExcluded && filters[field] ? { [field]: filters[field].filter((v) => v !== value) } : {}),
 		});
 	};
 
@@ -204,16 +227,22 @@ export const FilterPanel = ({
 				onRemoveFilter={handleRemoveFilter}
 			/>
 			<ScrollArea className="flex-1">
-				<div className="px-2 py-2">
+				{/* w-0 + min-w-full: Radix ScrollArea's viewport child is display:table, which
+				    grows to CONTENT width — one long option label would widen every row past
+				    the visible panel and push the +/− controls and count badges out of view.
+				    This pins the content to the viewport width so labels truncate and the
+				    controls stay hugging the visible right edge. */}
+				<div className="px-2 py-2 w-0 min-w-full">
 					<Accordion type="multiple" value={openValues} onValueChange={setOpenValues} className="w-full">
 						{config.fields.map((field) => {
 							const fieldFacets = facets[field] || [];
 							const activeValues = filters[field] || [];
+							const excludedValues = filters[`!${field}`] || [];
 							const seenValues = allSeenValues[field] || new Set();
 
 							const existingValues = new Set(fieldFacets.map((f) => f.value));
-							const orphanedFilters = activeValues
-								.filter((v) => !existingValues.has(v))
+							const orphanedFilters = [...activeValues, ...excludedValues]
+								.filter((v, i, arr) => !existingValues.has(v) && arr.indexOf(v) === i)
 								.map((value) => ({ value, count: 0 }));
 
 							// Apply global search filter
@@ -232,7 +261,12 @@ export const FilterPanel = ({
 							};
 
 							const missingSeenValues = Array.from(seenValues)
-								.filter((v) => !existingValues.has(v) && !activeValues.includes(v))
+								.filter(
+									(v) =>
+										!existingValues.has(v) &&
+										!activeValues.includes(v) &&
+										!excludedValues.includes(v)
+								)
 								.map((value) => ({ value, count: 0 }));
 
 							const allFacets = [...fieldFacets, ...orphanedFilters, ...missingSeenValues];
@@ -255,12 +289,12 @@ export const FilterPanel = ({
 											<span className="text-xs font-medium text-foreground">
 												{config.fieldLabels[field] || field}
 											</span>
-											{activeValues.length > 0 && (
+											{activeValues.length + excludedValues.length > 0 && (
 												<Badge
 													variant="outline"
 													className="text-[10px] px-1.5 py-0 h-4 bg-muted/50 border-muted-foreground/20"
 												>
-													{activeValues.length}
+													{activeValues.length + excludedValues.length}
 												</Badge>
 											)}
 										</div>
@@ -285,41 +319,105 @@ export const FilterPanel = ({
 													<>
 														{filteredAndLimitedFacets.map(
 															({ value, count, displayValue, disabled }) => {
-																const isChecked = activeValues.includes(value);
+																const isIncluded = activeValues.includes(value);
+																const isExcluded = excludedValues.includes(value);
 																const label = displayValue || value;
 																const isDisabled = disabled === true;
 																return (
-																	<label
+																	// Row click = include toggle (the biggest target,
+																	// same gesture the old checkbox served); the +/−
+																	// buttons are the explicit controls — hover-revealed
+																	// when idle, pinned while their state is active.
+																	<div
 																		key={value}
+																		onClick={() =>
+																			!isDisabled &&
+																			handleFilterToggle(field, value)
+																		}
 																		className={cn(
-																			'flex items-center gap-2 py-1 px-1 rounded transition-colors w-full overflow-hidden',
+																			'group/row flex items-center gap-1.5 py-1 px-1 rounded transition-colors w-full overflow-hidden',
 																			isDisabled
 																				? 'cursor-not-allowed opacity-50'
 																				: 'cursor-pointer hover:bg-muted/50',
-																			isChecked && 'bg-muted'
+																			isIncluded && 'bg-muted',
+																			isExcluded && 'bg-destructive/10'
 																		)}
 																	>
-																		<Checkbox
-																			checked={isChecked}
-																			disabled={isDisabled}
-																			onCheckedChange={() =>
-																				handleFilterToggle(field, value)
-																			}
-																			className="h-3 w-3 border-2 shrink-0 data-[state=checked]:bg-primary data-[state=checked]:border-primary cursor-pointer hover:bg-primary/10 transition-colors disabled:cursor-not-allowed"
-																		/>
 																		<span
-																			className="text-xs overflow-hidden text-ellipsis whitespace-nowrap block max-w-[100px] text-foreground"
+																			className={cn(
+																				'text-xs flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-foreground',
+																				isIncluded &&
+																					'font-medium text-primary',
+																				isExcluded &&
+																					'line-through text-destructive'
+																			)}
 																			title={label}
 																		>
 																			{label}
 																		</span>
+																		{!isDisabled && (
+																			<button
+																				type="button"
+																				onClick={(e) => {
+																					e.stopPropagation();
+																					handleFilterToggle(field, value);
+																				}}
+																				aria-pressed={isIncluded}
+																				className={cn(
+																					'shrink-0 rounded p-0.5 transition-opacity',
+																					isIncluded
+																						? 'opacity-100 text-primary'
+																						: 'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 text-muted-foreground hover:text-primary'
+																				)}
+																				title={
+																					isIncluded
+																						? 'Remove filter'
+																						: 'Filter'
+																				}
+																				aria-label={
+																					isIncluded
+																						? `Stop filtering ${label}`
+																						: `Filter ${label}`
+																				}
+																			>
+																				<CirclePlus className="h-3.5 w-3.5" />
+																			</button>
+																		)}
+																		{!isDisabled && (
+																			<button
+																				type="button"
+																				onClick={(e) => {
+																					e.stopPropagation();
+																					handleExcludeToggle(field, value);
+																				}}
+																				aria-pressed={isExcluded}
+																				className={cn(
+																					'shrink-0 rounded p-0.5 transition-opacity',
+																					isExcluded
+																						? 'opacity-100 text-destructive'
+																						: 'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 text-muted-foreground hover:text-destructive'
+																				)}
+																				title={
+																					isExcluded
+																						? 'Stop filtering out'
+																						: 'Filter out'
+																				}
+																				aria-label={
+																					isExcluded
+																						? `Stop filtering out ${label}`
+																						: `Filter out ${label}`
+																				}
+																			>
+																				<CircleMinus className="h-3.5 w-3.5" />
+																			</button>
+																		)}
 																		<Badge
 																			variant="outline"
-																			className="text-[10px] px-1 py-0 h-4 min-w-[20px] shrink-0 flex items-center justify-center ml-auto"
+																			className="text-[10px] px-1 py-0 h-4 min-w-[20px] shrink-0 flex items-center justify-center"
 																		>
 																			{count}
 																		</Badge>
-																	</label>
+																	</div>
 																);
 															}
 														)}

--- a/apps/client/src/components/shared/FilterPanel/ActiveFiltersSection.tsx
+++ b/apps/client/src/components/shared/FilterPanel/ActiveFiltersSection.tsx
@@ -1,4 +1,5 @@
-import { Badge } from '@/components/ui/badge';
+import { badgeVariants } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import { X } from 'lucide-react';
 
 interface ActiveFiltersSectionProps {
@@ -26,21 +27,34 @@ export const ActiveFiltersSection = ({
 				Active Filters
 			</div>
 			<div className="flex flex-wrap gap-1">
-				{Object.entries(filters).map(([field, values]) =>
-					values.map((value) => (
-						<Badge
-							key={`${field}-${value}`}
-							variant="outline"
-							className="text-[10px] px-1.5 py-0.5 h-5 gap-1 cursor-pointer hover:bg-destructive/10 hover:border-destructive hover:text-destructive transition-colors group bg-background"
-							onClick={() => onRemoveFilter(field, value)}
-							title={`Remove ${fieldLabels[field]}: ${getDisplayValue(field, value)}`}
+				{Object.entries(filters).map(([key, values]) => {
+					// "!field" entries are exclusions — labelled with ≠ and tinted red.
+					const isExclusion = key.startsWith('!');
+					const field = isExclusion ? key.slice(1) : key;
+					return values.map((value) => (
+						// Native button (not Badge's div) so the removable chip is focusable
+						// and keyboard-operable.
+						<button
+							key={`${key}-${value}`}
+							type="button"
+							className={cn(
+								badgeVariants({ variant: 'outline' }),
+								'text-[10px] px-1.5 py-0.5 h-5 gap-1 cursor-pointer hover:bg-destructive/10 hover:border-destructive hover:text-destructive transition-colors group bg-background',
+								isExclusion && 'border-destructive/40 text-destructive'
+							)}
+							onClick={() => onRemoveFilter(key, value)}
+							title={`Remove ${fieldLabels[field]} ${isExclusion ? '≠' : ':'} ${getDisplayValue(field, value)}`}
+							aria-label={`Remove ${fieldLabels[field]} ${isExclusion ? '≠' : ':'} ${getDisplayValue(field, value)}`}
 						>
-							<span className="text-primary font-semibold">{fieldLabels[field]}:</span>
+							<span className={cn('font-semibold', isExclusion ? 'text-destructive' : 'text-primary')}>
+								{fieldLabels[field]}
+								{isExclusion ? ' ≠' : ':'}
+							</span>
 							<span className="max-w-[60px] truncate font-medium">{getDisplayValue(field, value)}</span>
 							<X className="h-2.5 w-2.5 opacity-60 group-hover:opacity-100" />
-						</Badge>
-					))
-				)}
+						</button>
+					));
+				})}
 			</div>
 		</div>
 	);

--- a/apps/client/src/components/shared/FilterSidebar.tsx
+++ b/apps/client/src/components/shared/FilterSidebar.tsx
@@ -15,7 +15,7 @@ export const FilterSidebar = ({ children, collapsed, onToggle, className }: Filt
 		<div
 			className={cn(
 				'border-r border-border transition-all duration-300 ease-in-out shrink-0 relative',
-				collapsed ? 'w-12' : 'w-48',
+				collapsed ? 'w-12' : 'w-64',
 				className
 			)}
 		>

--- a/apps/client/src/test/FilterPanel.test.tsx
+++ b/apps/client/src/test/FilterPanel.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { FilterPanel, FilterPanelConfig } from '@/components/shared/FilterPanel';
+
+// The sidebar's option rows use +/− controls (no checkboxes): row click or "+" includes,
+// "−" filters the value OUT (stored under a "!<field>" key), and the two states are
+// mutually exclusive per value.
+
+const config: FilterPanelConfig = {
+	fields: ['severity'],
+	fieldLabels: { severity: 'Severity' },
+};
+
+const facets = {
+	severity: [
+		{ value: 'Critical', count: 3 },
+		{ value: 'Info', count: 5 },
+	],
+};
+
+describe('FilterPanel +/− controls', () => {
+	test('the + button includes a value', () => {
+		const onFilterChange = vi.fn();
+		render(<FilterPanel config={config} facets={facets} filters={{}} onFilterChange={onFilterChange} />);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Filter Critical' }));
+		expect(onFilterChange).toHaveBeenCalledWith({ severity: ['Critical'] });
+	});
+
+	test('clicking the row body also includes (the old checkbox gesture)', () => {
+		const onFilterChange = vi.fn();
+		render(<FilterPanel config={config} facets={facets} filters={{}} onFilterChange={onFilterChange} />);
+
+		fireEvent.click(screen.getByTitle('Info'));
+		expect(onFilterChange).toHaveBeenCalledWith({ severity: ['Info'] });
+	});
+
+	test('the − button excludes a value under the !field key', () => {
+		const onFilterChange = vi.fn();
+		render(<FilterPanel config={config} facets={facets} filters={{}} onFilterChange={onFilterChange} />);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Filter out Critical' }));
+		expect(onFilterChange).toHaveBeenCalledWith({ '!severity': ['Critical'] });
+	});
+
+	test('excluding an included value drops the include (mutually exclusive)', () => {
+		const onFilterChange = vi.fn();
+		render(
+			<FilterPanel
+				config={config}
+				facets={facets}
+				filters={{ severity: ['Critical'] }}
+				onFilterChange={onFilterChange}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Filter out Critical' }));
+		expect(onFilterChange).toHaveBeenCalledWith({ severity: [], '!severity': ['Critical'] });
+	});
+
+	test('including an excluded value drops the exclusion', () => {
+		const onFilterChange = vi.fn();
+		render(
+			<FilterPanel
+				config={config}
+				facets={facets}
+				filters={{ '!severity': ['Critical'] }}
+				onFilterChange={onFilterChange}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Filter Critical' }));
+		expect(onFilterChange).toHaveBeenCalledWith({ severity: ['Critical'], '!severity': [] });
+	});
+
+	test('an excluded value shows a red ≠ chip that removes the exclusion on click', () => {
+		const onFilterChange = vi.fn();
+		render(
+			<FilterPanel
+				config={config}
+				facets={facets}
+				filters={{ '!severity': ['Critical'] }}
+				onFilterChange={onFilterChange}
+			/>
+		);
+
+		const chip = screen.getByRole('button', { name: 'Remove Severity ≠ Critical' });
+		fireEvent.click(chip);
+		expect(onFilterChange).toHaveBeenCalledWith({ '!severity': [] });
+	});
+
+	test('an excluded value that no longer appears in any facet still renders as an option', () => {
+		const onFilterChange = vi.fn();
+		render(
+			<FilterPanel
+				config={config}
+				facets={{ severity: [{ value: 'Info', count: 5 }] }}
+				filters={{ '!severity': ['Critical'] }}
+				onFilterChange={onFilterChange}
+			/>
+		);
+
+		expect(screen.getByTitle('Critical')).toBeInTheDocument();
+	});
+});

--- a/apps/client/src/test/useAlertsFiltering.test.tsx
+++ b/apps/client/src/test/useAlertsFiltering.test.tsx
@@ -183,3 +183,37 @@ describe('in-range override with mixed timestamp formats', () => {
 		expect(result.current[0]?.startsAt).toBe(laterUtc);
 	});
 });
+
+// "!field" filter keys are exclusions ("filter out" from the sidebar): listed values are
+// dropped; same field semantics as the positive filters, including tag-key fields.
+describe('exclusion filters (!field keys)', () => {
+	const critical = { ...mkAlert('crit', 0), severity: 'critical', tags: { env: 'prod' } } as unknown as Alert;
+	const info = { ...mkAlert('info', 0), severity: 'info', tags: { env: 'dev' } } as unknown as Alert;
+
+	test('!severity drops the listed severities and keeps the rest', () => {
+		const { result } = renderHook(() => useAlertsFiltering([critical, info], { '!severity': ['Critical'] }), {
+			wrapper,
+		});
+		expect(result.current.map((a) => a.id)).toEqual(['info']);
+	});
+
+	test('include and exclude compose across fields', () => {
+		const { result } = renderHook(
+			() => useAlertsFiltering([critical, info], { status: ['Firing'], '!severity': ['Info'] }),
+			{ wrapper }
+		);
+		expect(result.current.map((a) => a.id)).toEqual(['crit']);
+	});
+
+	test('excludes tag-key fields too', () => {
+		const { result } = renderHook(() => useAlertsFiltering([critical, info], { '!tagKey:env': ['prod'] }), {
+			wrapper,
+		});
+		expect(result.current.map((a) => a.id)).toEqual(['info']);
+	});
+
+	test('an empty exclusion list constrains nothing', () => {
+		const { result } = renderHook(() => useAlertsFiltering([critical, info], { '!severity': [] }), { wrapper });
+		expect(result.current).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## What

Redo of #793 with the UI the feedback asked for — **no checkboxes**, just **+/−**:

- Each filter option row is `label ... count`; hovering reveals a **⊕ (filter)** and **⊖ (filter out)** pair
- Clicking the **row body still includes** — the familiar gesture keeps working, now with the whole row as the target
- **Included**: row highlighted, label in primary, ⊕ pinned. **Excluded**: red strikethrough label, ⊖ pinned red, row tinted red
- Active Filters strip shows exclusions as red **`Field ≠ value`** chips (click to remove, same as includes)
- Include and exclude are **mutually exclusive per value** — excluding an included value un-includes it and vice versa

## How

Exclusions are stored in the same filters record under `!<field>` keys (`{"!severity": ["Info"]}`), so dashboard persistence, the API, and the DB are untouched. `useAlertsFiltering` treats `!field` entries as inverted matches, tag-key fields included.

- Facet counts self-exempt a field's own exclusions (same rule as its own includes), so the excluded option keeps showing its real count
- The Resolved/All views suspend `!status` alongside `status`
- Excluded values that disappear from the data still render as options (count 0) so they can be un-excluded
- ScrollArea content pinned to viewport width (`w-0 min-w-full`) — Radix's `display:table` viewport child otherwise grows to content width and long labels push the controls out of view
- No `allowExclude` opt-in: since the provider/services removal (#815) the alerts panel is the shared FilterPanel's only consumer

## Verification

- 74/74 client tests — 7 new FilterPanel component tests (+ include, − exclude, row-click include, both mutual-exclusion directions, ≠ chip removal, orphaned excluded value) and 4 useAlertsFiltering exclusion tests (severity, cross-field compose, tag keys, empty list)
- Live: excluded "Info" on a 19-alert board → 7 remain, red ≠ chip, count badge stays 12; row-click flipped it to include (12 shown); chip removal restored baseline. Console clean.

Closes #783-adjacent follow-up: none. Replaces #793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added include and exclude filtering for alert fields, with exclusions marked by minus controls and “≠” indicators.
  - Excluded values remain available in filter panels and active-filter chips for review and removal.
  - Added keyboard-accessible filter controls and improved layout behavior on narrow screens.
  - Expanded the filter sidebar for easier browsing.

- **Bug Fixes**
  - Resolved and All views now correctly show alerts across all statuses when status filtering is hidden.
  - Combined positive and negative filters now produce accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->