### PR TITLE
fix: the comment box takes focus when Comments opens

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/CommentsWall/CommentInput/CommentInput.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/CommentsWall/CommentInput/CommentInput.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Send } from 'lucide-react';
-import { KeyboardEvent } from 'react';
+import { KeyboardEvent, useEffect, useRef } from 'react';
 import { SUBMIT_BUTTON_TEXT, WRITE_COMMENT_PLACEHOLDER } from '../CommentsWall.constants';
 
 interface CommentInputProps {
@@ -10,6 +10,9 @@ interface CommentInputProps {
 	onSubmit: () => void;
 	isSubmitting: boolean;
 	placeholder?: string;
+	// Put the caret in the box as soon as it appears: opening Comments is intent enough to
+	// write, so it shouldn't cost a second click into the field.
+	autoFocus?: boolean;
 }
 
 export const CommentInput = ({
@@ -18,19 +21,52 @@ export const CommentInput = ({
 	onSubmit,
 	isSubmitting,
 	placeholder = WRITE_COMMENT_PLACEHOLDER,
+	autoFocus = false,
 }: CommentInputProps) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const refocusFrame = useRef<number | undefined>(undefined);
+
+	// Deferred a frame on purpose: the Comments tab activates on mousedown, so mounting
+	// happens BEFORE the browser applies that click's default focus to the tab button —
+	// focusing synchronously here would just be overwritten by the trigger.
+	// preventScroll: the composer is already pinned in view, and letting the browser
+	// scroll to it would jerk the comment list.
+	useEffect(() => {
+		if (!autoFocus) return;
+		const frame = requestAnimationFrame(() => textareaRef.current?.focus({ preventScroll: true }));
+		return () => cancelAnimationFrame(frame);
+	}, [autoFocus]);
+
+	useEffect(() => () => cancelAnimationFrame(refocusFrame.current ?? 0), []);
+
+	// Sending puts focus on the Send button, which then goes disabled and drops focus to
+	// the body — so a second comment would need a fresh click into the box. Hand the caret
+	// back instead, unless focus has meanwhile landed somewhere the user chose.
+	const submit = () => {
+		onSubmit();
+		refocusFrame.current = requestAnimationFrame(() => {
+			const active = document.activeElement;
+			const focusIsLoose = !active || active === document.body;
+			if (focusIsLoose || containerRef.current?.contains(active)) {
+				textareaRef.current?.focus({ preventScroll: true });
+			}
+		});
+	};
+
 	const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
 		if (e.key === 'Enter' && !e.shiftKey) {
 			e.preventDefault();
 			if (value.trim()) {
-				onSubmit();
+				submit();
 			}
 		}
 	};
 
 	return (
-		<div className="flex gap-2 p-3 border-t bg-background">
+		<div ref={containerRef} className="flex gap-2 p-3 border-t bg-background">
 			<Textarea
+				ref={textareaRef}
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 				onKeyDown={handleKeyDown}
@@ -40,7 +76,7 @@ export const CommentInput = ({
 			/>
 			<Button
 				size="icon"
-				onClick={onSubmit}
+				onClick={submit}
 				disabled={!value.trim() || isSubmitting}
 				className="shrink-0 h-10 w-10"
 			>

--- a/apps/client/src/components/Alerts/AlertDetails/CommentsWall/CommentsWall.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/CommentsWall/CommentsWall.tsx
@@ -97,11 +97,14 @@ export const CommentsWall = ({ alertId }: CommentsWallProps) => {
 				</div>
 			</ScrollArea>
 
+			{/* The wall only mounts when the user opens Comments, so focusing here means
+			    "opened Comments" == "ready to type" — no click into the field first. */}
 			<CommentInput
 				value={newComment}
 				onChange={setNewComment}
 				onSubmit={handleSubmit}
 				isSubmitting={createMutation.isPending}
+				autoFocus
 			/>
 		</div>
 	);

--- a/apps/client/src/test/CommentInput.test.tsx
+++ b/apps/client/src/test/CommentInput.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { CommentInput } from '@/components/Alerts/AlertDetails/CommentsWall/CommentInput';
+
+// Opening the Comments tab should be enough to start typing: the composer takes focus on
+// mount instead of making the user click into it first. The focus is deferred a frame (the
+// tab trigger's own click focus would otherwise win), hence the waitFor.
+
+const noop = () => {};
+
+describe('CommentInput focus', () => {
+	test('takes focus on mount when autoFocus is set', async () => {
+		render(<CommentInput value="" onChange={noop} onSubmit={noop} isSubmitting={false} autoFocus />);
+
+		await waitFor(() => expect(screen.getByRole('textbox')).toHaveFocus());
+	});
+
+	test('leaves focus alone without autoFocus', async () => {
+		render(<CommentInput value="" onChange={noop} onSubmit={noop} isSubmitting={false} />);
+
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+		expect(screen.getByRole('textbox')).not.toHaveFocus();
+	});
+
+	// Sending disables the Send button, which drops focus to the body — without the handback
+	// a second comment would need a fresh click into the box.
+	test('hands focus back to the box after sending', async () => {
+		render(<CommentInput value="hi" onChange={noop} onSubmit={noop} isSubmitting={false} autoFocus />);
+
+		const sendButton = screen.getByRole('button');
+		sendButton.focus();
+		fireEvent.click(sendButton);
+
+		await waitFor(() => expect(screen.getByRole('textbox')).toHaveFocus());
+	});
+
+	test('does not steal focus back when the user moved on after sending', async () => {
+		render(
+			<>
+				<input aria-label="elsewhere" />
+				<CommentInput value="hi" onChange={noop} onSubmit={noop} isSubmitting={false} />
+			</>
+		);
+
+		fireEvent.click(screen.getByRole('button'));
+		const elsewhere = screen.getByLabelText('elsewhere');
+		elsewhere.focus();
+
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+		expect(elsewhere).toHaveFocus();
+	});
+
+	test('Enter submits, Shift+Enter does not', () => {
+		const onSubmit = vi.fn();
+		render(<CommentInput value="hi" onChange={noop} onSubmit={onSubmit} isSubmitting={false} autoFocus />);
+
+		const box = screen.getByRole('textbox');
+		fireEvent.keyDown(box, { key: 'Enter', shiftKey: true });
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		fireEvent.keyDown(box, { key: 'Enter' });
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## The bug

Opening an alert's **Comments** tab and typing did nothing — focus stayed on the tab button, so you had to click into "Write a comment…" before the caret appeared. Two clicks to write one comment.

## The fix

`CommentInput` focuses its textarea on mount, and `CommentsWall` opts in. The wall only mounts when the user opens Comments (Radix `TabsContent` doesn't `forceMount`), so "opened Comments" == "ready to type" — no autofocus fires while browsing the Details tab.

Two details worth knowing:

- **The focus is deferred one animation frame.** The Comments tab activates on *mousedown*, so the wall mounts **before** the browser applies that click's default focus to the trigger. Focusing synchronously gets silently overwritten — I hit exactly this in the browser and confirmed `document.activeElement` came back as the `role="tab"` button.
- **Sending hands the caret back.** The Send button goes `disabled` on submit, which drops focus to `<body>`, so a second comment needed a fresh click. The handback is skipped if focus has meanwhile landed on something the user chose, so it can't steal focus from a deliberate click elsewhere.

Both comment entry points are covered: the **Comments tab** and **Latest comment → View all** in the Details tab.

## Verification

- 79/79 client tests, 5 new (focus on mount, no focus without the prop, handback after send, no theft when the user moved on, Enter/Shift+Enter unchanged)
- Live in Chrome: clicked Comments → typed immediately, text landed; clicked Send → kept typing the next comment with no click; also verified via the "View all" path. Test comments cleaned up afterwards.

Closes the "comments needs an extra click" report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)