### PR TITLE
fix: comment timestamps are ISO UTC, so they render in local time

### DIFF
--- a/apps/server/src/dal/alertCommentsRepository.ts
+++ b/apps/server/src/dal/alertCommentsRepository.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { runAsync } from './db';
 import { AlertCommentRow, ForeignKeyInfoRow } from './models.ts';
 import { AlertComment } from '@OpsiMate/shared';
+import { toIsoUtc } from '../utils/time';
 
 export class AlertCommentsRepository {
 	private db: Database.Database;
@@ -70,8 +71,12 @@ export class AlertCommentsRepository {
 			alertId: row.alert_id,
 			userId: row.user_id,
 			comment: row.comment,
-			createdAt: row.created_at,
-			updatedAt: row.updated_at,
+			// CURRENT_TIMESTAMP is UTC but carries no timezone marker, so the client's
+			// new Date(...) reads it as LOCAL and a fresh comment shows up hours old
+			// (UTC+3 → "3h ago" the moment you post it). Normalized here, the same way
+			// the alert repositories do it.
+			createdAt: toIsoUtc(row.created_at),
+			updatedAt: toIsoUtc(row.updated_at),
 		};
 	};
 

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -2140,3 +2140,62 @@ describe('Synthesized last-update history entry', () => {
 		expect(entries.some((e) => e.date === T && e.eventType === 'status_changed')).toBe(true);
 	});
 });
