### PR TITLE
fix: a newly selected alert opens on Details, not the previous alert's tab

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsDrawer/AlertDetailsDrawer.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsDrawer/AlertDetailsDrawer.tsx
@@ -98,7 +98,9 @@ export const AlertDetailsDrawer = ({
 				</Button>
 			</div>
 
-			<Tabs defaultValue="details" className="flex-1 flex flex-col min-h-0">
+			{/* Keyed by alert: switching alerts remounts the tabs, so a new alert always
+			    opens on Details instead of inheriting the previous one's tab. */}
+			<Tabs key={renderedAlert?.id} defaultValue="details" className="flex-1 flex flex-col min-h-0">
 				<TabsList className="mx-4 mt-4 grid w-auto grid-cols-2">
 					<TabsTrigger value="details" className="gap-1.5">
 						<Info className="h-4 w-4" />

--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel.tsx
@@ -1,7 +1,7 @@
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
 import { Alert } from '@OpsiMate/shared';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TimeRange } from '../../AlertsTable/TimeFilter/TimeFilter.types';
 import { AlertDetailsBody } from '../AlertDetailsBody';
 import { AlertDetailsHeader } from '../AlertDetailsHeader';
@@ -39,6 +39,14 @@ export const AlertDetailsPanel = ({
 	const [tab, setTab] = useState('details');
 	const { width, panelRef, startResizing, resetWidth } = useResizablePanelWidth();
 	const { signal, broadcast } = useSectionsExpandBroadcast();
+
+	// Selecting a different alert starts a fresh read: back to Details, not whichever tab
+	// the previous alert was left on. Reading someone else's comment thread is never what
+	// clicking a new row means — and it also drops the half-typed comment that belonged to
+	// the alert you just left (the wall unmounts with the tab).
+	useEffect(() => {
+		setTab('details');
+	}, [alert.id]);
 
 	return (
 		<div

--- a/apps/client/src/test/AlertDetailsPanel.test.tsx
+++ b/apps/client/src/test/AlertDetailsPanel.test.tsx
@@ -1,0 +1,67 @@
+import { Alert, AlertStatus } from '@OpsiMate/shared';
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { AlertDetailsPanel } from '@/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel';
+import { render } from './test-utils';
+
+// The panel's body, footer and comment wall all fetch; stub them out so this test is about
+// tab behavior alone.
+vi.mock('@/components/Alerts/AlertDetails/AlertDetailsBody', () => ({
+	AlertDetailsBody: () => <div>details-body</div>,
+}));
+vi.mock('@/components/Alerts/AlertDetails/AlertFooterActions', () => ({
+	AlertFooterActions: () => <div>footer-actions</div>,
+}));
+vi.mock('@/components/Alerts/AlertDetails/CommentsWall', () => ({
+	CommentsWall: ({ alertId }: { alertId: string }) => <div>{`comments-wall:${alertId}`}</div>,
+}));
+vi.mock('@/components/Alerts/AlertDetails/hooks', () => ({
+	useAlertHistory: () => null,
+}));
+
+const mkAlert = (id: string): Alert =>
+	({
+		id,
+		alertName: `alert ${id}`,
+		type: 'Grafana',
+		status: 'firing',
+		severity: 'info',
+		tags: {},
+		startsAt: new Date(0).toISOString(),
+		updatedAt: new Date(0).toISOString(),
+		createdAt: new Date(0).toISOString(),
+		isSilenced: false,
+	}) as unknown as Alert;
+
+const noop = () => {};
+
+// Radix activates a tab on mousedown, not click.
+const openComments = () => fireEvent.mouseDown(screen.getByRole('tab', { name: /comments/i }));
+
+describe('AlertDetailsPanel tab reset', () => {
+	test('selecting a different alert returns to Details', () => {
+		const { rerender } = render(<AlertDetailsPanel alert={mkAlert('a')} isActive onClose={noop} />);
+
+		openComments();
+		expect(screen.getByText('comments-wall:a')).toBeInTheDocument();
+
+		rerender(<AlertDetailsPanel alert={mkAlert('b')} isActive onClose={noop} />);
+
+		expect(screen.getByText('details-body')).toBeInTheDocument();
+		expect(screen.queryByText('comments-wall:b')).not.toBeInTheDocument();
+	});
+
+	test('the same alert re-rendering (polling) keeps the open tab', () => {
+		const { rerender } = render(<AlertDetailsPanel alert={mkAlert('a')} isActive onClose={noop} />);
+
+		openComments();
+		expect(screen.getByText('comments-wall:a')).toBeInTheDocument();
+
+		// Same id, fresh object — an alerts refetch must not yank the user off Comments.
+		rerender(
+			<AlertDetailsPanel alert={{ ...mkAlert('a'), status: AlertStatus.RESOLVED }} isActive onClose={noop} />
+		);
+
+		expect(screen.getByText('comments-wall:a')).toBeInTheDocument();
+	});
+});

--- a/apps/client/src/test/AlertDetailsPanel.test.tsx
+++ b/apps/client/src/test/AlertDetailsPanel.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, test, vi } from 'vitest';
 import { AlertDetailsPanel } from '@/components/Alerts/AlertDetails/AlertDetailsPanel/AlertDetailsPanel';
 import { render } from './test-utils';
 
+// The stub echoes the alert id it was handed, which is what proves the wall is showing the
+// newly selected alert rather than the previous one.
+interface MockCommentsWallProps {
+	alertId: string;
+}
+
 // The panel's body, footer and comment wall all fetch; stub them out so this test is about
 // tab behavior alone.
 vi.mock('@/components/Alerts/AlertDetails/AlertDetailsBody', () => ({
@@ -13,7 +19,7 @@ vi.mock('@/components/Alerts/AlertDetails/AlertFooterActions', () => ({
 	AlertFooterActions: () => <div>footer-actions</div>,
 }));
 vi.mock('@/components/Alerts/AlertDetails/CommentsWall', () => ({
-	CommentsWall: ({ alertId }: { alertId: string }) => <div>{`comments-wall:${alertId}`}</div>,
+	CommentsWall: ({ alertId }: MockCommentsWallProps) => <div>{`comments-wall:${alertId}`}</div>,
 }));
 vi.mock('@/components/Alerts/AlertDetails/hooks', () => ({
 	useAlertHistory: () => null,


### PR DESCRIPTION
## The bug

With the details panel on **Comments**, clicking a different alert row kept the panel on Comments — so you landed in the new alert's comment thread instead of its details. Clicking a row means "show me this alert", never "show me its comments".

## The fix

`AlertDetailsPanel` resets its tab to Details when the selected **alert id** changes.

Two things worth noting:

- **Keyed on `alert.id`, not the alert object.** Alerts poll every few seconds, and a refetch hands the panel a fresh object for the *same* alert. Resetting on that would yank the user off Comments mid-read; the test pins this.
- **It also clears a stale draft.** `CommentsWall` holds the in-progress comment in state, and it previously stayed mounted across alert switches — so a comment typed for alert A sat in alert B's box, one click from being posted to the wrong alert. Returning to Details unmounts the wall and drops that draft.

The `AlertDetailsDrawer` variant (exported but not currently rendered anywhere) had the same flaw in its uncontrolled `Tabs`; keying them by alert id fixes it there too.

## Verification

- 76/76 client tests, 2 new: switching alerts returns to Details, and a same-id re-render keeps the open tab
- Live in Chrome: opened Comments on one alert, clicked another row → new alert opened on Details
- Incidental find, now documented in the test: Radix activates a tab on **mousedown**, so `fireEvent.click` never switches tabs — the test uses `mouseDown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alert details now open on the Details tab when switching between alerts.
  * The selected tab is preserved when refreshing data for the same alert.
* **Tests**
  * Added coverage for tab behavior when changing alerts and updating alert data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->