### PR TITLE
feat: silenced-alerts toolbar toggle, and the filter sidebar back to its old width

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -21,7 +21,7 @@ import { Dashboard } from '@/hooks/queries/dashboards/dashboards.types';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
-import { Bell, CheckCircle2, ChevronDown, Columns2, LayoutList, Palette, WrapText } from 'lucide-react';
+import { Bell, BellOff, CheckCircle2, ChevronDown, Columns2, LayoutList, Palette, WrapText } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { AlertsFilterPanel } from '.';
 import { AlertDetailsPanel } from './AlertDetails';
@@ -32,6 +32,7 @@ import { AssignmentPane } from './AssignmentPane';
 import { VerticalSplit } from './VerticalSplit';
 import { ACTIONS_COLUMN } from './AlertsTable/AlertsTable.constants';
 import { filterAlerts } from './AlertsTable/AlertsTable.utils';
+import { areSilencedAlertsShown, toggleSilencedAlerts } from './utils/silenced.utils';
 import { AlertTab } from './AlertsTable/AlertsTable.types';
 import { SearchBar } from './AlertsTable/SearchBar';
 import { TimeFilter, createEmptyTimeRange } from './AlertsTable/TimeFilter';
@@ -201,6 +202,13 @@ const Alerts = () => {
 	const handleFilterChange = (newFilters: Record<string, string[]>) => {
 		updateDashboardField('filters', newFilters);
 	};
+
+	// Derived from the filters themselves rather than tracked separately, so the button and
+	// the sidebar's Status section always describe the same thing. The count comes from the
+	// unfiltered active list — the point of the button is to reveal alerts the current
+	// filters are hiding, so it has to say how many are out there.
+	const silencedShown = areSilencedAlertsShown(dashboardState.filters);
+	const silencedCount = useMemo(() => alerts.filter((a) => a.isSilenced).length, [alerts]);
 
 	const filteredAlerts = useAlertsFiltering(alerts, {
 		filters: dashboardState.filters,
@@ -592,6 +600,30 @@ const Alerts = () => {
 										onSearchChange={(term) => updateDashboardField('query', term)}
 									/>
 								</div>
+
+								{/* Silenced alerts are usually filtered out (a dashboard's status filter
+								    typically pins Firing), and digging into the sidebar to check what's
+								    silenced is a lot of clicks for a routine question. Active-only: the
+								    Resolved and All views suspend the status filter, so the button would
+								    be inert there. */}
+								{activeTab === AlertTab.Active && (
+									<Button
+										variant={silencedShown ? 'default' : 'outline'}
+										size="sm"
+										onClick={() => handleFilterChange(toggleSilencedAlerts(dashboardState.filters))}
+										className="gap-1.5 shrink-0"
+										title={silencedShown ? 'Hide silenced alerts' : 'Show silenced alerts'}
+										aria-pressed={silencedShown}
+									>
+										<BellOff className="h-4 w-4" />
+										<span className="hidden lg:inline">Silenced</span>
+										{silencedCount > 0 && (
+											<span className="text-[10px] font-semibold tabular-nums opacity-80">
+												{silencedCount}
+											</span>
+										)}
+									</Button>
+								)}
 
 								{activeTab === AlertTab.Active && (
 									<Button

--- a/apps/client/src/components/Alerts/utils/silenced.utils.ts
+++ b/apps/client/src/components/Alerts/utils/silenced.utils.ts
@@ -1,0 +1,62 @@
+import { ActiveFilters } from '@/components/shared';
+
+// The status value a silenced alert presents (see useAlertsFiltering's getFieldValue).
+export const SILENCED_STATUS = 'Silenced';
+
+const STATUS_FIELD = 'status';
+const STATUS_EXCLUDE_FIELD = '!status';
+
+// Whether silenced alerts are part of what the current filters show. Three cases, because
+// the status filter has two halves: an include list and an exclusion list ("!status").
+//   - excluded outright        → hidden
+//   - an include list is set   → shown only if it lists Silenced
+//   - no status filter at all  → everything shows, silenced included
+export const areSilencedAlertsShown = (filters: ActiveFilters): boolean => {
+	if ((filters[STATUS_EXCLUDE_FIELD] ?? []).includes(SILENCED_STATUS)) return false;
+	const included = filters[STATUS_FIELD] ?? [];
+	if (included.length > 0) return included.includes(SILENCED_STATUS);
+	return true;
+};
+
+// Flips silenced alerts in or out of view, expressed in the same filters record the sidebar
+// edits — so the toolbar button and the Status section can never disagree, and the change
+// persists with the dashboard like any other filter.
+//
+// Hiding has to handle both shapes: with an include list, dropping Silenced from it is
+// enough; with no include list, only an exclusion can express "everything but silenced".
+// The empty-include case matters too — removing the last included value would lift the
+// filter entirely and bring silenced alerts back, so that case switches to an exclusion.
+export const toggleSilencedAlerts = (filters: ActiveFilters): ActiveFilters => {
+	const included = filters[STATUS_FIELD] ?? [];
+	const excluded = filters[STATUS_EXCLUDE_FIELD] ?? [];
+	const next = { ...filters };
+
+	const setField = (field: string, values: string[]) => {
+		if (values.length === 0) {
+			delete next[field];
+		} else {
+			next[field] = values;
+		}
+	};
+
+	if (areSilencedAlertsShown(filters)) {
+		const withoutSilenced = included.filter((v) => v !== SILENCED_STATUS);
+		if (included.length > 0 && withoutSilenced.length > 0) {
+			setField(STATUS_FIELD, withoutSilenced);
+			setField(STATUS_EXCLUDE_FIELD, excluded);
+		} else {
+			// No include list to narrow (or narrowing it would empty it): exclude instead.
+			setField(STATUS_FIELD, withoutSilenced);
+			setField(STATUS_EXCLUDE_FIELD, [...excluded, SILENCED_STATUS]);
+		}
+		return next;
+	}
+
+	setField(
+		STATUS_EXCLUDE_FIELD,
+		excluded.filter((v) => v !== SILENCED_STATUS)
+	);
+	// An include list that omits Silenced would keep hiding them once the exclusion is gone.
+	setField(STATUS_FIELD, included.length > 0 ? [...new Set([...included, SILENCED_STATUS])] : included);
+	return next;
+};

--- a/apps/client/src/components/shared/FilterSidebar.tsx
+++ b/apps/client/src/components/shared/FilterSidebar.tsx
@@ -15,7 +15,7 @@ export const FilterSidebar = ({ children, collapsed, onToggle, className }: Filt
 		<div
 			className={cn(
 				'border-r border-border transition-all duration-300 ease-in-out shrink-0 relative',
-				collapsed ? 'w-12' : 'w-64',
+				collapsed ? 'w-12' : 'w-48',
 				className
 			)}
 		>

--- a/apps/client/src/test/silenced.utils.test.ts
+++ b/apps/client/src/test/silenced.utils.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+import {
+	areSilencedAlertsShown,
+	SILENCED_STATUS,
+	toggleSilencedAlerts,
+} from '@/components/Alerts/utils/silenced.utils';
+
+// The toolbar's silenced toggle writes the same status filter the sidebar edits, so the two
+// always agree. Round-tripping matters most: whatever the filters look like, one click hides
+// silenced alerts and a second click brings them back.
+
+describe('areSilencedAlertsShown', () => {
+	test('no status filter shows everything, silenced included', () => {
+		expect(areSilencedAlertsShown({})).toBe(true);
+		expect(areSilencedAlertsShown({ severity: ['Critical'] })).toBe(true);
+	});
+
+	test('an include list decides by membership', () => {
+		expect(areSilencedAlertsShown({ status: ['Firing'] })).toBe(false);
+		expect(areSilencedAlertsShown({ status: ['Firing', 'Silenced'] })).toBe(true);
+	});
+
+	test('an exclusion wins over an include list', () => {
+		expect(areSilencedAlertsShown({ status: ['Firing', 'Silenced'], '!status': ['Silenced'] })).toBe(false);
+	});
+
+	test('an empty include list is no constraint', () => {
+		expect(areSilencedAlertsShown({ status: [] })).toBe(true);
+	});
+});
+
+describe('toggleSilencedAlerts', () => {
+	test('adds Silenced to an include list that omits it', () => {
+		expect(toggleSilencedAlerts({ status: ['Firing'] })).toEqual({ status: ['Firing', SILENCED_STATUS] });
+	});
+
+	test('drops Silenced from an include list that has other values', () => {
+		expect(toggleSilencedAlerts({ status: ['Firing', 'Silenced'] })).toEqual({ status: ['Firing'] });
+	});
+
+	test('excludes when there is no include list to narrow', () => {
+		expect(toggleSilencedAlerts({})).toEqual({ '!status': [SILENCED_STATUS] });
+	});
+
+	// Dropping the only included value would lift the status filter and bring silenced
+	// alerts straight back — the toggle has to express this as an exclusion instead.
+	test('status: [Silenced] alone becomes an exclusion, not an empty filter', () => {
+		expect(toggleSilencedAlerts({ status: ['Silenced'] })).toEqual({ '!status': [SILENCED_STATUS] });
+	});
+
+	test('removes an existing exclusion to show them again', () => {
+		expect(toggleSilencedAlerts({ '!status': [SILENCED_STATUS] })).toEqual({});
+	});
+
+	test('clearing an exclusion also re-adds Silenced to an include list', () => {
+		expect(toggleSilencedAlerts({ status: ['Firing'], '!status': [SILENCED_STATUS] })).toEqual({
+			status: ['Firing', SILENCED_STATUS],
+		});
+	});
+
+	test('leaves other fields and other excluded statuses alone', () => {
+		expect(toggleSilencedAlerts({ severity: ['Critical'], '!status': ['Muted'] })).toEqual({
+			severity: ['Critical'],
+			'!status': ['Muted', SILENCED_STATUS],
+		});
+	});
+
+	test('never duplicates Silenced in the include list', () => {
+		const once = toggleSilencedAlerts({ status: ['Firing'], '!status': [SILENCED_STATUS] });
+		expect(once.status).toEqual(['Firing', SILENCED_STATUS]);
+	});
+
+	test.each([
+		[{}],
+		[{ status: ['Firing'] }],
+		[{ status: ['Firing', 'Silenced'] }],
+		[{ status: ['Silenced'] }],
+		[{ severity: ['Critical'] }],
+		[{ '!status': ['Muted'] }],
+	])('two clicks restore what the filters showed: %j', (filters) => {
+		const shown = areSilencedAlertsShown(filters);
+		const once = toggleSilencedAlerts(filters);
+		expect(areSilencedAlertsShown(once)).toBe(!shown);
+		expect(areSilencedAlertsShown(toggleSilencedAlerts(once))).toBe(shown);
+	});
+});


### PR DESCRIPTION
Two small things from the same report.

## 1. Sidebar back to its old width

`w-64` → **`w-48`**. I widened it in #818 to stop option labels being clipped, but that gave up too much page width.

The two changes that actually fixed readability stay, so labels are still far more legible than before #818:
- long labels wrap to two lines instead of hard-truncating
- the ⊕/⊖ controls only occupy space on hover, so they no longer tax every row's label with ~44px they weren't using

## 2. "Silenced" toolbar button

Silenced alerts are normally invisible — a dashboard's status filter typically pins `Firing` — and checking what's silenced meant opening the sidebar, finding the Status section, and ticking a value. Now it's one click, and the button carries the count so you can see there *is* something silenced without opening anything:

`🔕 Silenced 1`

**It writes the same status filter the sidebar edits** rather than keeping a flag of its own, so the two can never disagree: the sidebar's Status section and the Active Filters chips move with it, and it persists with the dashboard like any other filter change.

Hiding has two shapes, which is where the real logic lives:

| Current filter | Hiding silenced becomes |
|---|---|
| `status: ['Firing','Silenced']` | `status: ['Firing']` |
| no status filter | `!status: ['Silenced']` (reuses #818's exclusions) |
| `status: ['Silenced']` only | `!status: ['Silenced']` — dropping the last included value would lift the filter and bring them straight back |

Active-only, like "Split by owner": the Resolved and All views suspend the status filter, so the button would be inert there.

## Verification

- 111 client tests, **18 new** covering the toggle logic — including a `test.each` round-trip property asserting that for every filter shape, one click flips silenced visibility and a second click restores it
- Live in Chrome with a real silenced alert, all three paths:
  1. with `status: ['Firing']` → click showed the silenced alert (22 → 23), sidebar gained `Silenced 1` with a pinned ⊕ and a matching chip; clicking again restored exactly the previous filter
  2. with no status filter → button correctly read as "on", and clicking produced the red `Status ≠ Silenced` exclusion (23 → 22)
  3. dashboard dirty-state behaved like any filter edit
- Sidebar width confirmed visually at the old size, with long labels still wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toolbar toggle for showing or hiding silenced alerts in the Active alerts view.
  * Displays the current count of silenced active alerts with a visual indicator.
  * Preserves existing alert filters when toggling silenced alerts.

* **Style**
  * Reduced the expanded filter sidebar width for a more compact layout.

* **Tests**
  * Added coverage for silenced-alert filtering and toggle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->