### PR TITLE
fix: enrich resolved alerts the same way active ones are enriched

### DIFF
--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -270,9 +270,19 @@ export class AlertBL {
 	async getAllResolvedAlerts(): Promise<Alert[]> {
 		try {
 			logger.info('Fetching all resolved alerts');
-			return await this.attachLastComments(
-				await this.attachFiringTimes(await this.resolvedAlertRepo.getAllResolvedAlerts())
-			);
+			let alerts = await this.resolvedAlertRepo.getAllResolvedAlerts();
+			// Resolved alerts are enriched exactly like active ones. The added tags, links,
+			// summary and severity are how an alert is DESCRIBED, and that description
+			// shouldn't change the instant it resolves: the Resolved view would show raw
+			// values, and any action whose filter matches an enrichment-added tag would
+			// stop offering itself (and would template its payload from unenriched values).
+			//
+			// Mute policies are deliberately not applied here: muting suppresses a firing
+			// alert, so "Muted" carries no meaning once the alert is resolved.
+			if (this.enrichmentBL) {
+				alerts = await this.enrichmentBL.applyEnrichments(alerts);
+			}
+			return await this.attachLastComments(await this.attachFiringTimes(alerts));
 		} catch (error) {
 			logger.error('Error fetching resolved alerts', error);
 			throw error;

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1567,6 +1567,86 @@ describe('Alerts API', () => {
 			});
 		});
 
+		// An alert's enrichment describes it — the added tags, links, summary and severity
+		// shouldn't vanish the moment it resolves. Actions matter here too: an action whose
+		// filter matches an enrichment-added tag has to keep matching on the Resolved view,
+		// and its payload templates from these same values.
+		describe('enrichment on resolved alerts', () => {
+			test('a resolved alert carries the same enrichment an active one gets', async () => {
+				await app
+					.post('/api/v1/alerts/custom')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send({
+						id: 'resolved-enrich-1',
+						tags: { host: 'db-9' },
+						alertName: 'Resolved Enrichment Test',
+					});
+
+				const created = await app
+					.post('/api/v1/enrichments')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send({
+						name: 'tag and link resolved alerts',
+						nameContains: 'Resolved Enrichment',
+						addFields: [{ key: 'team', value: 'platform-{{label.host}}' }],
+						addLinks: [{ label: 'Runbook', icon: 'grafana', url: 'https://rb.example.com/{{label.host}}' }],
+					});
+				expect(created.status).toBe(201);
+
+				const active = await app.get('/api/v1/alerts').set('Authorization', `Bearer ${jwtToken}`);
+				const activeAlert = active.body.data.alerts.find((a: { id: string }) => a.id === 'resolved-enrich-1');
+				expect(activeAlert.tags.team).toBe('platform-db-9');
+
+				// Resolve it, then read it back off the resolved listing.
+				const resolved = await app
+					.delete('/api/v1/alerts/resolved-enrich-1')
+					.set('Authorization', `Bearer ${jwtToken}`);
+				expect(resolved.status).toBe(200);
+
+				const list = await app.get('/api/v1/alerts/resolved').set('Authorization', `Bearer ${jwtToken}`);
+				const alert = list.body.data.alerts.find((a: { id: string }) => a.id === 'resolved-enrich-1');
+				expect(alert).toBeDefined();
+				expect(alert.tags.team).toBe('platform-db-9');
+				expect(alert.links).toEqual([
+					{ label: 'Runbook', icon: 'grafana', url: 'https://rb.example.com/db-9' },
+				]);
+				expect(alert.appliedEnrichments).toHaveLength(1);
+
+				await app
+					.delete(`/api/v1/enrichments/${created.body.data.id}`)
+					.set('Authorization', `Bearer ${jwtToken}`);
+				await app
+					.delete('/api/v1/alerts/resolved/resolved-enrich-1')
+					.set('Authorization', `Bearer ${jwtToken}`);
+			});
+
+			test('a mute policy does not mark a resolved alert muted', async () => {
+				await app
+					.post('/api/v1/alerts/custom')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send({ id: 'resolved-mute-1', tags: {}, alertName: 'Resolved Mute Test' });
+
+				const policy = await app
+					.post('/api/v1/mute-policies')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send({ name: 'mute resolved test', nameContains: 'Resolved Mute', matchAll: false });
+				expect(policy.status).toBe(201);
+
+				await app.delete('/api/v1/alerts/resolved-mute-1').set('Authorization', `Bearer ${jwtToken}`);
+
+				const list = await app.get('/api/v1/alerts/resolved').set('Authorization', `Bearer ${jwtToken}`);
+				const alert = list.body.data.alerts.find((a: { id: string }) => a.id === 'resolved-mute-1');
+				expect(alert).toBeDefined();
+				// Muting suppresses a FIRING alert; it carries no meaning once resolved.
+				expect(alert.isMuted).toBeFalsy();
+
+				await app
+					.delete(`/api/v1/mute-policies/${policy.body.data.id}`)
+					.set('Authorization', `Bearer ${jwtToken}`);
+				await app.delete('/api/v1/alerts/resolved/resolved-mute-1').set('Authorization', `Bearer ${jwtToken}`);
+			});
+		});
+
 		describe('Active to Resolved transition', () => {
 			test('should resolve alert with resolved status when deleted', async () => {
 				// Create a new alert


### PR DESCRIPTION
## Why they weren't

`AlertBL.getAllAlerts()` enriches before returning:

```ts
let alerts = await this.alertRepo.getAllAlerts();
if (this.enrichmentBL) alerts = await this.enrichmentBL.applyEnrichments(alerts);
```

`getAllResolvedAlerts()` only attached comments and firing times — it never called `applyEnrichments`. Nothing was disabling enrichment for resolved alerts; that code path simply never ran it.

Measured on one alert, before and after resolving it, with a rule that adds a link and rewrites a tag:

| | `links` | `tags` |
|---|---|---|
| active | `[{label: 'dashobard', …}]` | `{service: '👍kafka'}` |
| resolved (before this fix) | `null` | `{service: 'kafka'}` |
| resolved (after) | `[{label: 'dashobard', …}]` | `{service: '👍kafka'}` |

## Actions

Not a second bug — the same gap. Action filters match on `alert.tags` (`actionMatchesAlert` in `AlertActions.tsx`), with no status check anywhere, so:

- an action keyed to a **plain** tag or name always worked on resolved alerts
- an action keyed to an **enrichment-added** tag stopped matching the moment the alert resolved, because the alert arrived unenriched
- worse, `runOnAlert` builds its context from the alert the client passes in, so an action run from the Resolved view would have templated its payload from raw values

Enriching the read path fixes all three.

## What I deliberately did NOT change

**Mute policies stay active-only.** `markMuted` is still not applied to resolved alerts: muting suppresses a *firing* alert, so "Muted" carries no meaning once it's resolved, and the Resolved view suspends the status filter anyway. A test pins this so the asymmetry is intentional and documented rather than looking like the same oversight.

## Verification

- 140 server tests (2 new): a resolved alert carries the same enrichment an active one gets (templated tag + link + `appliedEnrichments`), and a mute policy does **not** mark a resolved alert muted
- Mutation-tested: removing the `applyEnrichments` call makes the new test fail, so it genuinely pins the fix
- Live against the real API — the same alert resolved before/after a server restart produced the table above, with `appliedEnrichments: [{id: 13, …}, {id: 14, …}]`
- Live in the UI: the resolved alert's details panel now shows the enrichment label `service: 👍kafka`, the enrichment link, and its matching Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard alert settings now save and restore assignment splitting and severity-color preferences.
  * Existing severity-color preferences are preserved when dashboard settings are not yet configured.
  * Dashboard APIs support validating and persisting the new alert settings.

* **Bug Fixes**
  * Resolved alerts now retain enrichment details while continuing to exclude mute policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->