+
+// SQLite's CURRENT_TIMESTAMP is UTC but carries no timezone marker, and the client feeds
+// these straight into new Date(...) — which reads a bare "YYYY-MM-DD HH:MM:SS" as LOCAL
+// time. Unnormalized, a comment posted right now renders as hours old for anyone east of
+// UTC (a UTC+3 viewer saw "3h ago" on a fresh comment).
+describe('Comment timestamps are ISO UTC', () => {
+	const alertId = 'comment-tz-alert';
+
+	test('createdAt and updatedAt come back as ISO UTC, matching real time', async () => {
+		await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ id: alertId, tags: {}, alertName: 'Comment TZ Test' });
+
+		const before = Date.now();
+		const created = await app
+			.post(`/api/v1/alerts/${alertId}/comments`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ comment: 'what time is it' });
+		expect(created.status).toBe(201);
+
+		const list = await app.get(`/api/v1/alerts/${alertId}/comments`).set('Authorization', `Bearer ${jwtToken}`);
+		const comment = (list.body.data.comments as { comment: string; createdAt: string; updatedAt: string }[]).find(
+			(c) => c.comment === 'what time is it'
+		);
+		expect(comment).toBeDefined();
+
+		// Explicitly UTC — this is what stops new Date() reading it as local time.
+		expect(comment!.createdAt).toMatch(/Z$/);
+		expect(comment!.updatedAt).toMatch(/Z$/);
+
+		// The instant it names must be NOW, not now shifted by a timezone offset. A whole
+		// hour of tolerance would still pass under the old behaviour in UTC+1, so this is
+		// deliberately tight (SQLite truncates to the second, hence the small allowance).
+		const parsed = new Date(comment!.createdAt).getTime();
+		expect(Math.abs(parsed - before)).toBeLessThan(5_000);
+	});
+
+	test('an edited comment keeps a UTC updatedAt', async () => {
+		const created = await app
+			.post(`/api/v1/alerts/${alertId}/comments`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ comment: 'before edit' });
+		expect(created.status).toBe(201);
+
+		const updated = await app
+			.patch(`/api/v1/alerts/comments/${created.body.data.comment.id}`)
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ comment: 'after edit' });
+		expect(updated.status).toBe(200);
+
+		const list = await app.get(`/api/v1/alerts/${alertId}/comments`).set('Authorization', `Bearer ${jwtToken}`);
+		const comment = (list.body.data.comments as { comment: string; updatedAt: string }[]).find(
+			(c) => c.comment === 'after edit'
+		);
+		expect(comment!.updatedAt).toMatch(/Z$/);
+		expect(Math.abs(new Date(comment!.updatedAt).getTime() - Date.now())).toBeLessThan(5_000);
+	});
+});

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -2145,6 +2145,13 @@ describe('Synthesized last-update history entry', () => {
 // these straight into new Date(...) — which reads a bare "YYYY-MM-DD HH:MM:SS" as LOCAL
 // time. Unnormalized, a comment posted right now renders as hours old for anyone east of
 // UTC (a UTC+3 viewer saw "3h ago" on a fresh comment).
+interface CommentResponse {
+	id: string;
+	comment: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
 describe('Comment timestamps are ISO UTC', () => {
 	const alertId = 'comment-tz-alert';
 
@@ -2162,9 +2169,7 @@ describe('Comment timestamps are ISO UTC', () => {
 		expect(created.status).toBe(201);
 
 		const list = await app.get(`/api/v1/alerts/${alertId}/comments`).set('Authorization', `Bearer ${jwtToken}`);
-		const comment = (list.body.data.comments as { comment: string; createdAt: string; updatedAt: string }[]).find(
-			(c) => c.comment === 'what time is it'
-		);
+		const comment = (list.body.data.comments as CommentResponse[]).find((c) => c.comment === 'what time is it');
 		expect(comment).toBeDefined();
 
 		// Explicitly UTC — this is what stops new Date() reading it as local time.
@@ -2192,9 +2197,7 @@ describe('Comment timestamps are ISO UTC', () => {
 		expect(updated.status).toBe(200);
 
 		const list = await app.get(`/api/v1/alerts/${alertId}/comments`).set('Authorization', `Bearer ${jwtToken}`);
-		const comment = (list.body.data.comments as { comment: string; updatedAt: string }[]).find(
-			(c) => c.comment === 'after edit'
-		);
+		const comment = (list.body.data.comments as CommentResponse[]).find((c) => c.comment === 'after edit');
 		expect(comment!.updatedAt).toMatch(/Z$/);
 		expect(Math.abs(new Date(comment!.updatedAt).getTime() - Date.now())).toBeLessThan(5_000);
 	});


### PR DESCRIPTION
Yes — comments were being sent as UTC in a format the browser then read as local time.

## The bug

SQLite's `CURRENT_TIMESTAMP` is UTC but writes no timezone marker, and the comment repository passed the raw string through:

```json
"createdAt": "2026-08-10 14:16:31"
```

`new Date("2026-08-10 14:16:31")` is not an ISO string, so browsers parse it as **local** time. Every comment therefore appeared shifted by the viewer's UTC offset — in UTC+3, a comment posted *seconds* ago rendered as **"3h ago"**.

## The fix

`toIsoUtc` in the row mapper, so the API returns `"2026-08-10T14:16:31.000Z"`. That's the same treatment `alertRepository` and `resolvedAlertRepository` already give their timestamps — and the helper's own comment describes precisely this trap, so comments were simply missed when it was introduced.

Fixing it at the source covers both renderers at once (the comments wall and the "Latest comment" preview in the details panel) instead of patching each call site.

## Verification

- 142 server tests, 2 new: `createdAt`/`updatedAt` come back ending in `Z` **and** name an instant within 5s of now (a loose tolerance would still pass the buggy behaviour in UTC+1, so it's deliberately tight), plus an edited comment keeping a UTC `updatedAt`
- Mutation-tested: reverting the mapper makes both new tests fail
- Live in Chrome: a comment stored at `14:16 UTC`, viewed at `21:49 UTC`, now reads **"7h ago"**. Before the fix the same comment read **"10h ago"** — exactly the 3-hour offset

## Same bug class elsewhere (not fixed here)

Worth knowing, since it's the same root cause:

- **The audit log already carries a client-side workaround** — `parseUTCDate()` in `Settings.tsx` appends `'Z'` by hand. It works, but it's the second approach to the same problem; server-side normalization would let it go away.
- Several repositories still return raw `created_at` (`actionRepository`, `enrichmentRepository`, `mutePolicyRepository`, `dashboardRepository`, `integrationRepository`, `userRepository`). Those surface as **date-only** displays in the UI, so the shift is invisible except within a few hours of midnight. Happy to sweep them in a follow-up if you want it consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alert comment creation and edit timestamps are now consistently returned as ISO-formatted UTC values.
  * Improved timestamp accuracy across different time zones.

* **Tests**
  * Added coverage for timestamps when comments are created and edited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->