### PR TITLE
feat(alerts): server-side filtering, search, sorting and pagination (Phase 1)

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -878,6 +878,7 @@ const Alerts = () => {
 								<div className="shrink-0">
 									<AlertsSelectionBar
 										selectedAlerts={selectedAlerts}
+										hasUnloadedMatches={showPartialNotice}
 										onClearSelection={() => setSelectedAlerts([])}
 										onSilenceAll={confirmSilenceAllSelected}
 										onUnsilenceAll={handleUnsilenceAllSelected}

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -10,7 +10,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useDashboard } from '@/context/DashboardContext';
 import { deserializeTimeRange, readLegacySeverityColors, serializeTimeRange } from '@/context/DashboardContext.utils';
-import { useAlerts, useResolvedAlerts, useDeleteResolvedAlert, useMarkAlertRead } from '@/hooks/queries/alerts';
+import {
+	useAlertFacets,
+	useAlerts,
+	useResolvedAlerts,
+	useDeleteResolvedAlert,
+	useMarkAlertRead,
+} from '@/hooks/queries/alerts';
 import {
 	useCreateDashboard,
 	useDeleteDashboard,
@@ -19,6 +25,7 @@ import {
 } from '@/hooks/queries/dashboards';
 import { Dashboard } from '@/hooks/queries/dashboards/dashboards.types';
 import { useToast } from '@/hooks/use-toast';
+import { AlertFacetsResponse } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { Bell, BellOff, CheckCircle2, ChevronDown, Columns2, LayoutList, Palette, WrapText } from 'lucide-react';
@@ -36,6 +43,8 @@ import { areSilencedAlertsShown, toggleSilencedAlerts } from './utils/silenced.u
 import { AlertTab } from './AlertsTable/AlertsTable.types';
 import { SearchBar } from './AlertsTable/SearchBar';
 import { TimeFilter, createEmptyTimeRange } from './AlertsTable/TimeFilter';
+import { resolveTimeRange } from './AlertsTable/TimeFilter/TimeFilter.utils';
+import { TimeRange } from './AlertsTable/TimeFilter/TimeFilter.types';
 import { DashboardHeader } from './DashboardHeader';
 import { DashboardSettingsDrawer } from './DashboardSettingsDrawer';
 import {
@@ -56,10 +65,55 @@ const ALERT_TAB_OPTIONS = [
 	{ value: AlertTab.All, label: 'All', Icon: LayoutList },
 ] as const;
 
+// One page of server-filtered alerts; views under this size (the overwhelmingly common
+// case) load completely and every client-side behavior — grouping, sorting, select-all —
+// is exactly what it was before server-side querying existed.
+const SERVER_PAGE_SIZE = 500;
+
+// Rolling presets re-anchor to "now" continuously; a raw resolved window in the query
+// would mint a new cache key every tick. Rounding the window OUTWARD to the minute keeps
+// the key stable for a minute at a time while the server window stays a superset — the
+// client pipeline narrows to the exact rolling window on top.
+const toCoarseWindow = (timeRange: TimeRange | undefined) => {
+	if (!timeRange) return { from: null, to: null };
+	const resolved = resolveTimeRange(timeRange);
+	const floorMinute = (d: Date) => new Date(Math.floor(d.getTime() / 60000) * 60000);
+	const ceilMinute = (d: Date) => new Date(Math.ceil(d.getTime() / 60000) * 60000);
+	return {
+		from: resolved.from ? floorMinute(resolved.from).toISOString() : null,
+		to: resolved.to ? ceilMinute(resolved.to).toISOString() : null,
+	};
+};
+
+// The All view describes active + resolved together: counts add, tag keys union.
+const mergeFacetsResponses = (a?: AlertFacetsResponse, b?: AlertFacetsResponse): AlertFacetsResponse | undefined => {
+	if (!a || !b) return a ?? b;
+	const facets: Record<string, Record<string, number>> = {};
+	for (const field of new Set([...Object.keys(a.facets), ...Object.keys(b.facets)])) {
+		const merged: Record<string, number> = { ...a.facets[field] };
+		for (const [value, count] of Object.entries(b.facets[field] ?? {})) {
+			merged[value] = (merged[value] ?? 0) + count;
+		}
+		facets[field] = merged;
+	}
+	const tagKeys = new Map<string, { key: string; label: string; values: Set<string> }>();
+	for (const tk of [...a.tagKeys, ...b.tagKeys]) {
+		const entry = tagKeys.get(tk.key) ?? { key: tk.key, label: tk.label, values: new Set<string>() };
+		tk.values.forEach((v) => entry.values.add(v));
+		tagKeys.set(tk.key, entry);
+	}
+	return {
+		facets,
+		total: a.total + b.total,
+		silencedTotal: a.silencedTotal + b.silencedTotal,
+		tagKeys: Array.from(tagKeys.values())
+			.map((e) => ({ key: e.key, label: e.label, values: Array.from(e.values).sort() }))
+			.sort((x, y) => x.label.localeCompare(y.label)),
+	};
+};
+
 const Alerts = () => {
 	const { toast } = useToast();
-	const { data: alerts = [], isLoading, refetch } = useAlerts();
-	const { data: resolvedAlerts = [], isLoading: isLoadingResolved, refetch: refetchResolved } = useResolvedAlerts();
 	const { data: dashboards = [] } = useGetDashboards();
 	const createDashboardMutation = useCreateDashboard();
 	const updateDashboardMutation = useUpdateDashboard();
@@ -77,6 +131,48 @@ const Alerts = () => {
 		setInitialState,
 	} = useDashboard();
 
+	// The Resolved and All VIEWS run with the status filter suspended — not deleted
+	// (see the view notes below). The SERVER query always uses the suspended record:
+	// it's the superset of all three views, so one active query serves them all and the
+	// client pipeline narrows by status exactly as it always has.
+	const statusSuspendedFilters = useMemo(() => {
+		const { status: _status, ['!status']: _notStatus, ...rest } = dashboardState.filters;
+		return rest;
+	}, [dashboardState.filters]);
+
+	const serverQuery = useMemo(() => {
+		const window = toCoarseWindow(dashboardState.timeRange);
+		return {
+			filters: statusSuspendedFilters,
+			from: window.from,
+			to: window.to,
+			search: dashboardState.query || undefined,
+			// Newest-first regardless of the table's visual sort: when a view exceeds the
+			// page size, the page holds the most recent matches — the table re-sorts the
+			// loaded set client-side as it always has.
+			sort: 'startsAt',
+			dir: 'desc' as const,
+			limit: SERVER_PAGE_SIZE,
+		};
+	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query]);
+
+	const {
+		data: alerts = [],
+		total: activeTotal,
+		isLoading,
+		refetch,
+		fetchNextPage: fetchMoreActive,
+		hasNextPage: hasMoreActive,
+	} = useAlerts(serverQuery);
+	const {
+		data: resolvedAlerts = [],
+		total: resolvedTotal,
+		isLoading: isLoadingResolved,
+		refetch: refetchResolved,
+		fetchNextPage: fetchMoreResolved,
+		hasNextPage: hasMoreResolved,
+	} = useResolvedAlerts(serverQuery);
+
 	const [activeTab, setActiveTab] = useState<AlertTab>(AlertTab.Active);
 	const [selectedAlerts, setSelectedAlerts] = useState<Alert[]>([]);
 	const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
@@ -89,7 +185,31 @@ const Alerts = () => {
 	const { filterPanelCollapsed, toggleFilterPanelCollapsed } = useFilterPanelCollapsed();
 
 	const allAlerts = useMemo(() => [...alerts, ...resolvedAlerts], [alerts, resolvedAlerts]);
-	const tagKeys = useAlertTagKeys(allAlerts);
+
+	// Sidebar facets, tag keys and the silenced total come from the server, computed
+	// over the RAW dataset — the loaded page is filtered, so deriving them from it
+	// would shrink the sidebar to what's already visible. Three variants because each
+	// view facets under its own effective filters. The client derivation stays as the
+	// fallback (facets request in flight or failed).
+	const activeFacets = useAlertFacets(dashboardState.filters);
+	const suspendedActiveFacets = useAlertFacets(statusSuspendedFilters);
+	const resolvedFacets = useAlertFacets(statusSuspendedFilters, { resolved: true });
+
+	const clientTagKeys = useAlertTagKeys(allAlerts);
+	const tagKeys = useMemo(() => {
+		const active = activeFacets.data?.tagKeys;
+		const resolved = resolvedFacets.data?.tagKeys;
+		if (!active && !resolved) return clientTagKeys;
+		const merged = new Map<string, { key: string; label: string; values: Set<string> }>();
+		for (const tk of [...(active ?? []), ...(resolved ?? [])]) {
+			const entry = merged.get(tk.key) ?? { key: tk.key, label: tk.label, values: new Set<string>() };
+			tk.values.forEach((v) => entry.values.add(v));
+			merged.set(tk.key, entry);
+		}
+		return Array.from(merged.values())
+			.map((e) => ({ key: e.key, label: e.label, values: Array.from(e.values).sort() }))
+			.sort((a, b) => a.label.localeCompare(b.label));
+	}, [activeFacets.data?.tagKeys, resolvedFacets.data?.tagKeys, clientTagKeys]);
 
 	const currentAlertData =
 		activeTab === AlertTab.Active ? alerts : activeTab === AlertTab.Resolved ? resolvedAlerts : allAlerts;
@@ -209,23 +329,17 @@ const Alerts = () => {
 	// unfiltered active list — the point of the button is to reveal alerts the current
 	// filters are hiding, so it has to say how many are out there.
 	const silencedShown = areSilencedAlertsShown(dashboardState.filters);
-	const silencedCount = useMemo(() => alerts.filter((a) => a.isSilenced).length, [alerts]);
+	const silencedCount = activeFacets.data?.silencedTotal ?? alerts.filter((a) => a.isSilenced).length;
 
 	const filteredAlerts = useAlertsFiltering(alerts, {
 		filters: dashboardState.filters,
 		timeRange: dashboardState.timeRange,
 	});
-	// The Resolved and All VIEWS run with the status filter suspended — not deleted.
 	// Resolved: an active status like Firing/Silenced can never match resolved alerts,
 	// so applying it would make the view silently empty. All: the tab's promise is
 	// every alert regardless of status, so a status filter picked on Active must not
-	// follow the user there. Wiping the filter instead (the old behavior) destroyed
-	// the user's stored filter — and dirtied the dashboard — just for peeking at
-	// another tab; the stored filters stay intact and Active keeps applying them.
-	const statusSuspendedFilters = useMemo(() => {
-		const { status: _status, ['!status']: _notStatus, ...rest } = dashboardState.filters;
-		return rest;
-	}, [dashboardState.filters]);
+	// follow the user there — the stored filters stay intact and Active keeps applying
+	// them (narrowing the suspended superset the server returned).
 	const resolvedViewAlerts = useAlertsFiltering(resolvedAlerts, {
 		filters: statusSuspendedFilters,
 		timeRange: dashboardState.timeRange,
@@ -387,11 +501,39 @@ const Alerts = () => {
 			run: (comment) => void handleResolveAllSelected(comment),
 		});
 
+	// Next-page triggers per view; undefined when the loaded set is complete so the
+	// table doesn't keep firing at the bottom of a fully-loaded list.
+	const loadMoreActive = hasMoreActive ? () => void fetchMoreActive() : undefined;
+	const loadMoreResolved = hasMoreResolved ? () => void fetchMoreResolved() : undefined;
+	const loadMoreAll =
+		hasMoreActive || hasMoreResolved
+			? () => {
+					if (hasMoreActive) void fetchMoreActive();
+					if (hasMoreResolved) void fetchMoreResolved();
+				}
+			: undefined;
+
+	// Over-limit notice: the view holds the newest page of a larger match set.
+	const loadedCount =
+		activeTab === AlertTab.Active
+			? alerts.length
+			: activeTab === AlertTab.Resolved
+				? resolvedAlerts.length
+				: allAlerts.length;
+	const matchTotal =
+		activeTab === AlertTab.Active
+			? activeTotal
+			: activeTab === AlertTab.Resolved
+				? resolvedTotal
+				: activeTotal + resolvedTotal;
+	const showPartialNotice = matchTotal > loadedCount;
+
 	// Active-tab alerts table, parameterized by the alert list so it can render full-width
 	// or inside one of the split-by-assignment panes without duplicating the prop wiring.
 	const renderActiveAlertsTable = (list: Alert[]) => (
 		<AlertsTable
 			alerts={list}
+			onEndReached={loadMoreActive}
 			onSilenceAlert={confirmSilenceAlert}
 			onUnsilenceAlert={handleUnsilenceAlert}
 			onDeleteAlert={confirmResolveAlert}
@@ -501,6 +643,13 @@ const Alerts = () => {
 				<FilterSidebar collapsed={filterPanelCollapsed} onToggle={toggleFilterPanelCollapsed}>
 					<AlertsFilterPanel
 						alerts={currentAlertData}
+						serverFacets={
+							activeTab === AlertTab.Active
+								? activeFacets.data
+								: activeTab === AlertTab.Resolved
+									? resolvedFacets.data
+									: mergeFacetsResponses(suspendedActiveFacets.data, resolvedFacets.data)
+						}
 						filters={dashboardState.filters}
 						onFilterChange={handleFilterChange}
 						collapsed={filterPanelCollapsed}
@@ -666,6 +815,13 @@ const Alerts = () => {
 							</div>
 						</div>
 
+						{showPartialNotice && (
+							<div className="shrink-0 px-4 py-1.5 text-xs text-muted-foreground bg-muted/50 border-b border-border">
+								Showing the {loadedCount.toLocaleString()} most recent of {matchTotal.toLocaleString()}{' '}
+								matching alerts — scroll to load more, or narrow the filters.
+							</div>
+						)}
+
 						{activeTab === AlertTab.Active ? (
 							<>
 								{splitByAssignment ? (
@@ -731,6 +887,7 @@ const Alerts = () => {
 							>
 								<AlertsTable
 									alerts={resolvedViewAlerts}
+									onEndReached={loadMoreResolved}
 									onSilenceAlert={undefined}
 									onUnsilenceAlert={undefined}
 									onDeleteAlert={confirmDeleteResolvedAlert}
@@ -770,6 +927,7 @@ const Alerts = () => {
 							>
 								<AlertsTable
 									alerts={filteredAllAlerts}
+									onEndReached={loadMoreAll}
 									onSilenceAlert={confirmSilenceAlert}
 									onUnsilenceAlert={handleUnsilenceAlert}
 									onDeleteAlert={confirmDeleteAnyAlert}

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -513,7 +513,8 @@ const Alerts = () => {
 				}
 			: undefined;
 
-	// Over-limit notice: the view holds the newest page of a larger match set.
+	// Over-limit notice: counts describe what's LOADED for the view's query — the table
+	// may show fewer rows after the client narrows by status/search on top.
 	const loadedCount =
 		activeTab === AlertTab.Active
 			? alerts.length
@@ -817,8 +818,8 @@ const Alerts = () => {
 
 						{showPartialNotice && (
 							<div className="shrink-0 px-4 py-1.5 text-xs text-muted-foreground bg-muted/50 border-b border-border">
-								Showing the {loadedCount.toLocaleString()} most recent of {matchTotal.toLocaleString()}{' '}
-								matching alerts — scroll to load more, or narrow the filters.
+								Loaded the {loadedCount.toLocaleString()} most recent of {matchTotal.toLocaleString()}{' '}
+								alerts matching this view — scroll to load more, or narrow the filters.
 							</div>
 						)}
 

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -157,9 +157,22 @@ const Alerts = () => {
 	// load". So when a group-by is active the query drops its limit and the server returns
 	// every matching alert (filtered/searched/time-bounded), which the client groups
 	// exactly as it always did. Flat views keep the page limit and infinite-scroll.
+	const [activeTab, setActiveTab] = useState<AlertTab>(AlertTab.Active);
+
 	const isGrouping = dashboardState.groupBy.length > 0;
 
-	const serverQuery = useMemo(() => {
+	// Grouping loads the WHOLE matching set, but only for the list you're actually
+	// looking at. Active alerts number in the thousands; resolved can be 50-60k, so
+	// pulling all resolved to group the active tab would be a huge wasted download.
+	// Active data feeds the Active and All views; resolved data feeds Resolved and All.
+	// The non-viewed list stays a cheap 500-row page — enough for its tab-dropdown count
+	// (the response carries the true total regardless of limit) and a ready first page.
+	// Both queries already honor the time range, so narrowing the window trims what a
+	// grouped view has to load.
+	const activeViewed = activeTab === AlertTab.Active || activeTab === AlertTab.All;
+	const resolvedViewed = activeTab === AlertTab.Resolved || activeTab === AlertTab.All;
+
+	const baseQuery = useMemo(() => {
 		const window = toCoarseWindow(dashboardState.timeRange);
 		return {
 			filters: statusSuspendedFilters,
@@ -168,9 +181,17 @@ const Alerts = () => {
 			search: dashboardState.query || undefined,
 			sort: alertSort.field,
 			dir: alertSort.dir,
-			limit: isGrouping ? undefined : SERVER_PAGE_SIZE,
 		};
-	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort, isGrouping]);
+	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort]);
+
+	const activeQuery = useMemo(
+		() => ({ ...baseQuery, limit: isGrouping && activeViewed ? undefined : SERVER_PAGE_SIZE }),
+		[baseQuery, isGrouping, activeViewed]
+	);
+	const resolvedQuery = useMemo(
+		() => ({ ...baseQuery, limit: isGrouping && resolvedViewed ? undefined : SERVER_PAGE_SIZE }),
+		[baseQuery, isGrouping, resolvedViewed]
+	);
 
 	const {
 		data: alerts = [],
@@ -179,7 +200,7 @@ const Alerts = () => {
 		refetch,
 		fetchNextPage: fetchMoreActive,
 		hasNextPage: hasMoreActive,
-	} = useAlerts(serverQuery, { refetchIntervalMs: isGrouping ? GROUPED_POLL_MS : undefined });
+	} = useAlerts(activeQuery, { refetchIntervalMs: isGrouping && activeViewed ? GROUPED_POLL_MS : undefined });
 	const {
 		data: resolvedAlerts = [],
 		total: resolvedTotal,
@@ -187,9 +208,10 @@ const Alerts = () => {
 		refetch: refetchResolved,
 		fetchNextPage: fetchMoreResolved,
 		hasNextPage: hasMoreResolved,
-	} = useResolvedAlerts(serverQuery, { refetchIntervalMs: isGrouping ? GROUPED_POLL_MS : undefined });
+	} = useResolvedAlerts(resolvedQuery, {
+		refetchIntervalMs: isGrouping && resolvedViewed ? GROUPED_POLL_MS : undefined,
+	});
 
-	const [activeTab, setActiveTab] = useState<AlertTab>(AlertTab.Active);
 	const [selectedAlerts, setSelectedAlerts] = useState<Alert[]>([]);
 	const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
 	const [showDashboardSettings, setShowDashboardSettings] = useState(false);

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -38,7 +38,6 @@ import { AlertsTable } from './AlertsTable';
 import { AssignmentPane } from './AssignmentPane';
 import { VerticalSplit } from './VerticalSplit';
 import { ACTIONS_COLUMN } from './AlertsTable/AlertsTable.constants';
-import { filterAlerts } from './AlertsTable/AlertsTable.utils';
 import { areSilencedAlertsShown, toggleSilencedAlerts } from './utils/silenced.utils';
 import { AlertTab } from './AlertsTable/AlertsTable.types';
 import { SearchBar } from './AlertsTable/SearchBar';
@@ -140,6 +139,15 @@ const Alerts = () => {
 		return rest;
 	}, [dashboardState.filters]);
 
+	// Sort drives the server query: the loaded page is the top-N under this sort across
+	// ALL matching alerts, so sorting by severity surfaces the most critical in the whole
+	// dataset — not a reorder of the newest 500. Kept as view-local state (not a dashboard
+	// field) so changing it doesn't dirty the dashboard, matching the prior behaviour.
+	const [alertSort, setAlertSort] = useState<{ field: string; dir: 'asc' | 'desc' }>({
+		field: 'startsAt',
+		dir: 'desc',
+	});
+
 	const serverQuery = useMemo(() => {
 		const window = toCoarseWindow(dashboardState.timeRange);
 		return {
@@ -147,14 +155,11 @@ const Alerts = () => {
 			from: window.from,
 			to: window.to,
 			search: dashboardState.query || undefined,
-			// Newest-first regardless of the table's visual sort: when a view exceeds the
-			// page size, the page holds the most recent matches — the table re-sorts the
-			// loaded set client-side as it always has.
-			sort: 'startsAt',
-			dir: 'desc' as const,
+			sort: alertSort.field,
+			dir: alertSort.dir,
 			limit: SERVER_PAGE_SIZE,
 		};
-	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query]);
+	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort]);
 
 	const {
 		data: alerts = [],
@@ -535,6 +540,9 @@ const Alerts = () => {
 		<AlertsTable
 			alerts={list}
 			onEndReached={loadMoreActive}
+			sortField={alertSort.field}
+			sortDirection={alertSort.dir}
+			onSortChange={(field, dir) => setAlertSort({ field, dir })}
 			onSilenceAlert={confirmSilenceAlert}
 			onUnsilenceAlert={handleUnsilenceAlert}
 			onDeleteAlert={confirmResolveAlert}
@@ -629,14 +637,19 @@ const Alerts = () => {
 	// switching isn't needed just to see how many resolved/all alerts there are. The
 	// search term is applied too — AlertsTable filters by it after the sidebar/time
 	// filters, and the counts must agree with the rows actually shown.
+	// Counts come from the SERVER totals, not the loaded page — so a search matching 1,800
+	// alerts reads "1,800", not "500". Each total already reflects that tab's filters,
+	// search and time window. Caveat: the active query suspends the status filter (it's the
+	// superset serving all three tabs), so with a status filter applied — e.g. silenced
+	// hidden — the Active count is the pre-status total. It signals "more than loaded"
+	// correctly; an exact status-aware count would need its own count query.
 	const tabCounts: Record<AlertTab, number> = useMemo(
 		() => ({
-			[AlertTab.Active]: filterAlerts(filteredAlerts, dashboardState.query).length,
-			// Resolved and All mirror their views, which suspend the status filter (see above).
-			[AlertTab.Resolved]: filterAlerts(resolvedViewAlerts, dashboardState.query).length,
-			[AlertTab.All]: filterAlerts(filteredAllAlerts, dashboardState.query).length,
+			[AlertTab.Active]: activeTotal,
+			[AlertTab.Resolved]: resolvedTotal,
+			[AlertTab.All]: activeTotal + resolvedTotal,
 		}),
-		[filteredAlerts, resolvedViewAlerts, filteredAllAlerts, dashboardState.query]
+		[activeTotal, resolvedTotal]
 	);
 	return (
 		<DashboardLayout>
@@ -889,6 +902,9 @@ const Alerts = () => {
 								<AlertsTable
 									alerts={resolvedViewAlerts}
 									onEndReached={loadMoreResolved}
+									sortField={alertSort.field}
+									sortDirection={alertSort.dir}
+									onSortChange={(field, dir) => setAlertSort({ field, dir })}
 									onSilenceAlert={undefined}
 									onUnsilenceAlert={undefined}
 									onDeleteAlert={confirmDeleteResolvedAlert}
@@ -929,6 +945,9 @@ const Alerts = () => {
 								<AlertsTable
 									alerts={filteredAllAlerts}
 									onEndReached={loadMoreAll}
+									sortField={alertSort.field}
+									sortDirection={alertSort.dir}
+									onSortChange={(field, dir) => setAlertSort({ field, dir })}
 									onSilenceAlert={confirmSilenceAlert}
 									onUnsilenceAlert={handleUnsilenceAlert}
 									onDeleteAlert={confirmDeleteAnyAlert}

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -69,6 +69,10 @@ const ALERT_TAB_OPTIONS = [
 // is exactly what it was before server-side querying existed.
 const SERVER_PAGE_SIZE = 500;
 
+// Grouping loads the whole matching set, so a 5s poll would re-download all of it every
+// tick. A grouped overview doesn't need second-by-second freshness — poll it slower.
+const GROUPED_POLL_MS = 20 * 1000;
+
 // Rolling presets re-anchor to "now" continuously; a raw resolved window in the query
 // would mint a new cache key every tick. Rounding the window OUTWARD to the minute keeps
 // the key stable for a minute at a time while the server window stays a superset — the
@@ -148,6 +152,13 @@ const Alerts = () => {
 		dir: 'desc',
 	});
 
+	// Grouping needs the WHOLE matching set, or headers count only the loaded page — a
+	// user grouping by severity must see 3,332 criticals, not "the 166 that happened to
+	// load". So when a group-by is active the query drops its limit and the server returns
+	// every matching alert (filtered/searched/time-bounded), which the client groups
+	// exactly as it always did. Flat views keep the page limit and infinite-scroll.
+	const isGrouping = dashboardState.groupBy.length > 0;
+
 	const serverQuery = useMemo(() => {
 		const window = toCoarseWindow(dashboardState.timeRange);
 		return {
@@ -157,9 +168,9 @@ const Alerts = () => {
 			search: dashboardState.query || undefined,
 			sort: alertSort.field,
 			dir: alertSort.dir,
-			limit: SERVER_PAGE_SIZE,
+			limit: isGrouping ? undefined : SERVER_PAGE_SIZE,
 		};
-	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort]);
+	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort, isGrouping]);
 
 	const {
 		data: alerts = [],
@@ -168,7 +179,7 @@ const Alerts = () => {
 		refetch,
 		fetchNextPage: fetchMoreActive,
 		hasNextPage: hasMoreActive,
-	} = useAlerts(serverQuery);
+	} = useAlerts(serverQuery, { refetchIntervalMs: isGrouping ? GROUPED_POLL_MS : undefined });
 	const {
 		data: resolvedAlerts = [],
 		total: resolvedTotal,
@@ -176,7 +187,7 @@ const Alerts = () => {
 		refetch: refetchResolved,
 		fetchNextPage: fetchMoreResolved,
 		hasNextPage: hasMoreResolved,
-	} = useResolvedAlerts(serverQuery);
+	} = useResolvedAlerts(serverQuery, { refetchIntervalMs: isGrouping ? GROUPED_POLL_MS : undefined });
 
 	const [activeTab, setActiveTab] = useState<AlertTab>(AlertTab.Active);
 	const [selectedAlerts, setSelectedAlerts] = useState<Alert[]>([]);
@@ -518,8 +529,8 @@ const Alerts = () => {
 				}
 			: undefined;
 
-	// Over-limit notice: counts describe what's LOADED for the view's query — the table
-	// may show fewer rows after the client narrows by status/search on top.
+	// Loaded vs total for the current view — drives the select-all scope note (bulk
+	// actions apply only to loaded rows). Equal in grouping mode, where everything loads.
 	const loadedCount =
 		activeTab === AlertTab.Active
 			? alerts.length
@@ -828,13 +839,6 @@ const Alerts = () => {
 								/>
 							</div>
 						</div>
-
-						{showPartialNotice && (
-							<div className="shrink-0 px-4 py-1.5 text-xs text-muted-foreground bg-muted/50 border-b border-border">
-								Loaded the {loadedCount.toLocaleString()} most recent of {matchTotal.toLocaleString()}{' '}
-								alerts matching this view — scroll to load more, or narrow the filters.
-							</div>
-						)}
 
 						{activeTab === AlertTab.Active ? (
 							<>

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -1,13 +1,16 @@
 import { ActiveFilters, FilterFacets, FilterPanel, FilterPanelConfig } from '@/components/shared';
 import { useUsers } from '@/hooks/queries/users';
 import { extractTagKeyFromColumnId, getTagKeyColumnId, isTagKeyColumn, TagKeyInfo } from '@/types';
-import { Alert } from '@OpsiMate/shared';
+import { AlertFacetsResponse } from '@/lib/api';
+import { Alert, getAlertFilterFieldValue } from '@OpsiMate/shared';
 import { useMemo } from 'react';
-import { getOwnerDisplayName } from './utils/owner.utils';
-import { getAlertSeverity, SEVERITY_LABELS } from './utils/severity.utils';
 
 interface AlertsFilterPanelProps {
 	alerts: Alert[];
+	// Server-computed facet counts over the RAW dataset (the alerts prop only holds the
+	// filtered page). When present these win; the client derivation from `alerts`
+	// remains the fallback so the playground and error paths keep a working sidebar.
+	serverFacets?: AlertFacetsResponse | null;
 	filters: ActiveFilters;
 	onFilterChange: (filters: ActiveFilters) => void;
 	collapsed?: boolean;
@@ -30,6 +33,7 @@ const BASE_FIELD_LABELS: Record<string, string> = {
 
 export const AlertsFilterPanel = ({
 	alerts,
+	serverFacets,
 	filters,
 	onFilterChange,
 	collapsed = false,
@@ -70,29 +74,24 @@ export const AlertsFilterPanel = ({
 	}, [filters, hideStatusFilter]);
 
 	const facets: FilterFacets = useMemo(() => {
-		// The value an alert presents for a given filter field, matching useAlertsFiltering's
-		// logic — including null for unknown fields, which never constrain (a stale persisted
-		// filter must not zero out every facet).
-		const getFieldValue = (alert: Alert, field: string): string | null => {
-			if (isTagKeyColumn(field)) {
-				const tagKey = extractTagKeyFromColumnId(field);
-				return tagKey ? alert.tags?.[tagKey] || '' : null;
-			}
-			switch (field) {
-				case 'status':
-					return alert.isSilenced ? 'Silenced' : alert.isMuted ? 'Muted' : capitalizeFirst(alert.status);
-				case 'severity':
-					return SEVERITY_LABELS[getAlertSeverity(alert)];
-				case 'type':
-					return getAlertType(alert);
-				case 'alertName':
-					return alert.alertName ?? '';
-				case 'owner':
-					return getOwnerDisplayName(alert.ownerId, users);
-				default:
-					return null;
-			}
-		};
+		if (serverFacets) {
+			const result: FilterFacets = {};
+			filterConfig.fields.forEach((field) => {
+				const counts = serverFacets.facets[field] ?? {};
+				result[field] = Object.entries(counts)
+					.map(([value, count]) => ({ value, count }))
+					.sort((a, b) => {
+						if (b.count !== a.count) return b.count - a.count;
+						return a.value.localeCompare(b.value);
+					});
+			});
+			return result;
+		}
+
+		// The value an alert presents for a filter field — the shared implementation the
+		// table filter and the server both use, so the sidebar can never disagree with them.
+		const getFieldValue = (alert: Alert, field: string): string | null =>
+			getAlertFilterFieldValue(alert, field, users);
 
 		// Faceted filtering: an alert counts toward a field's facet only if it passes every OTHER
 		// active filter (includes AND "!field" exclusions). A facet never constrains itself —
@@ -129,7 +128,7 @@ export const AlertsFilterPanel = ({
 		});
 
 		return result;
-	}, [alerts, filterConfig.fields, effectiveFilters, users]);
+	}, [alerts, serverFacets, filterConfig.fields, effectiveFilters, users]);
 
 	return (
 		<FilterPanel

--- a/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
+++ b/apps/client/src/components/Alerts/AlertsFilterPanel.tsx
@@ -43,12 +43,6 @@ export const AlertsFilterPanel = ({
 }: AlertsFilterPanelProps) => {
 	const { data: users = [] } = useUsers();
 
-	const getAlertType = (alert: Alert): string => {
-		return alert.type || 'Custom';
-	};
-
-	const capitalizeFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
-
 	const filterConfig: FilterPanelConfig = useMemo(() => {
 		const tagKeyFields = tagKeys.map((tk) => getTagKeyColumnId(tk.key));
 		const tagKeyLabels: Record<string, string> = {};

--- a/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
@@ -26,6 +26,11 @@ export interface AlertsSelectionBarProps {
 	// Adds the same comment to every selected alert (opens the comment dialog).
 	onCommentAll?: () => void;
 	onDeleteAll?: () => void;
+	// True when the current view has matching alerts that are NOT loaded (the "N of M"
+	// banner is showing). Bulk actions apply only to the loaded selection, so the scope
+	// must be explicit — otherwise "Silence all" on a select-all reads as "silence every
+	// matching alert" when it silences only the loaded page.
+	hasUnloadedMatches?: boolean;
 }
 
 export const AlertsSelectionBar = ({
@@ -37,6 +42,7 @@ export const AlertsSelectionBar = ({
 	onResolveAll,
 	onCommentAll,
 	onDeleteAll,
+	hasUnloadedMatches,
 }: AlertsSelectionBarProps) => {
 	const { data: users = [] } = useUsers();
 	const [confirmDelete, setConfirmDelete] = useState(false);
@@ -113,6 +119,11 @@ export const AlertsSelectionBar = ({
 
 			<span className="text-sm font-medium whitespace-nowrap">
 				{selectedAlerts.length} Alert{selectedAlerts.length !== 1 ? 's' : ''} selected
+				{hasUnloadedMatches && (
+					<span className="ml-2 text-xs text-muted-foreground">
+						— actions apply to the loaded alerts only; scroll to load more first
+					</span>
+				)}
 			</span>
 
 			<AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>

--- a/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
@@ -117,8 +117,10 @@ export const AlertsSelectionBar = ({
 				</Button>
 			</div>
 
-			<span className="text-sm font-medium whitespace-nowrap">
-				{selectedAlerts.length} Alert{selectedAlerts.length !== 1 ? 's' : ''} selected
+			<span className="min-w-0 text-sm font-medium">
+				<span className="whitespace-nowrap">
+					{selectedAlerts.length} Alert{selectedAlerts.length !== 1 ? 's' : ''} selected
+				</span>
 				{hasUnloadedMatches && (
 					<span className="ml-2 text-xs text-muted-foreground">
 						— actions apply to the loaded alerts only; scroll to load more first

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -176,17 +176,33 @@ export const AlertsTable = ({
 
 	const virtualItems = virtualizer.getVirtualItems();
 
-	// Infinite scroll: when the rendered window nears the end of what's loaded, ask for
-	// the next page. fetchNextPage dedupes in-flight requests, so firing per render is
-	// safe; the 10-row lead keeps skeleton time mostly out of view at scroll speed.
-	const lastVirtualIndex = virtualItems.length > 0 ? virtualItems[virtualItems.length - 1].index : -1;
+	// Infinite scroll, keyed on actual scroll position: the next page is requested when
+	// the user is within NEAR_BOTTOM_PX of the end of a scrollable list. Rendering-based
+	// triggers ("last row is in the virtual window") misfire on short lists — overscan
+	// keeps the last row permanently rendered, which chain-loads page after page until
+	// the entire dataset is in the browser. The initial check covers arriving back at a
+	// list that is already scrolled to its end; growth from an appended page moves the
+	// bottom away, so it cannot re-fire without the user scrolling again.
 	useEffect(() => {
 		if (!onEndReached) return;
-		if (flatRows.length === 0) return;
-		if (lastVirtualIndex >= flatRows.length - 10) {
-			onEndReached();
-		}
-	}, [onEndReached, lastVirtualIndex, flatRows.length]);
+		const scroller = scrollerRef.current;
+		if (!scroller) return;
+		const NEAR_BOTTOM_PX = 400;
+		const maybeFire = () => {
+			if (scroller.scrollHeight <= scroller.clientHeight + 1) return;
+			// Never at the very top: a barely-scrollable list (content shorter than
+			// viewport + threshold) is "near its bottom" before anyone touches it, and
+			// firing there chain-loads. Requiring real scroll makes the trigger strictly
+			// user-driven.
+			if (scroller.scrollTop === 0) return;
+			if (scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - NEAR_BOTTOM_PX) {
+				onEndReached();
+			}
+		};
+		maybeFire();
+		scroller.addEventListener('scroll', maybeFire, { passive: true });
+		return () => scroller.removeEventListener('scroll', maybeFire);
+	}, [onEndReached, flatRows.length]);
 	const activeStickyHeaders = useStickyHeaders({ flatRows, groupByColumns, virtualItems, virtualizer });
 
 	const orderedColumns = useMemo(() => {

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -49,6 +49,9 @@ const HEADER_ICONS: Record<string, ReactNode> = {
 export const AlertsTable = ({
 	alerts,
 	onEndReached,
+	sortField: controlledSortField,
+	sortDirection: controlledSortDirection,
+	onSortChange,
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
@@ -124,7 +127,12 @@ export const AlertsTable = ({
 
 	const allColumnLabels = useMemo(() => ({ ...COLUMN_LABELS, ...tagKeyColumnLabels }), [tagKeyColumnLabels]);
 
-	const { sortField, sortDirection, sortedAlerts, handleSort } = useAlertSorting(filteredAlerts);
+	const { sortField, sortDirection, sortedAlerts, handleSort } = useAlertSorting(
+		filteredAlerts,
+		controlledSortField,
+		controlledSortDirection,
+		onSortChange
+	);
 	const { groupByColumns, setGroupByColumns, flatRows, toggleGroup, expandAll, collapseAll } = useAlertGrouping(
 		sortedAlerts,
 		allColumnLabels,

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -184,25 +184,35 @@ export const AlertsTable = ({
 
 	const virtualItems = virtualizer.getVirtualItems();
 
-	// Infinite scroll, keyed on actual scroll position: the next page is requested when
-	// the user is within NEAR_BOTTOM_PX of the end of a scrollable list. Rendering-based
-	// triggers ("last row is in the virtual window") misfire on short lists — overscan
-	// keeps the last row permanently rendered, which chain-loads page after page until
-	// the entire dataset is in the browser. The initial check covers arriving back at a
-	// list that is already scrolled to its end; growth from an appended page moves the
-	// bottom away, so it cannot re-fire without the user scrolling again.
+	// Infinite scroll. onEndReached is defined only while more pages exist (the parent
+	// passes undefined once the loaded set is complete), so its presence IS "there is
+	// more to load". Two ways to ask for the next page:
+	//
+	//  - Scrollable list: fire when the user reaches within NEAR_BOTTOM_PX of the bottom.
+	//    A render-based trigger ("last row in the virtual window") can't be used — overscan
+	//    keeps the last row permanently rendered and chain-loads to the whole dataset.
+	//
+	//  - NON-scrollable list while more pages exist: fetch the next page immediately. This
+	//    is the recovery path. The server query suspends the status filter, so status is
+	//    narrowed client-side over the loaded page; if the loaded page happens to hold only
+	//    a screenful of status-matching rows (e.g. Active pinned to Firing while the newest
+	//    500 are almost all silenced), the list can't scroll and a scroll-only trigger would
+	//    strand every matching alert past page 1. Auto-fetching pulls pages until the
+	//    viewport fills or the data is exhausted (onEndReached becomes undefined). It's
+	//    bounded — fetchNextPage dedupes, and the effect re-runs per appended page — so it
+	//    can't chain-load a scrollable list.
 	useEffect(() => {
 		if (!onEndReached) return;
 		const scroller = scrollerRef.current;
 		if (!scroller) return;
 		const NEAR_BOTTOM_PX = 400;
+		const isScrollable = () => scroller.scrollHeight > scroller.clientHeight + 1;
 		const maybeFire = () => {
-			if (scroller.scrollHeight <= scroller.clientHeight + 1) return;
-			// Never at the very top: a barely-scrollable list (content shorter than
-			// viewport + threshold) is "near its bottom" before anyone touches it, and
-			// firing there chain-loads. Requiring real scroll makes the trigger strictly
-			// user-driven.
-			if (scroller.scrollTop === 0) return;
+			if (!onEndReached) return;
+			if (!isScrollable()) {
+				onEndReached();
+				return;
+			}
 			if (scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - NEAR_BOTTOM_PX) {
 				onEndReached();
 			}

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -48,6 +48,7 @@ const HEADER_ICONS: Record<string, ReactNode> = {
 
 export const AlertsTable = ({
 	alerts,
+	onEndReached,
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
@@ -174,6 +175,18 @@ export const AlertsTable = ({
 	}, [expandRows, virtualizer]);
 
 	const virtualItems = virtualizer.getVirtualItems();
+
+	// Infinite scroll: when the rendered window nears the end of what's loaded, ask for
+	// the next page. fetchNextPage dedupes in-flight requests, so firing per render is
+	// safe; the 10-row lead keeps skeleton time mostly out of view at scroll speed.
+	const lastVirtualIndex = virtualItems.length > 0 ? virtualItems[virtualItems.length - 1].index : -1;
+	useEffect(() => {
+		if (!onEndReached) return;
+		if (flatRows.length === 0) return;
+		if (lastVirtualIndex >= flatRows.length - 10) {
+			onEndReached();
+		}
+	}, [onEndReached, lastVirtualIndex, flatRows.length]);
 	const activeStickyHeaders = useStickyHeaders({ flatRows, groupByColumns, virtualItems, virtualizer });
 
 	const orderedColumns = useMemo(() => {

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -14,6 +14,9 @@ export type AlertSortField = string;
 export type SortDirection = 'asc' | 'desc';
 
 export interface AlertsTableProps {
+	// Invoked when the scroll approaches the last loaded row — the parent fetches the
+	// next server page. Absent when the loaded set is complete.
+	onEndReached?: () => void;
 	alerts: Alert[];
 	onSilenceAlert?: (alertId: string) => void;
 	onUnsilenceAlert?: (alertId: string) => void;

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -35,6 +35,11 @@ export interface AlertsTableProps {
 	tagKeyColumnLabels?: Record<string, string>;
 	groupByColumns?: string[];
 	onGroupByChange?: (cols: string[]) => void;
+	// Controlled sort — lifted to the parent so it can drive the SERVER query (the loaded
+	// page becomes the top-N under this sort across all alerts, not a reorder of the page).
+	sortField?: AlertSortField;
+	sortDirection?: SortDirection;
+	onSortChange?: (field: AlertSortField, direction: SortDirection) => void;
 	onColumnToggle?: (column: string) => void;
 	// Persists a user-arranged base-column order (from the column settings drag list).
 	onColumnOrderChange?: (columns: string[]) => void;

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
@@ -1,7 +1,7 @@
 import { UserInfo } from '@/hooks/queries/users';
 import { formatDateTime, formatTime, isSameLocalDay } from '@/lib/datetime';
+import { Alert, searchAlerts, sortAlertsBy } from '@OpsiMate/shared';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
-import { Alert } from '@OpsiMate/shared';
 import { getIntegrationLabel, resolveAlertIntegration } from '../IntegrationAvatar';
 import { getAlertTagsString } from '../utils/alertTags.utils';
 import { getOwnerDisplayName, getOwnerSortKey } from '../utils/owner.utils';
@@ -9,24 +9,9 @@ import { getAlertFix, FIX_LABELS, FIX_RANK } from '../utils/fix.utils';
 import { getAlertSeverity, SEVERITY_LABELS, SEVERITY_RANK } from '../utils/severity.utils';
 import { AlertSortField, FlatGroupItem, GroupNode, GroupStatus, SortDirection } from './AlertsTable.types';
 
-export const filterAlerts = (alerts: Alert[], searchTerm: string): Alert[] => {
-	if (!searchTerm.trim()) return alerts;
-
-	const lower = searchTerm.toLowerCase();
-	return alerts.filter((alert) => {
-		const integration = resolveAlertIntegration(alert);
-		const integrationLabel = getIntegrationLabel(integration).toLowerCase();
-		const tagsString = getAlertTagsString(alert).toLowerCase();
-		return (
-			(alert.alertName && alert.alertName.toLowerCase().includes(lower)) ||
-			(alert.status && alert.status.toLowerCase().includes(lower)) ||
-			tagsString.includes(lower) ||
-			(alert.summary && alert.summary.toLowerCase().includes(lower)) ||
-			(alert.lastComment && alert.lastComment.toLowerCase().includes(lower)) ||
-			integrationLabel.includes(lower)
-		);
-	});
-};
+// Search lives in @OpsiMate/shared (searchAlerts) so a server-side search matches this
+// table's semantics field for field.
+export const filterAlerts = (alerts: Alert[], searchTerm: string): Alert[] => searchAlerts(alerts, searchTerm);
 
 const getTagKeyValue = (alert: Alert, columnId: string): string => {
 	const tagKey = extractTagKeyFromColumnId(columnId);
@@ -34,61 +19,15 @@ const getTagKeyValue = (alert: Alert, columnId: string): string => {
 	return alert.tags?.[tagKey] || '';
 };
 
-// Comparable value for one alert under a sort field; null means "field not sortable".
-const getSortValue = (alert: Alert, sortField: AlertSortField, users: UserInfo[]): string | number | null => {
-	if (isTagKeyColumn(sortField)) {
-		return getTagKeyValue(alert, sortField).toLowerCase();
-	}
-	switch (sortField) {
-		case 'alertName':
-			return alert.alertName.toLowerCase();
-		case 'status':
-			return alert.isSilenced ? 'silenced' : alert.isMuted ? 'muted' : 'firing';
-		case 'severity':
-			// Rank-based so desc = critical first, info last.
-			return SEVERITY_RANK[getAlertSeverity(alert)];
-		case 'fix': {
-			// Rank-based so desc = manual first; unclassified alerts sink to rank 0.
-			const fix = getAlertFix(alert);
-			return fix ? FIX_RANK[fix] : 0;
-		}
-		case 'summary':
-			return (alert.summary || '').toLowerCase();
-		case 'lastComment':
-			return (alert.lastComment || '').toLowerCase();
-		case 'startsAt': {
-			const date = new Date(alert.startsAt);
-			return isNaN(date.getTime()) ? 0 : date.getTime();
-		}
-		case 'updatedAt': {
-			const date = new Date(alert.updatedAt);
-			return isNaN(date.getTime()) ? 0 : date.getTime();
-		}
-		case 'type':
-			return getIntegrationLabel(resolveAlertIntegration(alert)).toLowerCase();
-		case 'owner':
-			return getOwnerSortKey(alert.ownerId, users);
-		default:
-			return null;
-	}
-};
-
+// Sorting lives in @OpsiMate/shared (sortAlertsBy) so server-side pages are ordered
+// exactly as this table would order them; equal keys tiebreak on id, which keeps row
+// order stable across refetches and makes pagination cursors well-defined.
 export const sortAlerts = (
 	alerts: Alert[],
 	sortField: AlertSortField,
 	sortDirection: SortDirection,
 	users: UserInfo[] = []
-): Alert[] => {
-	return [...alerts].sort((a, b) => {
-		const aValue = getSortValue(a, sortField, users);
-		const bValue = getSortValue(b, sortField, users);
-		if (aValue === null || bValue === null) return 0;
-
-		if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
-		if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
-		return 0;
-	});
-};
+): Alert[] => sortAlertsBy(alerts, sortField, sortDirection, users);
 
 // Timestamps from today render time-only — the date part is noise for the rows users
 // care about most; older timestamps keep the full date. Sorting is unaffected: it runs

--- a/apps/client/src/components/Alerts/AlertsTable/SearchBar/SearchBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/SearchBar/SearchBar.tsx
@@ -1,19 +1,39 @@
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 export interface SearchBarProps {
 	searchTerm: string;
 	onSearchChange: (searchTerm: string) => void;
 }
 
+// Search runs on the SERVER now (it always did — the term flows into the alerts query),
+// so an un-debounced input fired a request per keystroke and dirtied the dashboard on
+// every character. The input stays instant against local state; the term is pushed to the
+// parent (and thus the server query) only after a short pause. An external change to
+// searchTerm — a dashboard load or a reset — resyncs the field without echoing back.
+const SEARCH_DEBOUNCE_MS = 300;
+
 export const SearchBar = ({ searchTerm, onSearchChange }: SearchBarProps) => {
+	const [value, setValue] = useState(searchTerm);
+
+	useEffect(() => {
+		setValue(searchTerm);
+	}, [searchTerm]);
+
+	useEffect(() => {
+		if (value === searchTerm) return;
+		const timer = setTimeout(() => onSearchChange(value), SEARCH_DEBOUNCE_MS);
+		return () => clearTimeout(timer);
+	}, [value, searchTerm, onSearchChange]);
+
 	return (
 		<div className="relative flex-1 max-w-sm">
 			<Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
 			<Input
 				placeholder="Search alerts..."
-				value={searchTerm}
-				onChange={(e) => onSearchChange(e.target.value)}
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
 				className="h-7 pl-7 pr-2 text-sm"
 			/>
 		</div>

--- a/apps/client/src/components/Alerts/AlertsTable/SearchBar/SearchBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/SearchBar/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export interface SearchBarProps {
 	searchTerm: string;
@@ -17,15 +17,22 @@ const SEARCH_DEBOUNCE_MS = 300;
 export const SearchBar = ({ searchTerm, onSearchChange }: SearchBarProps) => {
 	const [value, setValue] = useState(searchTerm);
 
+	// Read the latest callback through a ref so the debounce effect does NOT depend on it.
+	// The parent passes a fresh closure every render, and a parent re-render (the 5s poll)
+	// while a term is pending would otherwise clear and restart the timer — delaying the
+	// search. Keyed only on value/searchTerm now, the timer survives unrelated re-renders.
+	const onSearchChangeRef = useRef(onSearchChange);
+	onSearchChangeRef.current = onSearchChange;
+
 	useEffect(() => {
 		setValue(searchTerm);
 	}, [searchTerm]);
 
 	useEffect(() => {
 		if (value === searchTerm) return;
-		const timer = setTimeout(() => onSearchChange(value), SEARCH_DEBOUNCE_MS);
+		const timer = setTimeout(() => onSearchChangeRef.current(value), SEARCH_DEBOUNCE_MS);
 		return () => clearTimeout(timer);
-	}, [value, searchTerm, onSearchChange]);
+	}, [value, searchTerm]);
 
 	return (
 		<div className="relative flex-1 max-w-sm">

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertSorting.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertSorting.ts
@@ -4,10 +4,30 @@ import { useMemo, useState } from 'react';
 import { AlertSortField, SortDirection } from '../AlertsTable.types';
 import { sortAlerts } from '../AlertsTable.utils';
 
-export const useAlertSorting = (filteredAlerts: Alert[]) => {
+// Sort can be CONTROLLED by the parent (Alerts.tsx lifts it up to drive the server query,
+// so the loaded page is the top-N under this sort across the whole dataset — not just a
+// reorder of the newest 500). When uncontrolled, it holds its own state, preserving the
+// standalone behaviour of any table rendered without a parent-managed sort. Either way the
+// loaded page is re-sorted client-side with the same shared engine the server uses, so the
+// visual order is identical and updates instantly on a header click.
+const nextDirectionFor = (field: AlertSortField, current: AlertSortField, currentDir: SortDirection): SortDirection => {
+	if (current === field) return currentDir === 'asc' ? 'desc' : 'asc';
+	// Time columns: newest first; severity/fix: highest rank first (all desc by default).
+	return field === 'startsAt' || field === 'updatedAt' || field === 'severity' || field === 'fix' ? 'desc' : 'asc';
+};
+
+export const useAlertSorting = (
+	filteredAlerts: Alert[],
+	controlledSortField?: AlertSortField,
+	controlledSortDirection?: SortDirection,
+	onSortChange?: (field: AlertSortField, direction: SortDirection) => void
+) => {
 	const { data: users = [] } = useUsers();
-	const [sortField, setSortField] = useState<AlertSortField>('startsAt');
-	const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+	const [localSortField, setLocalSortField] = useState<AlertSortField>('startsAt');
+	const [localSortDirection, setLocalSortDirection] = useState<SortDirection>('desc');
+
+	const sortField = controlledSortField !== undefined ? controlledSortField : localSortField;
+	const sortDirection = controlledSortDirection !== undefined ? controlledSortDirection : localSortDirection;
 
 	const sortedAlerts = useMemo(() => {
 		if (!sortField) return filteredAlerts;
@@ -15,17 +35,12 @@ export const useAlertSorting = (filteredAlerts: Alert[]) => {
 	}, [filteredAlerts, sortField, sortDirection, users]);
 
 	const handleSort = (field: AlertSortField) => {
-		if (sortField === field) {
-			setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+		const nextDirection = nextDirectionFor(field, sortField, sortDirection);
+		if (onSortChange) {
+			onSortChange(field, nextDirection);
 		} else {
-			setSortField(field);
-			// Time columns: newest first; severity: critical first; fix: manual first
-			// (both desc by rank).
-			setSortDirection(
-				field === 'startsAt' || field === 'updatedAt' || field === 'severity' || field === 'fix'
-					? 'desc'
-					: 'asc'
-			);
+			setLocalSortField(field);
+			setLocalSortDirection(nextDirection);
 		}
 	};
 

--- a/apps/client/src/components/Alerts/IntegrationAvatar.types.ts
+++ b/apps/client/src/components/Alerts/IntegrationAvatar.types.ts
@@ -1,7 +1,6 @@
-import { AlertType } from '@OpsiMate/shared';
 import { ReactNode } from 'react';
 
-export type AlertIntegrationKind = Lowercase<AlertType>;
+export type { AlertIntegrationKind } from '@OpsiMate/shared';
 
 export interface IntegrationDefinition {
 	label: string;

--- a/apps/client/src/components/Alerts/IntegrationAvatar.utils.tsx
+++ b/apps/client/src/components/Alerts/IntegrationAvatar.utils.tsx
@@ -7,7 +7,10 @@ import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { Bell } from 'lucide-react';
 import { AlertIntegrationKind, IntegrationDefinition } from './IntegrationAvatar.types';
-import { getAlertPrimaryTag } from './utils/alertTags.utils';
+
+// Resolution and labels live in @OpsiMate/shared so server-side search matches the
+// integration column exactly; this file layers the icons and styling on top.
+export { normalizeIntegration, resolveAlertIntegration, getIntegrationLabel } from '@OpsiMate/shared';
 
 export const integrationDefinitions: Record<AlertIntegrationKind, IntegrationDefinition> = {
 	grafana: {
@@ -53,27 +56,3 @@ export const integrationDefinitions: Record<AlertIntegrationKind, IntegrationDef
 		render: (iconSizeClass) => <Bell className={cn(iconSizeClass)} />,
 	},
 };
-
-export const normalizeIntegration = (value?: string | null): AlertIntegrationKind | undefined => {
-	if (!value) return undefined;
-	const normalized = value.toLowerCase();
-	if (normalized.includes('grafana')) return 'grafana';
-	if (normalized.includes('gcp') || normalized.includes('google')) return 'gcp';
-	if (normalized.includes('uptimekuma') || normalized.includes('uptime-kuma')) return 'uptimekuma';
-	if (normalized.includes('datadog')) return 'datadog';
-	if (normalized.includes('zabbix')) return 'zabbix';
-	if (normalized.includes('custom')) return 'custom';
-	return undefined;
-};
-
-export const resolveAlertIntegration = (alert: Alert): AlertIntegrationKind => {
-	return (
-		normalizeIntegration(alert.type) ||
-		normalizeIntegration(getAlertPrimaryTag(alert)) ||
-		normalizeIntegration(alert.id) ||
-		normalizeIntegration(alert.summary) ||
-		'custom'
-	);
-};
-
-export const getIntegrationLabel = (integration: AlertIntegrationKind) => integrationDefinitions[integration].label;

--- a/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsFiltering.ts
@@ -1,23 +1,14 @@
 import { TimeRange } from '@/context/DashboardContext';
 import { useUsers } from '@/hooks/queries/users';
-import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
-import { Alert } from '@OpsiMate/shared';
+import { Alert, alertMatchesFilters, applyTimeWindow } from '@OpsiMate/shared';
 import { useEffect, useMemo, useState } from 'react';
 import { resolveTimeRange } from '../AlertsTable/TimeFilter/TimeFilter.utils';
-import { getOwnerDisplayName } from '../utils/owner.utils';
-import { getAlertSeverity, SEVERITY_LABELS } from '../utils/severity.utils';
 
 // How often a quick-preset window re-anchors to "now". This is the roll cadence: alert
 // refetches keep the same array identity when data is unchanged (react-query structural
 // sharing), so without the tick the memo would never re-evaluate the window. 10s keeps
 // even the "Last 1 minute" preset reasonably fresh at negligible recompute cost.
 const ROLLING_WINDOW_TICK_MS = 10 * 1000;
-
-const getAlertType = (alert: Alert): string => {
-	return alert.type || 'Custom';
-};
-
-const capitalizeFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 
 interface UseAlertsFilteringOptions {
 	filters: Record<string, string[]>;
@@ -57,83 +48,18 @@ export const useAlertsFiltering = (
 	const filteredAlerts = useMemo(() => {
 		// Reference the tick so a preset window re-anchors to "now" periodically.
 		void tick;
-		let result = alerts;
-
+		// The window/filter semantics live in @OpsiMate/shared (applyTimeWindow,
+		// alertMatchesFilters) — the same functions the server runs for pushed-down
+		// queries, so the two can never disagree about what a filter shows.
 		const resolved = timeRange ? resolveTimeRange(timeRange) : { from: null, to: null };
-		if (resolved.from || resolved.to) {
-			const filterStart = resolved.from || new Date(0);
-			const filterEnd = resolved.to || new Date();
-
-			result = result.filter((alert) => {
-				const alertStartDate = new Date(alert.startsAt);
-				const alertEndDate = new Date(alert.updatedAt);
-
-				return alertStartDate <= filterEnd && alertEndDate >= filterStart;
-			});
-
-			// Inside a time window, "Started At" means when the firing episode CURRENT AS OF
-			// the window's end began: the LATEST transition into firing at or before the
-			// window closes. An alert that fired at 18:00, resolved at 19:00 and re-fired at
-			// 20:00 shows 20:00 — the 18:00 episode ended; showing it would misstate how long
-			// the alert has been burning. Transitions after the window's end belong to a
-			// later episode and are ignored; an alert that simply kept firing across the
-			// window's start keeps its real (pre-window) start.
-			result = result.map((alert) => {
-				// Numeric (epoch) comparison: startsAt can carry a timezone offset while
-				// firingTimes are normalized UTC — lexicographic order would mis-pick
-				// across formats.
-				const candidates = [alert.startsAt, ...(alert.firingTimes ?? [])]
-					.map((iso) => ({ iso, epoch: new Date(iso).getTime() }))
-					.filter(({ epoch }) => !isNaN(epoch) && epoch <= filterEnd.getTime());
-				if (candidates.length === 0) return alert;
-				const episodeStart = candidates.reduce((latest, c) => (c.epoch > latest.epoch ? c : latest));
-				return episodeStart.iso === alert.startsAt ? alert : { ...alert, startsAt: episodeStart.iso };
-			});
-		}
-
-		if (Object.keys(filters).length === 0) return result;
-
-		// The value an alert presents for a filter field; null when the field is unknown
-		// (unknown fields never constrain).
-		const getFieldValue = (alert: Alert, field: string): string | null => {
-			if (isTagKeyColumn(field)) {
-				const tagKey = extractTagKeyFromColumnId(field);
-				return tagKey ? alert.tags?.[tagKey] || '' : null;
-			}
-			switch (field) {
-				case 'status':
-					return alert.isSilenced ? 'Silenced' : alert.isMuted ? 'Muted' : capitalizeFirst(alert.status);
-				case 'severity':
-					return SEVERITY_LABELS[getAlertSeverity(alert)];
-				case 'type':
-					return getAlertType(alert);
-				case 'alertName':
-					return alert.alertName ?? '';
-				case 'owner':
-					return getOwnerDisplayName(alert.ownerId, users);
-				default:
-					return null;
-			}
-		};
-
-		return result.filter((alert) => {
-			for (const [key, values] of Object.entries(filters)) {
-				if (values.length === 0) continue;
-
-				// "!field" entries are exclusions ("filter out" in the sidebar): an alert
-				// whose value is listed is dropped. Same field-value semantics as the
-				// positive filters, same storage shape — dashboards persist them with no
-				// schema change.
-				const isExclusion = key.startsWith('!');
-				const fieldValue = getFieldValue(alert, isExclusion ? key.slice(1) : key);
-				if (fieldValue === null) continue;
-
-				if (isExclusion ? values.includes(fieldValue) : !values.includes(fieldValue)) {
-					return false;
-				}
-			}
-			return true;
+		let result = applyTimeWindow(alerts, {
+			from: resolved.from ? resolved.from.toISOString() : null,
+			to: resolved.to ? resolved.to.toISOString() : null,
 		});
+		if (Object.keys(filters).length > 0) {
+			result = result.filter((alert) => alertMatchesFilters(alert, filters, users));
+		}
+		return result;
 	}, [alerts, filters, timeRange, users, tick]);
 
 	return filteredAlerts;

--- a/apps/client/src/components/Alerts/utils/alertTags.utils.ts
+++ b/apps/client/src/components/Alerts/utils/alertTags.utils.ts
@@ -1,41 +1,11 @@
-import { Alert } from '@OpsiMate/shared';
-
-// Tags kept out of every tag UI (labels section, tag columns, facets, TV cards). The
-// severity tag is an internal mirror of the first-class severity field, and the fix tag
-// backs the first-class Fix column/badge the same way — users interact with the dedicated
-// column/badges, never the raw tag.
-export const HIDDEN_TAG_KEYS = new Set(['severity', 'fix']);
-
-export const getAlertTagsArray = (alert: Alert): string[] => {
-	if (!alert.tags || typeof alert.tags !== 'object') return [];
-	return Object.entries(alert.tags)
-		.filter(([key, value]) => !HIDDEN_TAG_KEYS.has(key) && Boolean(value))
-		.map(([, value]) => value);
-};
-
-export const getAlertTagsString = (alert: Alert): string => {
-	const tags = getAlertTagsArray(alert);
-	return tags.join(', ') || '';
-};
-
-export const getAlertPrimaryTag = (alert: Alert): string | undefined => {
-	const tags = getAlertTagsArray(alert);
-	return tags[0];
-};
-
-export const hasAlertTags = (alert: Alert): boolean => {
-	return getAlertTagsArray(alert).length > 0;
-};
-
-export const alertMatchesTagFilter = (alert: Alert, filterValues: string[]): boolean => {
-	if (filterValues.length === 0) return true;
-	const tags = getAlertTagsArray(alert);
-	return tags.some((tag) => filterValues.includes(tag));
-};
-
-export const getAlertTagEntries = (alert: Alert): Array<{ key: string; value: string }> => {
-	if (!alert.tags || typeof alert.tags !== 'object') return [];
-	return Object.entries(alert.tags)
-		.filter(([key, value]) => !HIDDEN_TAG_KEYS.has(key) && Boolean(value))
-		.map(([key, value]) => ({ key, value }));
-};
+// Tag presentation logic lives in @OpsiMate/shared so the server searches and facets
+// with identical semantics (hidden keys included).
+export {
+	HIDDEN_TAG_KEYS,
+	getAlertTagsArray,
+	getAlertTagsString,
+	getAlertPrimaryTag,
+	hasAlertTags,
+	alertMatchesTagFilter,
+	getAlertTagEntries,
+} from '@OpsiMate/shared';

--- a/apps/client/src/components/Alerts/utils/fix.utils.ts
+++ b/apps/client/src/components/Alerts/utils/fix.utils.ts
@@ -1,17 +1,3 @@
-import { Alert, AlertFix, normalizeAlertFix } from '@OpsiMate/shared';
-
-export const FIX_LABELS: Record<AlertFix, string> = {
-	[AlertFix.MANUAL]: 'Manual fix',
-	[AlertFix.AUTO]: 'Auto fix',
-};
-
-// Sort rank: higher = needs a human, so a descending sort surfaces manual-fix alerts
-// first; unclassified alerts (null) rank 0 and sink to the end either way.
-export const FIX_RANK: Record<AlertFix, number> = {
-	[AlertFix.MANUAL]: 2,
-	[AlertFix.AUTO]: 1,
-};
-
-// The fix classification rides on a `fix` tag (there is no first-class column like
-// severity's); null when the alert carries no recognizable value.
-export const getAlertFix = (alert: Alert): AlertFix | null => normalizeAlertFix(alert.tags?.['fix']);
+// Fix classification logic lives in @OpsiMate/shared so the server sorts and facets
+// with identical semantics.
+export { FIX_LABELS, FIX_RANK, getAlertFix } from '@OpsiMate/shared';

--- a/apps/client/src/components/Alerts/utils/owner.utils.ts
+++ b/apps/client/src/components/Alerts/utils/owner.utils.ts
@@ -1,21 +1,3 @@
-import { UserInfo } from '@/hooks/queries/users';
-
-/**
- * Get the display name for an alert owner.
- * Returns the user's full name, "Unassigned" for null/undefined, or a fallback for unknown users.
- */
-export const getOwnerDisplayName = (ownerId: string | null | undefined, users: UserInfo[]): string => {
-	if (ownerId === null || ownerId === undefined) return 'Unassigned';
-	const user = users.find((u) => u.id === ownerId);
-	return user?.fullName || `User ${ownerId}`;
-};
-
-/**
- * Get the sort key for an owner (for alphabetical sorting).
- * Unassigned owners sort to the end.
- */
-export const getOwnerSortKey = (ownerId: string | null | undefined, users: UserInfo[]): string => {
-	if (ownerId === null || ownerId === undefined) return 'zzz_unassigned';
-	const user = users.find((u) => u.id === ownerId);
-	return user?.fullName?.toLowerCase() || `user_${ownerId}`;
-};
+// Owner display/sort logic lives in @OpsiMate/shared so the server renders and sorts
+// owners with identical semantics (UserInfo is structurally an AlertOwnerInfo).
+export { getOwnerDisplayName, getOwnerSortKey } from '@OpsiMate/shared';

--- a/apps/client/src/components/Alerts/utils/severity.utils.ts
+++ b/apps/client/src/components/Alerts/utils/severity.utils.ts
@@ -1,17 +1,8 @@
-import { Alert, AlertSeverity, normalizeAlertSeverity } from '@OpsiMate/shared';
+import { AlertSeverity } from '@OpsiMate/shared';
 
-// Sort rank: higher = more severe, so a descending sort shows critical first.
-export const SEVERITY_RANK: Record<AlertSeverity, number> = {
-	[AlertSeverity.CRITICAL]: 3,
-	[AlertSeverity.WARNING]: 2,
-	[AlertSeverity.INFO]: 1,
-};
-
-export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
-	[AlertSeverity.CRITICAL]: 'Critical',
-	[AlertSeverity.WARNING]: 'Warning',
-	[AlertSeverity.INFO]: 'Info',
-};
+// The logic (rank, labels, fallback chain) lives in @OpsiMate/shared so the server
+// filters and sorts with identical semantics; only the visual classes are client-side.
+export { SEVERITY_RANK, SEVERITY_LABELS, getAlertSeverity } from '@OpsiMate/shared';
 
 // Subtle full-row tint used by the "severity colors" table toggle. Opacity-based so it
 // works in both light and dark themes.
@@ -26,9 +17,3 @@ export const SEVERITY_TEXT_CLASSES: Record<AlertSeverity, string> = {
 	[AlertSeverity.WARNING]: 'text-amber-500',
 	[AlertSeverity.INFO]: 'text-sky-500',
 };
-
-// The server always sets severity, but data from older deployments or playground fixtures
-// may miss it — fall back to a `severity` tag, then a `priority` tag (P1–P5, the signal
-// TV mode has historically used), then the default, like the server does.
-export const getAlertSeverity = (alert: Alert): AlertSeverity =>
-	normalizeAlertSeverity(alert.severity ?? alert.tags?.['severity'] ?? alert.tags?.['priority']);

--- a/apps/client/src/hooks/queries/alerts/index.ts
+++ b/apps/client/src/hooks/queries/alerts/index.ts
@@ -1,4 +1,5 @@
 export { useAlerts } from './useAlerts';
+export { useAlertFacets } from './useAlertFacets';
 export { useResolvedAlerts } from './useResolvedAlerts';
 export { useDeleteAlert } from './useDeleteAlert';
 export { useDeleteResolvedAlert } from './useDeleteResolvedAlert';

--- a/apps/client/src/hooks/queries/alerts/useAlertFacets.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertFacets.ts
@@ -1,4 +1,4 @@
-import { alertsApi, AlertFacetsResponse } from '@/lib/api';
+import { alertsApi, AlertFacetsOptions, AlertFacetsResponse } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '../queryKeys';
 
@@ -6,7 +6,7 @@ import { queryKeys } from '../queryKeys';
 // the RAW dataset — the sidebar describes what filters WOULD show, so it must not be
 // limited to the filtered page the table loaded. The playground serves this from a
 // mock handler over the same shared engine.
-export const useAlertFacets = (filters: Record<string, string[]>, options?: { resolved?: boolean }) => {
+export const useAlertFacets = (filters: Record<string, string[]>, options?: AlertFacetsOptions) => {
 	return useQuery<AlertFacetsResponse>({
 		queryKey: [...queryKeys.alerts, 'facets', options?.resolved ? 'resolved' : 'active', filters],
 		queryFn: async () => {

--- a/apps/client/src/hooks/queries/alerts/useAlertFacets.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertFacets.ts
@@ -1,0 +1,22 @@
+import { alertsApi, AlertFacetsResponse } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+// Faceted sidebar counts, tag keys and the silenced total, computed server-side over
+// the RAW dataset — the sidebar describes what filters WOULD show, so it must not be
+// limited to the filtered page the table loaded. The playground serves this from a
+// mock handler over the same shared engine.
+export const useAlertFacets = (filters: Record<string, string[]>, options?: { resolved?: boolean }) => {
+	return useQuery<AlertFacetsResponse>({
+		queryKey: [...queryKeys.alerts, 'facets', options?.resolved ? 'resolved' : 'active', filters],
+		queryFn: async () => {
+			const response = await alertsApi.getAlertFacets(filters, options);
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to fetch alert facets');
+			}
+			return response.data;
+		},
+		staleTime: 5 * 1000,
+		refetchInterval: 10 * 1000,
+	});
+};

--- a/apps/client/src/hooks/queries/alerts/useAlerts.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlerts.ts
@@ -8,7 +8,7 @@ import { queryKeys } from '../queryKeys';
 // slice and nextCursor drives the scroll; the playground's mock handler ignores the
 // params and returns the full list as a single page (nextCursor undefined), which is
 // exactly the legacy behavior — no separate code path to drift.
-export const useAlerts = (query?: AlertQueryParams) => {
+export const useAlerts = (query?: AlertQueryParams, options?: { refetchIntervalMs?: number }) => {
 	const playgroundMode = isPlaygroundMode();
 
 	const result = useInfiniteQuery({
@@ -25,7 +25,7 @@ export const useAlerts = (query?: AlertQueryParams) => {
 		initialPageParam: '',
 		getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
 		staleTime: 5 * 1000,
-		refetchInterval: playgroundMode ? false : 5 * 1000,
+		refetchInterval: playgroundMode ? false : (options?.refetchIntervalMs ?? 5 * 1000),
 	});
 
 	const alerts = useMemo(() => result.data?.pages.flatMap((page) => page.alerts) ?? [], [result.data]);

--- a/apps/client/src/hooks/queries/alerts/useAlerts.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlerts.ts
@@ -1,21 +1,45 @@
-import { alertsApi } from '@/lib/api';
+import { alertsApi, AlertListResponse, AlertQueryParams } from '@/lib/api';
 import { isPlaygroundMode } from '@/lib/playground';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { queryKeys } from '../queryKeys';
 
-export const useAlerts = () => {
+// One infinite query serves both worlds. With a server query, each page is a filtered
+// slice and nextCursor drives the scroll; the playground's mock handler ignores the
+// params and returns the full list as a single page (nextCursor undefined), which is
+// exactly the legacy behavior — no separate code path to drift.
+export const useAlerts = (query?: AlertQueryParams) => {
 	const playgroundMode = isPlaygroundMode();
 
-	return useQuery({
-		queryKey: [...queryKeys.alerts, playgroundMode ? 'playground' : 'api'],
-		queryFn: async () => {
-			const response = await alertsApi.getAllAlerts();
+	const result = useInfiniteQuery({
+		queryKey: [...queryKeys.alerts, playgroundMode ? 'playground' : 'api', query ?? null],
+		queryFn: async ({ pageParam }): Promise<AlertListResponse> => {
+			const response = await alertsApi.getAllAlerts(
+				query ? { ...query, cursor: pageParam || undefined } : undefined
+			);
 			if (!response.success) {
 				throw new Error(response.error || 'Failed to fetch alerts');
 			}
-			return response.data?.alerts || [];
+			return response.data ?? { alerts: [] };
 		},
+		initialPageParam: '',
+		getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
 		staleTime: 5 * 1000,
 		refetchInterval: playgroundMode ? false : 5 * 1000,
 	});
+
+	const alerts = useMemo(() => result.data?.pages.flatMap((page) => page.alerts) ?? [], [result.data]);
+	// The server's filtered total; undefined on legacy/playground responses, where the
+	// single page IS the whole list.
+	const total = result.data?.pages[0]?.total ?? alerts.length;
+
+	return {
+		data: alerts,
+		total,
+		isLoading: result.isLoading,
+		refetch: result.refetch,
+		fetchNextPage: result.fetchNextPage,
+		hasNextPage: result.hasNextPage,
+		isFetchingNextPage: result.isFetchingNextPage,
+	};
 };

--- a/apps/client/src/hooks/queries/alerts/useResolvedAlerts.ts
+++ b/apps/client/src/hooks/queries/alerts/useResolvedAlerts.ts
@@ -5,7 +5,7 @@ import { queryKeys } from '../queryKeys';
 
 // Mirror of useAlerts over the resolved list — see that hook for the single-path
 // design; only the poll cadence differs (resolved alerts change less).
-export const useResolvedAlerts = (query?: AlertQueryParams) => {
+export const useResolvedAlerts = (query?: AlertQueryParams, options?: { refetchIntervalMs?: number }) => {
 	const result = useInfiniteQuery({
 		queryKey: [...queryKeys.resolvedAlerts, query ?? null],
 		queryFn: async ({ pageParam }): Promise<AlertListResponse> => {
@@ -20,7 +20,7 @@ export const useResolvedAlerts = (query?: AlertQueryParams) => {
 		initialPageParam: '',
 		getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
 		staleTime: 30 * 1000,
-		refetchInterval: 30 * 1000,
+		refetchInterval: options?.refetchIntervalMs ?? 30 * 1000,
 	});
 
 	const alerts = useMemo(() => result.data?.pages.flatMap((page) => page.alerts) ?? [], [result.data]);

--- a/apps/client/src/hooks/queries/alerts/useResolvedAlerts.ts
+++ b/apps/client/src/hooks/queries/alerts/useResolvedAlerts.ts
@@ -1,18 +1,38 @@
-import { alertsApi } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
+import { alertsApi, AlertListResponse, AlertQueryParams } from '@/lib/api';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { queryKeys } from '../queryKeys';
 
-export const useResolvedAlerts = () => {
-	return useQuery({
-		queryKey: queryKeys.resolvedAlerts,
-		queryFn: async () => {
-			const response = await alertsApi.getAllResolvedAlerts();
+// Mirror of useAlerts over the resolved list — see that hook for the single-path
+// design; only the poll cadence differs (resolved alerts change less).
+export const useResolvedAlerts = (query?: AlertQueryParams) => {
+	const result = useInfiniteQuery({
+		queryKey: [...queryKeys.resolvedAlerts, query ?? null],
+		queryFn: async ({ pageParam }): Promise<AlertListResponse> => {
+			const response = await alertsApi.getAllResolvedAlerts(
+				query ? { ...query, cursor: pageParam || undefined } : undefined
+			);
 			if (!response.success) {
 				throw new Error(response.error || 'Failed to fetch resolved alerts');
 			}
-			return response.data?.alerts || [];
+			return response.data ?? { alerts: [] };
 		},
-		staleTime: 30 * 1000, // 30 seconds
-		refetchInterval: 30 * 1000, // Refetch every 30 seconds
+		initialPageParam: '',
+		getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
+		staleTime: 30 * 1000,
+		refetchInterval: 30 * 1000,
 	});
+
+	const alerts = useMemo(() => result.data?.pages.flatMap((page) => page.alerts) ?? [], [result.data]);
+	const total = result.data?.pages[0]?.total ?? alerts.length;
+
+	return {
+		data: alerts,
+		total,
+		isLoading: result.isLoading,
+		refetch: result.refetch,
+		fetchNextPage: result.fetchNextPage,
+		hasNextPage: result.hasNextPage,
+		isFetchingNextPage: result.isFetchingNextPage,
+	};
 };

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -510,10 +510,64 @@ export const integrationApi = {
 // Alert IDs are caller-supplied (custom alerts API) and may contain URL-hostile
 // characters (#, /, ?, %); any ID placed in a request path must be encoded or the
 // browser truncates/mangles the URL.
+// Server-side list query (Phase 1): the same filter record the dashboard stores, a
+// concrete time window, search, and paging. Undefined/empty params are omitted so a
+// paramless call keeps the legacy full-list response.
+export interface AlertQueryParams {
+	filters?: Record<string, string[]>;
+	from?: string | null;
+	to?: string | null;
+	search?: string;
+	sort?: string;
+	dir?: 'asc' | 'desc';
+	limit?: number;
+	cursor?: string;
+}
+
+export interface AlertListResponse {
+	alerts: SharedAlert[];
+	total?: number;
+	nextCursor?: string | null;
+}
+
+export interface AlertFacetsResponse {
+	facets: Record<string, Record<string, number>>;
+	total: number;
+	silencedTotal: number;
+	tagKeys: Array<{ key: string; label: string; values: string[] }>;
+}
+
+const alertQueryString = (params?: AlertQueryParams): string => {
+	if (!params) return '';
+	const q = new URLSearchParams();
+	if (params.filters && Object.keys(params.filters).length > 0) q.set('filters', JSON.stringify(params.filters));
+	if (params.from) q.set('from', params.from);
+	if (params.to) q.set('to', params.to);
+	if (params.search?.trim()) q.set('search', params.search);
+	if (params.sort) q.set('sort', params.sort);
+	if (params.dir) q.set('dir', params.dir);
+	if (params.limit !== undefined) q.set('limit', String(params.limit));
+	if (params.cursor) q.set('cursor', params.cursor);
+	const qs = q.toString();
+	return qs ? `?${qs}` : '';
+};
+
 export const alertsApi = {
-	// Get all alerts
-	async getAllAlerts(): Promise<ApiResponse<{ alerts: SharedAlert[] }>> {
-		return await apiRequest<{ alerts: SharedAlert[] }>('/alerts');
+	// Get alerts; with params the server filters/sorts/pages, without them the full list.
+	async getAllAlerts(params?: AlertQueryParams): Promise<ApiResponse<AlertListResponse>> {
+		return await apiRequest<AlertListResponse>(`/alerts${alertQueryString(params)}`);
+	},
+
+	// Faceted sidebar counts + tag keys over the raw dataset, computed server-side.
+	async getAlertFacets(
+		filters: Record<string, string[]>,
+		options?: { resolved?: boolean }
+	): Promise<ApiResponse<AlertFacetsResponse>> {
+		const q = new URLSearchParams();
+		if (Object.keys(filters).length > 0) q.set('filters', JSON.stringify(filters));
+		const base = options?.resolved ? '/alerts/resolved/facets' : '/alerts/facets';
+		const qs = q.toString();
+		return await apiRequest<AlertFacetsResponse>(`${base}${qs ? `?${qs}` : ''}`);
 	},
 
 	// Silence an alert until `silencedUntil` (ISO; null = forever). Re-silencing overwrites
@@ -581,9 +635,9 @@ export const alertsApi = {
 		return response;
 	},
 
-	// Get all resolved alerts
-	async getAllResolvedAlerts(): Promise<ApiResponse<{ alerts: SharedAlert[] }>> {
-		return await apiRequest<{ alerts: SharedAlert[] }>('/alerts/resolved');
+	// Get resolved alerts; same query contract as the active list.
+	async getAllResolvedAlerts(params?: AlertQueryParams): Promise<ApiResponse<AlertListResponse>> {
+		return await apiRequest<AlertListResponse>(`/alerts/resolved${alertQueryString(params)}`);
 	},
 
 	// Delete an resolved alert permanently

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -530,11 +530,21 @@ export interface AlertListResponse {
 	nextCursor?: string | null;
 }
 
+export interface AlertFacetTagKey {
+	key: string;
+	label: string;
+	values: string[];
+}
+
 export interface AlertFacetsResponse {
 	facets: Record<string, Record<string, number>>;
 	total: number;
 	silencedTotal: number;
-	tagKeys: Array<{ key: string; label: string; values: string[] }>;
+	tagKeys: AlertFacetTagKey[];
+}
+
+export interface AlertFacetsOptions {
+	resolved?: boolean;
 }
 
 const alertQueryString = (params?: AlertQueryParams): string => {
@@ -561,7 +571,7 @@ export const alertsApi = {
 	// Faceted sidebar counts + tag keys over the raw dataset, computed server-side.
 	async getAlertFacets(
 		filters: Record<string, string[]>,
-		options?: { resolved?: boolean }
+		options?: AlertFacetsOptions
 	): Promise<ApiResponse<AlertFacetsResponse>> {
 		const q = new URLSearchParams();
 		if (Object.keys(filters).length > 0) q.set('filters', JSON.stringify(filters));

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { AlertHistoryData, AlertHistoryEventType, AlertStatus, OncallTeam } from '@OpsiMate/shared';
+import { computeAlertFacets, AlertHistoryData, AlertHistoryEventType, AlertStatus, OncallTeam } from '@OpsiMate/shared';
 import { http, HttpResponse } from 'msw';
 import { getPlaygroundUser, OncallTeamState, playgroundState, randomId } from './state';
 
@@ -171,6 +171,26 @@ export const handlers = [
 		return HttpResponse.json({
 			success: true,
 			data: { alerts: playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment) },
+		});
+	}),
+
+	http.get(`${API_BASE}/alerts/facets`, ({ request }) => {
+		const url = new URL(request.url);
+		const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
+		const alerts = playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment);
+		return HttpResponse.json({
+			success: true,
+			data: computeAlertFacets(alerts, filters, undefined, []),
+		});
+	}),
+
+	http.get(`${API_BASE}/alerts/resolved/facets`, ({ request }) => {
+		const url = new URL(request.url);
+		const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
+		const alerts = playgroundState.resolvedAlerts.map(withLastComment);
+		return HttpResponse.json({
+			success: true,
+			data: computeAlertFacets(alerts, filters, undefined, []),
 		});
 	}),
 

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -152,6 +152,19 @@ const withLastComment = <T extends { id: string }>(alert: T): T & { lastComment:
 	return { ...alert, lastComment: newest?.comment ?? null };
 };
 
+// Mirrors the server's facets param contract: malformed JSON is a 400, and an explicit
+// fields list is honored, so the playground can't drift from production behavior.
+const parseFacetsParams = (url: URL): { filters: Record<string, string[]>; fields?: string[] } | null => {
+	try {
+		const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
+		const rawFields = url.searchParams.get('fields');
+		const fields = rawFields ? (JSON.parse(rawFields) as string[]) : undefined;
+		return { filters, fields };
+	} catch {
+		return null;
+	}
+};
+
 export const handlers = [
 	// ==================== ALERTS ====================
 	http.get(`${API_BASE}/alerts`, () => {
@@ -176,21 +189,23 @@ export const handlers = [
 
 	http.get(`${API_BASE}/alerts/facets`, ({ request }) => {
 		const url = new URL(request.url);
-		const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
+		const params = parseFacetsParams(url);
+		if (!params) return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
 		const alerts = playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment);
 		return HttpResponse.json({
 			success: true,
-			data: computeAlertFacets(alerts, filters, undefined, []),
+			data: computeAlertFacets(alerts, params.filters, params.fields, []),
 		});
 	}),
 
 	http.get(`${API_BASE}/alerts/resolved/facets`, ({ request }) => {
 		const url = new URL(request.url);
-		const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
+		const params = parseFacetsParams(url);
+		if (!params) return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
 		const alerts = playgroundState.resolvedAlerts.map(withLastComment);
 		return HttpResponse.json({
 			success: true,
-			data: computeAlertFacets(alerts, filters, undefined, []),
+			data: computeAlertFacets(alerts, params.filters, params.fields, []),
 		});
 	}),
 

--- a/apps/client/src/types/TagKey.ts
+++ b/apps/client/src/types/TagKey.ts
@@ -1,16 +1,9 @@
+// Tag-key column helpers live in @OpsiMate/shared so the server can address the same
+// tagKey:<key> filter/sort fields the client uses.
+export { TAG_KEY_COLUMN_PREFIX, getTagKeyColumnId, isTagKeyColumn, extractTagKeyFromColumnId } from '@OpsiMate/shared';
+
 export interface TagKeyInfo {
 	key: string;
 	label: string;
 	values: string[];
 }
-
-export const TAG_KEY_COLUMN_PREFIX = 'tagKey:';
-
-export const getTagKeyColumnId = (tagKey: string): string => `${TAG_KEY_COLUMN_PREFIX}${tagKey}`;
-
-export const isTagKeyColumn = (columnId: string): boolean => columnId.startsWith(TAG_KEY_COLUMN_PREFIX);
-
-export const extractTagKeyFromColumnId = (columnId: string): string | null => {
-	if (!isTagKeyColumn(columnId)) return null;
-	return columnId.slice(TAG_KEY_COLUMN_PREFIX.length);
-};

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -689,6 +689,9 @@ export class AlertController {
 			const snapshot = await this.alertBL.getResolvedAlertsSnapshot();
 			return this.sendAlertsSnapshot(req, res, snapshot);
 		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
 			logger.error('Error getting resolved alerts:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -24,22 +24,83 @@ import {
 } from './models';
 import { isZodError } from '../../../utils/isZodError.ts';
 import { ifNoneMatchSatisfied } from '../../../utils/etag';
+import crypto from 'crypto';
+import { ALERT_QUERY_PARAM_KEYS, AlertFacetsParamsSchema, AlertListQueryParamsSchema } from './models';
 import { createHash } from 'crypto';
 import { AuthenticatedRequest } from '../../../middleware/auth.ts';
 
 const logger: Logger = new Logger('alerts.controller');
+
+const hasAlertQueryParams = (req: Request): boolean =>
+	ALERT_QUERY_PARAM_KEYS.some((key) => req.query[key] !== undefined);
 
 export class AlertController {
 	constructor(private alertBL: AlertBL) {}
 
 	async getAlerts(req: Request, res: Response) {
 		try {
+			if (hasAlertQueryParams(req)) {
+				const query = AlertListQueryParamsSchema.parse(req.query);
+				const page = await this.alertBL.queryAlerts(query);
+				return this.sendAlertsPage(req, res, page);
+			}
 			const snapshot = await this.alertBL.getAlertsSnapshot();
 			return this.sendAlertsSnapshot(req, res, snapshot);
 		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
 			logger.error('Error getting alerts:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
+	}
+
+	async getAlertFacets(req: Request, res: Response) {
+		try {
+			const params = AlertFacetsParamsSchema.parse(req.query);
+			const result = await this.alertBL.getAlertFacets(params.filters ?? {}, params.fields);
+			return res.json({ success: true, data: result });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
+			logger.error('Error computing alert facets:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
+	async getResolvedAlertFacets(req: Request, res: Response) {
+		try {
+			const params = AlertFacetsParamsSchema.parse(req.query);
+			const result = await this.alertBL.getResolvedAlertFacets(params.filters ?? {}, params.fields);
+			return res.json({ success: true, data: result });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
+			logger.error('Error computing resolved alert facets:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
+	// Paged responses get the same revalidation contract as the snapshot: the ETag is
+	// content-derived, so an unchanged page (the common poll) is a bodyless 304.
+	private sendAlertsPage(
+		req: Request,
+		res: Response,
+		page: { items: unknown[]; total: number; nextCursor: string | null }
+	) {
+		const body = JSON.stringify({
+			success: true,
+			data: { alerts: page.items, total: page.total, nextCursor: page.nextCursor },
+		});
+		const etag = `"${crypto.createHash('sha1').update(body).digest('hex')}"`;
+		res.set('ETag', etag);
+		res.set('Cache-Control', 'no-cache');
+		if (ifNoneMatchSatisfied(req.headers['if-none-match'], etag)) {
+			return res.status(304).end();
+		}
+		return res.type('application/json').send(body);
 	}
 
 	// The list is identical for every viewer and polled on a short interval, so the
@@ -620,6 +681,11 @@ export class AlertController {
 
 	async getResolvedAlerts(req: Request, res: Response) {
 		try {
+			if (hasAlertQueryParams(req)) {
+				const query = AlertListQueryParamsSchema.parse(req.query);
+				const page = await this.alertBL.queryResolvedAlerts(query);
+				return this.sendAlertsPage(req, res, page);
+			}
 			const snapshot = await this.alertBL.getResolvedAlertsSnapshot();
 			return this.sendAlertsSnapshot(req, res, snapshot);
 		} catch (error) {

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -313,3 +313,41 @@ export interface ZabbixWebhookPayload {
 	// Allow additional fields
 	[key: string]: string | undefined;
 }
+
+// ---------- list-query params (Phase 1: server-side filtering/paging) ----------
+
+// JSON-in-a-param: the sidebar filter record and the facet field list are structured
+// values; encoding them as JSON strings keeps the URL contract simple and lossless
+// (tag keys may contain any character, so comma-lists are not safe).
+const jsonParam = <T>(parse: (raw: unknown) => T) =>
+	z.string().transform((raw, ctx): T => {
+		try {
+			return parse(JSON.parse(raw));
+		} catch {
+			ctx.addIssue({ code: 'custom', message: 'invalid JSON parameter' });
+			return z.NEVER;
+		}
+	});
+
+const FiltersParamSchema = jsonParam((value) => z.record(z.string(), z.array(z.string())).parse(value));
+const FieldsParamSchema = jsonParam((value) => z.array(z.string()).parse(value));
+
+export const AlertListQueryParamsSchema = z.object({
+	filters: FiltersParamSchema.optional(),
+	from: z.string().optional(),
+	to: z.string().optional(),
+	search: z.string().optional(),
+	sort: z.string().optional(),
+	dir: z.enum(['asc', 'desc']).optional(),
+	limit: z.coerce.number().int().min(1).max(1000).optional(),
+	cursor: z.string().optional(),
+});
+
+export const AlertFacetsParamsSchema = z.object({
+	filters: FiltersParamSchema.optional(),
+	fields: FieldsParamSchema.optional(),
+});
+
+// Any of these present means the caller speaks the query contract; none means the
+// legacy full-snapshot response (older clients, playground harnesses).
+export const ALERT_QUERY_PARAM_KEYS = ['filters', 'from', 'to', 'search', 'sort', 'dir', 'limit', 'cursor'] as const;

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -334,8 +334,9 @@ const FieldsParamSchema = jsonParam((value) => z.array(z.string()).parse(value))
 
 export const AlertListQueryParamsSchema = z.object({
 	filters: FiltersParamSchema.optional(),
-	from: z.string().optional(),
-	to: z.string().optional(),
+	// Unparseable datetimes must be a 400, not a silently-empty 200 page.
+	from: z.iso.datetime({ offset: true }).optional(),
+	to: z.iso.datetime({ offset: true }).optional(),
 	search: z.string().optional(),
 	sort: z.string().optional(),
 	dir: z.enum(['asc', 'desc']).optional(),

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -6,6 +6,7 @@ export default function createAlertRouter(controller: AlertController) {
 
 	// CRUD
 	router.get('/', controller.getAlerts.bind(controller));
+	router.get('/facets', controller.getAlertFacets.bind(controller));
 
 	// Daily silence reset settings (admin; must be before /:alertId to avoid route conflicts)
 	router.get('/silence-reset', controller.getSilenceResetSettings.bind(controller));
@@ -13,6 +14,7 @@ export default function createAlertRouter(controller: AlertController) {
 
 	// Resolved alerts (must be before /:alertId to avoid route conflicts)
 	router.get('/resolved', controller.getResolvedAlerts.bind(controller));
+	router.get('/resolved/facets', controller.getResolvedAlertFacets.bind(controller));
 	router.delete('/resolved/:alertId', controller.deleteResolvedAlert.bind(controller));
 	router.patch('/resolved/:id/owner', controller.setResolvedAlertOwner.bind(controller));
 	router.patch('/resolved/:id/unresolve', controller.unresolveAlert.bind(controller));

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -20,6 +20,14 @@ import { toIsoUtc } from '../../utils/time';
 import { EnrichmentBL } from '../enrichments/enrichment.bl';
 import { MutePolicyBL } from '../mute-policies/mutePolicy.bl';
 import { Snapshot, SnapshotCache } from './snapshotCache';
+import {
+	AlertFacetsResult,
+	AlertListPage,
+	AlertListQuery,
+	AlertOwnerInfo,
+	applyAlertListQuery,
+	computeAlertFacets,
+} from '@OpsiMate/shared';
 
 const logger = new Logger('bl/alert.bl');
 
@@ -64,6 +72,38 @@ export class AlertBL {
 
 	async getResolvedAlertsSnapshot(): Promise<Snapshot<Alert[]>> {
 		return this.resolvedSnapshot.get();
+	}
+
+	// Owner ids are numeric in the DB but string-typed on alerts; the engine compares
+	// strings, so the mapping happens once here.
+	private async getOwnerInfos(): Promise<AlertOwnerInfo[]> {
+		const users = await this.userRepo.getAllUsers();
+		return users.map((u) => ({ id: String(u.id), fullName: u.fullName }));
+	}
+
+	// Server-side execution of the client's own query engine over the cached snapshot:
+	// filter/search/sort/page semantics are the shared implementation, so a pushed-down
+	// query returns exactly what the client would have computed from the full list.
+	async queryAlerts(query: AlertListQuery): Promise<AlertListPage> {
+		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
+		return applyAlertListQuery(snapshot.value, owners, query);
+	}
+
+	async queryResolvedAlerts(query: AlertListQuery): Promise<AlertListPage> {
+		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.getOwnerInfos()]);
+		return applyAlertListQuery(snapshot.value, owners, query);
+	}
+
+	// Facets for the filter sidebar, computed over the RAW list (the sidebar describes
+	// what filters WOULD show — see computeAlertFacets).
+	async getAlertFacets(filters: Record<string, string[]>, fields?: string[]): Promise<AlertFacetsResult> {
+		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
+		return computeAlertFacets(snapshot.value, filters, fields, owners);
+	}
+
+	async getResolvedAlertFacets(filters: Record<string, string[]>, fields?: string[]): Promise<AlertFacetsResult> {
+		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.getOwnerInfos()]);
+		return computeAlertFacets(snapshot.value, filters, fields, owners);
 	}
 
 	// Best-effort history logging: never let a failed history write break the underlying

--- a/apps/server/tests/alertQueryEngine.test.ts
+++ b/apps/server/tests/alertQueryEngine.test.ts
@@ -47,7 +47,7 @@ describe('applyAlertListQuery paging', () => {
 		const first = applyAlertListQuery(alerts, [], { limit: 2 });
 		expect(first.items.map((a) => a.id)).toEqual(['a', 'b']);
 		expect(first.total).toBe(5);
-		expect(first.nextCursor).toBe('b');
+		expect(first.nextCursor).toBeTruthy();
 
 		const second = applyAlertListQuery(alerts, [], { limit: 2, cursor: first.nextCursor! });
 		expect(second.items.map((a) => a.id)).toEqual(['c', 'd']);
@@ -59,10 +59,29 @@ describe('applyAlertListQuery paging', () => {
 
 	test('a row disappearing between pages neither duplicates nor restarts the scroll', () => {
 		const first = applyAlertListQuery(alerts, [], { limit: 2 });
-		expect(first.nextCursor).toBe('b');
 		// 'b' resolves away before the next page is requested.
 		const remaining = alerts.filter((a) => a.id !== 'b');
-		const second = applyAlertListQuery(remaining, [], { limit: 2, cursor: 'b' });
+		const second = applyAlertListQuery(remaining, [], { limit: 2, cursor: first.nextCursor! });
+		expect(second.items.map((a) => a.id)).toEqual(['c', 'd']);
+	});
+
+	test('cursor recovery follows SORT order, not id order, when the cursor row vanished', () => {
+		// Ids deliberately disagree with the sort: startsAt desc yields z, m, a.
+		const disagreeing = [spanning('a', 10), spanning('m', 20), spanning('z', 30)];
+		const first = applyAlertListQuery(disagreeing, [], { limit: 1 });
+		expect(first.items.map((x) => x.id)).toEqual(['z']);
+
+		// 'z' disappears; a raw id comparison would restart at the top ('m' > 'z' is
+		// false for every remaining id) or skip — the comparator must land on 'm'.
+		const remaining = disagreeing.filter((x) => x.id !== 'z');
+		const second = applyAlertListQuery(remaining, [], { limit: 1, cursor: first.nextCursor! });
+		expect(second.items.map((x) => x.id)).toEqual(['m']);
+	});
+
+	test('a bare-id legacy cursor still pages when the row exists', () => {
+		const first = applyAlertListQuery(alerts, [], { limit: 2 });
+		expect(first.items.map((a) => a.id)).toEqual(['a', 'b']);
+		const second = applyAlertListQuery(alerts, [], { limit: 2, cursor: 'b' });
 		expect(second.items.map((a) => a.id)).toEqual(['c', 'd']);
 	});
 

--- a/apps/server/tests/alertQueryEngine.test.ts
+++ b/apps/server/tests/alertQueryEngine.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest';
+import { Alert, AlertStatus, applyAlertListQuery, computeAlertFacets, getTagKeyColumnId } from '@OpsiMate/shared';
+
+// The engine's own behaviors: paging, cursors, facet semantics. Filter/sort/search
+// semantics themselves are pinned by the client's test suite over the same functions.
+
+const mkAlert = (id: string, overrides: Partial<Alert> = {}): Alert =>
+	({
+		id,
+		type: 'Grafana',
+		status: AlertStatus.FIRING,
+		tags: {},
+		startsAt: new Date(2026, 0, 1, 12, 0, 0).toISOString(),
+		updatedAt: new Date(2026, 0, 2, 12, 0, 0).toISOString(),
+		alertUrl: `https://example.com/${id}`,
+		alertName: `Alert ${id}`,
+		isSilenced: false,
+		isMuted: false,
+		...overrides,
+	}) as Alert;
+
+// Each alert's [startsAt, updatedAt] spans one day, staggered a day apart.
+const spanning = (id: string, startDay: number, overrides: Partial<Alert> = {}) =>
+	mkAlert(id, {
+		startsAt: new Date(2026, 0, startDay).toISOString(),
+		updatedAt: new Date(2026, 0, startDay + 1).toISOString(),
+		...overrides,
+	});
+
+const alerts = [
+	spanning('a', 5, { tags: { env: 'prod' } }),
+	spanning('b', 4, { tags: { env: 'prod' } }),
+	spanning('c', 3, { tags: { env: 'staging' } }),
+	spanning('d', 2, { tags: { env: 'staging' }, isSilenced: true }),
+	spanning('e', 1, { tags: { env: 'dev' } }),
+];
+
+describe('applyAlertListQuery paging', () => {
+	test('no limit returns everything, sorted, with no cursor', () => {
+		const page = applyAlertListQuery(alerts, [], {});
+		expect(page.items.map((a) => a.id)).toEqual(['a', 'b', 'c', 'd', 'e']); // startsAt desc default
+		expect(page.total).toBe(5);
+		expect(page.nextCursor).toBeNull();
+	});
+
+	test('limit slices and hands back a cursor; the next page continues exactly', () => {
+		const first = applyAlertListQuery(alerts, [], { limit: 2 });
+		expect(first.items.map((a) => a.id)).toEqual(['a', 'b']);
+		expect(first.total).toBe(5);
+		expect(first.nextCursor).toBe('b');
+
+		const second = applyAlertListQuery(alerts, [], { limit: 2, cursor: first.nextCursor! });
+		expect(second.items.map((a) => a.id)).toEqual(['c', 'd']);
+
+		const third = applyAlertListQuery(alerts, [], { limit: 2, cursor: second.nextCursor! });
+		expect(third.items.map((a) => a.id)).toEqual(['e']);
+		expect(third.nextCursor).toBeNull();
+	});
+
+	test('a row disappearing between pages neither duplicates nor restarts the scroll', () => {
+		const first = applyAlertListQuery(alerts, [], { limit: 2 });
+		expect(first.nextCursor).toBe('b');
+		// 'b' resolves away before the next page is requested.
+		const remaining = alerts.filter((a) => a.id !== 'b');
+		const second = applyAlertListQuery(remaining, [], { limit: 2, cursor: 'b' });
+		expect(second.items.map((a) => a.id)).toEqual(['c', 'd']);
+	});
+
+	test('filters and search constrain before paging, and total reflects the filtered count', () => {
+		const page = applyAlertListQuery(alerts, [], {
+			filters: { [getTagKeyColumnId('env')]: ['prod', 'staging'] },
+			limit: 3,
+		});
+		expect(page.total).toBe(4);
+		expect(page.items.map((a) => a.id)).toEqual(['a', 'b', 'c']);
+	});
+
+	test('a concrete time window filters by overlap, boundaries inclusive', () => {
+		const page = applyAlertListQuery(alerts, [], {
+			from: new Date(2026, 0, 4).toISOString(),
+			to: new Date(2026, 0, 6).toISOString(),
+		});
+		// a [5,6] and b [4,5] sit inside; c [3,4] touches the window's start exactly and
+		// overlap is inclusive; d and e end before it opens.
+		expect(page.items.map((a) => a.id).sort()).toEqual(['a', 'b', 'c']);
+	});
+});
+
+describe('computeAlertFacets', () => {
+	test('counts values with faceted semantics: a field is not constrained by itself', () => {
+		const envField = getTagKeyColumnId('env');
+		const { facets } = computeAlertFacets(alerts, { [envField]: ['prod'] }, [envField, 'status'], []);
+		// env facet ignores its own filter: all three values visible with full counts.
+		expect(facets[envField]).toEqual({ prod: 2, staging: 2, dev: 1 });
+		// status facet IS constrained by the env filter: only prod alerts count.
+		expect(facets['status']).toEqual({ Firing: 2 });
+	});
+
+	test('exclusion filters constrain other facets', () => {
+		const envField = getTagKeyColumnId('env');
+		const { facets } = computeAlertFacets(alerts, { ['!' + envField]: ['prod'] }, ['status'], []);
+		expect(facets['status']).toEqual({ Firing: 2, Silenced: 1 });
+	});
+
+	test('reports raw totals alongside', () => {
+		const result = computeAlertFacets(alerts, {}, ['status'], []);
+		expect(result.total).toBe(5);
+		expect(result.silencedTotal).toBe(1);
+	});
+});

--- a/apps/server/tests/alertsQueryApi.test.ts
+++ b/apps/server/tests/alertsQueryApi.test.ts
@@ -1,0 +1,121 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { SuperTest, Test } from 'supertest';
+import Database from 'better-sqlite3';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
+
+// HTTP contract of the Phase-1 query endpoints: param parsing, paging envelope,
+// facets, legacy behavior when no query params are sent. Engine semantics themselves
+// are covered by alertQueryEngine.test.ts and the client suite.
+
+let app: SuperTest<Test>;
+let db: Database.Database;
+let jwtToken: string;
+
+const insertAlert = (id: string, name: string, tags: Record<string, string>, startsAt: string) => {
+	db.prepare(
+		`INSERT INTO alerts (id, status, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed)
+		 VALUES (?, 'firing', ?, ?, ?, ?, ?, 'Summary', NULL, 0)`
+	).run(id, JSON.stringify(tags), startsAt, new Date().toISOString(), `https://example.com/${id}`, name);
+};
+
+const get = (url: string) => app.get(url).set('Authorization', `Bearer ${jwtToken}`);
+
+beforeAll(async () => {
+	db = await setupDB();
+	app = await setupExpressApp(db);
+	jwtToken = await setupUserWithToken(app);
+	for (let i = 1; i <= 30; i++) {
+		insertAlert(
+			`q-${String(i).padStart(2, '0')}`,
+			`Query Alert ${i}`,
+			{ env: i % 3 === 0 ? 'prod' : 'staging' },
+			new Date(2026, 0, i, 12, 0, 0).toISOString()
+		);
+	}
+});
+
+describe('GET /alerts with query params', () => {
+	test('limit pages the list and reports the filtered total', async () => {
+		const res = await get('/api/v1/alerts?limit=10&sort=startsAt&dir=desc');
+		expect(res.status).toBe(200);
+		expect(res.body.data.alerts).toHaveLength(10);
+		expect(res.body.data.total).toBe(30);
+		expect(res.body.data.nextCursor).toBeTruthy();
+		// startsAt desc: latest (day 30) first
+		expect(res.body.data.alerts[0].id).toBe('q-30');
+	});
+
+	test('cursor continues the scroll without duplicates', async () => {
+		const first = await get('/api/v1/alerts?limit=10&sort=startsAt&dir=desc');
+		const second = await get(
+			`/api/v1/alerts?limit=10&sort=startsAt&dir=desc&cursor=${encodeURIComponent(first.body.data.nextCursor)}`
+		);
+		const firstIds = first.body.data.alerts.map((a: { id: string }) => a.id);
+		const secondIds = second.body.data.alerts.map((a: { id: string }) => a.id);
+		expect(secondIds).toHaveLength(10);
+		expect(new Set([...firstIds, ...secondIds]).size).toBe(20);
+	});
+
+	test('sidebar filters apply server-side with the same record shape the client stores', async () => {
+		const filters = encodeURIComponent(JSON.stringify({ 'tagKey:env': ['prod'] }));
+		const res = await get(`/api/v1/alerts?filters=${filters}&limit=100`);
+		expect(res.body.data.total).toBe(10);
+		for (const alert of res.body.data.alerts) {
+			expect(alert.tags.env).toBe('prod');
+		}
+	});
+
+	test('search applies server-side', async () => {
+		const res = await get('/api/v1/alerts?search=alert%203&limit=100');
+		// "alert 3" matches "Query Alert 3" and "Query Alert 30"
+		expect(res.body.data.total).toBe(2);
+	});
+
+	test('paged responses carry a content ETag and honor If-None-Match', async () => {
+		const first = await get('/api/v1/alerts?limit=5');
+		const etag = first.headers['etag'];
+		expect(etag).toBeTruthy();
+		const revalidated = await get('/api/v1/alerts?limit=5').set('If-None-Match', etag);
+		expect(revalidated.status).toBe(304);
+	});
+
+	test('no query params keeps the legacy full-snapshot envelope', async () => {
+		const res = await get('/api/v1/alerts');
+		expect(res.status).toBe(200);
+		expect(res.body.data.alerts).toHaveLength(30);
+		expect(res.body.data.total).toBeUndefined();
+		expect(res.body.data.nextCursor).toBeUndefined();
+	});
+
+	test('malformed params are a 400, not a 500', async () => {
+		const bad = await get('/api/v1/alerts?filters=not-json');
+		expect(bad.status).toBe(400);
+		expect(bad.body.success).toBe(false);
+		const badLimit = await get('/api/v1/alerts?limit=0');
+		expect(badLimit.status).toBe(400);
+	});
+});
+
+describe('GET /alerts/facets', () => {
+	test('returns faceted counts with the sidebar semantics', async () => {
+		const fields = encodeURIComponent(JSON.stringify(['tagKey:env', 'status']));
+		const filters = encodeURIComponent(JSON.stringify({ 'tagKey:env': ['prod'] }));
+		const res = await get(`/api/v1/alerts/facets?fields=${fields}&filters=${filters}`);
+		expect(res.status).toBe(200);
+		// A facet is not constrained by its own filter...
+		expect(res.body.data.facets['tagKey:env']).toEqual({ prod: 10, staging: 20 });
+		// ...but other facets are.
+		expect(res.body.data.facets['status']).toEqual({ Firing: 10 });
+		expect(res.body.data.total).toBe(30);
+	});
+
+	test('omitting fields defaults to the base fields plus every tag key, and reports tag keys', async () => {
+		const res = await get('/api/v1/alerts/facets');
+		expect(res.status).toBe(200);
+		expect(Object.keys(res.body.data.facets)).toEqual(
+			expect.arrayContaining(['status', 'severity', 'type', 'alertName', 'owner', 'tagKey:env'])
+		);
+		expect(res.body.data.tagKeys).toEqual([{ key: 'env', label: 'Env', values: ['prod', 'staging'] }]);
+		expect(res.body.data.silencedTotal).toBe(0);
+	});
+});

--- a/apps/server/tests/alertsQueryApi.test.ts
+++ b/apps/server/tests/alertsQueryApi.test.ts
@@ -119,3 +119,23 @@ describe('GET /alerts/facets', () => {
 		expect(res.body.data.silencedTotal).toBe(0);
 	});
 });
+
+describe('GET /alerts/resolved with query params', () => {
+	test('malformed params are a 400, not a 500', async () => {
+		const res = await get('/api/v1/alerts/resolved?filters=not-json');
+		expect(res.status).toBe(400);
+		expect(res.body.success).toBe(false);
+	});
+
+	test('unparseable from/to dates are a 400, not an empty 200', async () => {
+		const res = await get('/api/v1/alerts?from=yesterday');
+		expect(res.status).toBe(400);
+	});
+
+	test('paging envelope matches the active endpoint', async () => {
+		const res = await get('/api/v1/alerts/resolved?limit=5');
+		expect(res.status).toBe(200);
+		expect(res.body.data).toHaveProperty('total');
+		expect(res.body.data).toHaveProperty('nextCursor');
+	});
+});

--- a/packages/shared/src/alerts/alertQuery.ts
+++ b/packages/shared/src/alerts/alertQuery.ts
@@ -139,7 +139,7 @@ export const getAlertSortValue = (alert: Alert, sortField: string, users: AlertO
 	}
 	switch (sortField) {
 		case 'alertName':
-			return alert.alertName.toLowerCase();
+			return (alert.alertName ?? '').toLowerCase();
 		case 'status':
 			return alert.isSilenced ? 'silenced' : alert.isMuted ? 'muted' : 'firing';
 		case 'severity':
@@ -210,11 +210,52 @@ export interface AlertListQuery {
 	sort?: string;
 	dir?: AlertSortDirection;
 	limit?: number;
-	// Keyset cursor: the id of the last item of the previous page. Position is recovered
-	// against the CURRENT sorted result, so rows appearing/disappearing between polls
-	// shift the boundary by data, never duplicate-or-skip by arithmetic.
+	// Opaque keyset cursor produced by a previous page (see encodeAlertCursor). Position
+	// is recovered against the CURRENT sorted result, so rows appearing/disappearing
+	// between polls shift the boundary by data, never duplicate-or-skip by arithmetic.
 	cursor?: string;
 }
+
+// The cursor carries the boundary row's sort value alongside its id: if the row itself
+// is gone by the next request, the position is recovered with the same comparator the
+// sort used — a raw id comparison would only be right when id order happens to agree
+// with the sort order.
+interface AlertCursor {
+	v: string | number | null;
+	id: string;
+}
+
+export const encodeAlertCursor = (alert: Alert, sortField: string, users: AlertOwnerInfo[]): string =>
+	JSON.stringify({ v: getAlertSortValue(alert, sortField, users), id: alert.id });
+
+const decodeAlertCursor = (cursor: string): AlertCursor => {
+	try {
+		const parsed = JSON.parse(cursor) as Partial<AlertCursor>;
+		if (typeof parsed === 'object' && parsed !== null && typeof parsed.id === 'string') {
+			return { v: parsed.v ?? null, id: parsed.id };
+		}
+	} catch {
+		// Not JSON: treat the whole string as a bare id (no sort value to anchor on).
+	}
+	return { v: null, id: cursor };
+};
+
+// Where the cursor row would sort relative to `alert`: negative when the cursor comes
+// first. Mirrors compareAlerts, with the cursor's captured value standing in for the row.
+const compareToCursor = (
+	alert: Alert,
+	cursor: AlertCursor,
+	sortField: string,
+	dir: AlertSortDirection,
+	users: AlertOwnerInfo[]
+): number => {
+	const value = getAlertSortValue(alert, sortField, users);
+	if (value !== null && cursor.v !== null) {
+		if (cursor.v < value) return dir === 'asc' ? -1 : 1;
+		if (cursor.v > value) return dir === 'asc' ? 1 : -1;
+	}
+	return cursor.id < alert.id ? -1 : cursor.id > alert.id ? 1 : 0;
+};
 
 export interface AlertListPage {
 	items: Alert[];
@@ -248,21 +289,22 @@ export const applyAlertListQuery = (alerts: Alert[], users: AlertOwnerInfo[], qu
 	const limit = Math.max(1, query.limit);
 	let start = 0;
 	if (query.cursor) {
-		const cursorIndex = result.findIndex((alert) => alert.id === query.cursor);
+		const cursor = decodeAlertCursor(query.cursor);
+		const cursorIndex = result.findIndex((alert) => alert.id === cursor.id);
 		if (cursorIndex >= 0) {
 			start = cursorIndex + 1;
 		} else {
 			// The cursor row left the result set (resolved, filtered away) between pages.
-			// Recover the position order-wise: first row that would sort after it. Without
-			// the row itself the best anchor available is the id tiebreak; this degrades
-			// gracefully to "roughly where you were" instead of restarting at the top.
-			start = result.findIndex((alert) => alert.id > query.cursor!);
+			// Recover the position order-wise with the sort comparator: the first row the
+			// cursor would sort before is where the next page starts.
+			start = result.findIndex((alert) => compareToCursor(alert, cursor, sortField, dir, users) < 0);
 			if (start < 0) start = result.length;
 		}
 	}
 
 	const items = result.slice(start, start + limit);
-	const nextCursor = start + limit < result.length ? (items[items.length - 1]?.id ?? null) : null;
+	const lastItem = items[items.length - 1];
+	const nextCursor = start + limit < result.length && lastItem ? encodeAlertCursor(lastItem, sortField, users) : null;
 	return { items, total, nextCursor };
 };
 

--- a/packages/shared/src/alerts/alertQuery.ts
+++ b/packages/shared/src/alerts/alertQuery.ts
@@ -1,0 +1,371 @@
+import { Alert } from '../types';
+import {
+	AlertOwnerInfo,
+	HIDDEN_TAG_KEYS,
+	extractTagKeyFromColumnId,
+	FIX_RANK,
+	getAlertFix,
+	getAlertSeverity,
+	getAlertTagsString,
+	getIntegrationLabel,
+	getOwnerDisplayName,
+	getOwnerSortKey,
+	getTagKeyColumnId,
+	getTagKeyValue,
+	isTagKeyColumn,
+	resolveAlertIntegration,
+	SEVERITY_LABELS,
+	SEVERITY_RANK,
+} from './alertView';
+
+// The alerts query engine — the ONE implementation of how the alert list is filtered,
+// searched, sorted, faceted and paged. The client has always run this in the browser;
+// the server runs the same functions so a query pushed server-side can never disagree
+// with what the client would have shown. Semantics are pinned by the client's tests.
+
+// Sidebar filters as the dashboard stores them: field -> accepted display values, with
+// "!field" entries as exclusions. Field names are the base columns plus tagKey:<key>.
+export type AlertListFilters = Record<string, string[]>;
+
+const capitalizeFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+
+const getAlertType = (alert: Alert): string => alert.type || 'Custom';
+
+// The value an alert presents for a filter field; null when the field is unknown
+// (unknown fields never constrain — a stale persisted filter must not hide everything).
+export const getAlertFilterFieldValue = (alert: Alert, field: string, users: AlertOwnerInfo[]): string | null => {
+	if (isTagKeyColumn(field)) {
+		const tagKey = extractTagKeyFromColumnId(field);
+		return tagKey ? alert.tags?.[tagKey] || '' : null;
+	}
+	switch (field) {
+		case 'status':
+			return alert.isSilenced ? 'Silenced' : alert.isMuted ? 'Muted' : capitalizeFirst(alert.status);
+		case 'severity':
+			return SEVERITY_LABELS[getAlertSeverity(alert)];
+		case 'type':
+			return getAlertType(alert);
+		case 'alertName':
+			return alert.alertName ?? '';
+		case 'owner':
+			return getOwnerDisplayName(alert.ownerId, users);
+		default:
+			return null;
+	}
+};
+
+// One alert against the whole filters record — includes constrain, "!field" excludes.
+export const alertMatchesFilters = (alert: Alert, filters: AlertListFilters, users: AlertOwnerInfo[]): boolean => {
+	for (const [key, values] of Object.entries(filters)) {
+		if (values.length === 0) continue;
+		const isExclusion = key.startsWith('!');
+		const fieldValue = getAlertFilterFieldValue(alert, isExclusion ? key.slice(1) : key, users);
+		if (fieldValue === null) continue;
+		if (isExclusion ? values.includes(fieldValue) : !values.includes(fieldValue)) {
+			return false;
+		}
+	}
+	return true;
+};
+
+// ---------- time window ----------
+
+export interface ResolvedTimeWindow {
+	from: string | null;
+	to: string | null;
+}
+
+// Applies a concrete [from, to] window: an alert is in when its [startsAt, updatedAt]
+// span overlaps the window. Inside a window, "Started At" is rewritten to the firing
+// episode current as of the window's end — the LATEST transition into firing at or
+// before the window closes. An alert that fired at 18:00, resolved at 19:00 and re-fired
+// at 20:00 shows 20:00; transitions after the window's end belong to a later episode.
+export const applyTimeWindow = (alerts: Alert[], window: ResolvedTimeWindow): Alert[] => {
+	const from = window.from ? new Date(window.from) : null;
+	const to = window.to ? new Date(window.to) : null;
+	if (!from && !to) return alerts;
+
+	const filterStart = from || new Date(0);
+	const filterEnd = to || new Date();
+
+	const result = alerts.filter((alert) => {
+		const alertStartDate = new Date(alert.startsAt);
+		const alertEndDate = new Date(alert.updatedAt);
+		return alertStartDate <= filterEnd && alertEndDate >= filterStart;
+	});
+
+	return result.map((alert) => {
+		// Numeric (epoch) comparison: startsAt can carry a timezone offset while
+		// firingTimes are normalized UTC — lexicographic order would mis-pick across
+		// formats.
+		const candidates = [alert.startsAt, ...(alert.firingTimes ?? [])]
+			.map((iso) => ({ iso, epoch: new Date(iso).getTime() }))
+			.filter(({ epoch }) => !isNaN(epoch) && epoch <= filterEnd.getTime());
+		if (candidates.length === 0) return alert;
+		const episodeStart = candidates.reduce((latest, c) => (c.epoch > latest.epoch ? c : latest));
+		return episodeStart.iso === alert.startsAt ? alert : { ...alert, startsAt: episodeStart.iso };
+	});
+};
+
+// ---------- search ----------
+
+export const searchAlerts = (alerts: Alert[], searchTerm: string): Alert[] => {
+	if (!searchTerm.trim()) return alerts;
+
+	const lower = searchTerm.toLowerCase();
+	return alerts.filter((alert) => {
+		const integration = resolveAlertIntegration(alert);
+		const integrationLabel = getIntegrationLabel(integration).toLowerCase();
+		const tagsString = getAlertTagsString(alert).toLowerCase();
+		return (
+			(alert.alertName && alert.alertName.toLowerCase().includes(lower)) ||
+			(alert.status && alert.status.toLowerCase().includes(lower)) ||
+			tagsString.includes(lower) ||
+			(alert.summary && alert.summary.toLowerCase().includes(lower)) ||
+			(alert.lastComment && alert.lastComment.toLowerCase().includes(lower)) ||
+			integrationLabel.includes(lower)
+		);
+	});
+};
+
+// ---------- sort ----------
+
+export type AlertSortDirection = 'asc' | 'desc';
+
+// Comparable value for one alert under a sort field; null means "field not sortable".
+export const getAlertSortValue = (alert: Alert, sortField: string, users: AlertOwnerInfo[]): string | number | null => {
+	if (isTagKeyColumn(sortField)) {
+		return getTagKeyValue(alert, sortField).toLowerCase();
+	}
+	switch (sortField) {
+		case 'alertName':
+			return alert.alertName.toLowerCase();
+		case 'status':
+			return alert.isSilenced ? 'silenced' : alert.isMuted ? 'muted' : 'firing';
+		case 'severity':
+			// Rank-based so desc = critical first, info last.
+			return SEVERITY_RANK[getAlertSeverity(alert)];
+		case 'fix': {
+			// Rank-based so desc = manual first; unclassified alerts sink to rank 0.
+			const fix = getAlertFix(alert);
+			return fix ? FIX_RANK[fix] : 0;
+		}
+		case 'summary':
+			return (alert.summary || '').toLowerCase();
+		case 'lastComment':
+			return (alert.lastComment || '').toLowerCase();
+		case 'startsAt': {
+			const date = new Date(alert.startsAt);
+			return isNaN(date.getTime()) ? 0 : date.getTime();
+		}
+		case 'updatedAt': {
+			const date = new Date(alert.updatedAt);
+			return isNaN(date.getTime()) ? 0 : date.getTime();
+		}
+		case 'type':
+			return getIntegrationLabel(resolveAlertIntegration(alert)).toLowerCase();
+		case 'owner':
+			return getOwnerSortKey(alert.ownerId, users);
+		default:
+			return null;
+	}
+};
+
+// Equal sort values fall back to the alert id, so the order is total — which both keeps
+// the visual order stable across refetches and is what makes keyset cursors well-defined.
+export const compareAlerts = (
+	a: Alert,
+	b: Alert,
+	sortField: string,
+	sortDirection: AlertSortDirection,
+	users: AlertOwnerInfo[]
+): number => {
+	const aValue = getAlertSortValue(a, sortField, users);
+	const bValue = getAlertSortValue(b, sortField, users);
+	if (aValue !== null && bValue !== null) {
+		if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
+		if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
+	}
+	return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+};
+
+export const sortAlertsBy = (
+	alerts: Alert[],
+	sortField: string,
+	sortDirection: AlertSortDirection,
+	users: AlertOwnerInfo[] = []
+): Alert[] => {
+	return [...alerts].sort((a, b) => compareAlerts(a, b, sortField, sortDirection, users));
+};
+
+// ---------- paging ----------
+
+export interface AlertListQuery {
+	filters?: AlertListFilters;
+	// Concrete window — rolling presets are resolved by the CALLER at request time, so
+	// "Last 1 hour" re-anchors to the requesting clock, not a stored snapshot of it.
+	from?: string | null;
+	to?: string | null;
+	search?: string;
+	sort?: string;
+	dir?: AlertSortDirection;
+	limit?: number;
+	// Keyset cursor: the id of the last item of the previous page. Position is recovered
+	// against the CURRENT sorted result, so rows appearing/disappearing between polls
+	// shift the boundary by data, never duplicate-or-skip by arithmetic.
+	cursor?: string;
+}
+
+export interface AlertListPage {
+	items: Alert[];
+	total: number;
+	nextCursor: string | null;
+}
+
+export const DEFAULT_ALERT_SORT = 'startsAt';
+export const DEFAULT_ALERT_SORT_DIR: AlertSortDirection = 'desc';
+
+export const applyAlertListQuery = (alerts: Alert[], users: AlertOwnerInfo[], query: AlertListQuery): AlertListPage => {
+	let result = alerts;
+	result = applyTimeWindow(result, { from: query.from ?? null, to: query.to ?? null });
+	if (query.filters && Object.keys(query.filters).length > 0) {
+		const filters = query.filters;
+		result = result.filter((alert) => alertMatchesFilters(alert, filters, users));
+	}
+	if (query.search) {
+		result = searchAlerts(result, query.search);
+	}
+
+	const sortField = query.sort ?? DEFAULT_ALERT_SORT;
+	const dir = query.dir ?? DEFAULT_ALERT_SORT_DIR;
+	result = sortAlertsBy(result, sortField, dir, users);
+
+	const total = result.length;
+	if (query.limit === undefined) {
+		return { items: result, total, nextCursor: null };
+	}
+
+	const limit = Math.max(1, query.limit);
+	let start = 0;
+	if (query.cursor) {
+		const cursorIndex = result.findIndex((alert) => alert.id === query.cursor);
+		if (cursorIndex >= 0) {
+			start = cursorIndex + 1;
+		} else {
+			// The cursor row left the result set (resolved, filtered away) between pages.
+			// Recover the position order-wise: first row that would sort after it. Without
+			// the row itself the best anchor available is the id tiebreak; this degrades
+			// gracefully to "roughly where you were" instead of restarting at the top.
+			start = result.findIndex((alert) => alert.id > query.cursor!);
+			if (start < 0) start = result.length;
+		}
+	}
+
+	const items = result.slice(start, start + limit);
+	const nextCursor = start + limit < result.length ? (items[items.length - 1]?.id ?? null) : null;
+	return { items, total, nextCursor };
+};
+
+// ---------- tag keys ----------
+
+export interface AlertTagKeyInfo {
+	key: string;
+	label: string;
+	values: string[];
+}
+
+const formatTagKeyLabel = (key: string): string => {
+	if (!key) return '';
+	return key
+		.split(/[-_]/)
+		.filter((word) => word.length > 0)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+		.join(' ');
+};
+
+// Distinct tag keys (hidden keys excluded) with their value sets — the source for tag
+// columns, group-by options and sidebar facet fields.
+export const collectAlertTagKeys = (alerts: Alert[]): AlertTagKeyInfo[] => {
+	const tagKeyMap = new Map<string, Set<string>>();
+	alerts.forEach((alert) => {
+		if (alert.tags && typeof alert.tags === 'object') {
+			Object.entries(alert.tags).forEach(([key, value]) => {
+				if (HIDDEN_TAG_KEYS.has(key)) return;
+				if (value) {
+					if (!tagKeyMap.has(key)) tagKeyMap.set(key, new Set());
+					tagKeyMap.get(key)?.add(value);
+				}
+			});
+		}
+	});
+	return Array.from(tagKeyMap.entries())
+		.map(([key, valuesSet]) => ({
+			key,
+			label: formatTagKeyLabel(key),
+			values: Array.from(valuesSet).sort(),
+		}))
+		.sort((a, b) => a.label.localeCompare(b.label));
+};
+
+// ---------- facets ----------
+
+export const BASE_ALERT_FACET_FIELDS = ['status', 'severity', 'type', 'alertName', 'owner'] as const;
+
+export interface AlertFacetsResult {
+	// field -> display value -> count, computed with faceted semantics.
+	facets: Record<string, Record<string, number>>;
+	total: number;
+	silencedTotal: number;
+	// Distinct tag keys over the same raw dataset, so the sidebar (and tag columns) can
+	// be built without ever downloading the full list.
+	tagKeys: AlertTagKeyInfo[];
+}
+
+// Faceted filtering, exactly as the sidebar computes it: an alert counts toward a
+// field's facet only if it passes every OTHER active filter (includes and "!field"
+// exclusions). A facet never constrains itself — neither its includes nor its
+// exclusions — so its own options stay fully visible. Computed over the RAW dataset:
+// the sidebar describes what filters WOULD show, so time window and search don't
+// constrain it.
+export const computeAlertFacets = (
+	alerts: Alert[],
+	filters: AlertListFilters,
+	fields: string[] | undefined,
+	users: AlertOwnerInfo[]
+): AlertFacetsResult => {
+	const tagKeys = collectAlertTagKeys(alerts);
+	const facetFields = fields ?? [...BASE_ALERT_FACET_FIELDS, ...tagKeys.map((tk) => getTagKeyColumnId(tk.key))];
+	const passesOtherFilters = (alert: Alert, exceptField: string): boolean => {
+		for (const [key, values] of Object.entries(filters)) {
+			if (values.length === 0) continue;
+			const isExclusion = key.startsWith('!');
+			const field = isExclusion ? key.slice(1) : key;
+			if (field === exceptField) continue;
+			const fieldValue = getAlertFilterFieldValue(alert, field, users);
+			if (fieldValue === null) continue;
+			if (isExclusion ? values.includes(fieldValue) : !values.includes(fieldValue)) {
+				return false;
+			}
+		}
+		return true;
+	};
+
+	const facets: Record<string, Record<string, number>> = {};
+	for (const field of facetFields) {
+		const counts: Record<string, number> = {};
+		for (const alert of alerts) {
+			if (!passesOtherFilters(alert, field)) continue;
+			const value = getAlertFilterFieldValue(alert, field, users);
+			if (value === null || value === '') continue;
+			counts[value] = (counts[value] ?? 0) + 1;
+		}
+		facets[field] = counts;
+	}
+
+	return {
+		facets,
+		total: alerts.length,
+		silencedTotal: alerts.filter((a) => a.isSilenced).length,
+		tagKeys,
+	};
+};

--- a/packages/shared/src/alerts/alertView.ts
+++ b/packages/shared/src/alerts/alertView.ts
@@ -1,0 +1,164 @@
+import { Alert, AlertFix, AlertSeverity, AlertType, normalizeAlertFix, normalizeAlertSeverity } from '../types';
+
+// How an alert PRESENTS — the values users see, filter on, and sort by. Lifted from the
+// client so the server can filter/sort/facet with identical semantics: both sides import
+// this one implementation, and the client's existing tests pin it. Anything visual
+// (row tints, icons) stays in the client on top of these primitives.
+
+// ---------- severity ----------
+
+// Sort rank: higher = more severe, so a descending sort shows critical first.
+export const SEVERITY_RANK: Record<AlertSeverity, number> = {
+	[AlertSeverity.CRITICAL]: 3,
+	[AlertSeverity.WARNING]: 2,
+	[AlertSeverity.INFO]: 1,
+};
+
+export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
+	[AlertSeverity.CRITICAL]: 'Critical',
+	[AlertSeverity.WARNING]: 'Warning',
+	[AlertSeverity.INFO]: 'Info',
+};
+
+// The server always sets severity, but data from older deployments or playground fixtures
+// may miss it — fall back to a `severity` tag, then a `priority` tag (P1–P5), then the
+// default.
+export const getAlertSeverity = (alert: Alert): AlertSeverity =>
+	normalizeAlertSeverity(alert.severity ?? alert.tags?.['severity'] ?? alert.tags?.['priority']);
+
+// ---------- fix ----------
+
+export const FIX_LABELS: Record<AlertFix, string> = {
+	[AlertFix.MANUAL]: 'Manual fix',
+	[AlertFix.AUTO]: 'Auto fix',
+};
+
+// Sort rank: higher = needs a human, so a descending sort surfaces manual-fix alerts
+// first; unclassified alerts (null) rank 0 and sink to the end either way.
+export const FIX_RANK: Record<AlertFix, number> = {
+	[AlertFix.MANUAL]: 2,
+	[AlertFix.AUTO]: 1,
+};
+
+// The fix classification rides on a `fix` tag (there is no first-class column like
+// severity's); null when the alert carries no recognizable value.
+export const getAlertFix = (alert: Alert): AlertFix | null => normalizeAlertFix(alert.tags?.['fix']);
+
+// ---------- owner ----------
+
+// The slice of a user either side needs to render or sort an owner.
+export interface AlertOwnerInfo {
+	id: string;
+	fullName: string;
+}
+
+export const getOwnerDisplayName = (ownerId: string | null | undefined, users: AlertOwnerInfo[]): string => {
+	if (ownerId === null || ownerId === undefined) return 'Unassigned';
+	const user = users.find((u) => u.id === ownerId);
+	return user?.fullName || `User ${ownerId}`;
+};
+
+// Unassigned owners sort to the end.
+export const getOwnerSortKey = (ownerId: string | null | undefined, users: AlertOwnerInfo[]): string => {
+	if (ownerId === null || ownerId === undefined) return 'zzz_unassigned';
+	const user = users.find((u) => u.id === ownerId);
+	return user?.fullName?.toLowerCase() || `user_${ownerId}`;
+};
+
+// ---------- tags ----------
+
+// Tags kept out of every tag UI (labels section, tag columns, facets, TV cards). The
+// severity tag is an internal mirror of the first-class severity field, and the fix tag
+// backs the first-class Fix column/badge the same way — users interact with the dedicated
+// column/badges, never the raw tag.
+export const HIDDEN_TAG_KEYS = new Set(['severity', 'fix']);
+
+export const getAlertTagsArray = (alert: Alert): string[] => {
+	if (!alert.tags || typeof alert.tags !== 'object') return [];
+	return Object.entries(alert.tags)
+		.filter(([key, value]) => !HIDDEN_TAG_KEYS.has(key) && Boolean(value))
+		.map(([, value]) => value);
+};
+
+export const getAlertTagsString = (alert: Alert): string => {
+	const tags = getAlertTagsArray(alert);
+	return tags.join(', ') || '';
+};
+
+export const getAlertPrimaryTag = (alert: Alert): string | undefined => {
+	const tags = getAlertTagsArray(alert);
+	return tags[0];
+};
+
+export const hasAlertTags = (alert: Alert): boolean => {
+	return getAlertTagsArray(alert).length > 0;
+};
+
+export const alertMatchesTagFilter = (alert: Alert, filterValues: string[]): boolean => {
+	if (filterValues.length === 0) return true;
+	const tags = getAlertTagsArray(alert);
+	return tags.some((tag) => filterValues.includes(tag));
+};
+
+export const getAlertTagEntries = (alert: Alert): Array<{ key: string; value: string }> => {
+	if (!alert.tags || typeof alert.tags !== 'object') return [];
+	return Object.entries(alert.tags)
+		.filter(([key, value]) => !HIDDEN_TAG_KEYS.has(key) && Boolean(value))
+		.map(([key, value]) => ({ key, value }));
+};
+
+// ---------- tag-key columns ----------
+
+export const TAG_KEY_COLUMN_PREFIX = 'tagKey:';
+
+export const getTagKeyColumnId = (tagKey: string): string => `${TAG_KEY_COLUMN_PREFIX}${tagKey}`;
+
+export const isTagKeyColumn = (columnId: string): boolean => columnId.startsWith(TAG_KEY_COLUMN_PREFIX);
+
+export const extractTagKeyFromColumnId = (columnId: string): string | null => {
+	if (!isTagKeyColumn(columnId)) return null;
+	return columnId.slice(TAG_KEY_COLUMN_PREFIX.length);
+};
+
+export const getTagKeyValue = (alert: Alert, columnId: string): string => {
+	const tagKey = extractTagKeyFromColumnId(columnId);
+	if (!tagKey) return '';
+	return alert.tags?.[tagKey] || '';
+};
+
+// ---------- integration ----------
+
+export type AlertIntegrationKind = Lowercase<AlertType>;
+
+export const INTEGRATION_LABELS: Record<AlertIntegrationKind, string> = {
+	grafana: 'Grafana',
+	gcp: 'Google Cloud',
+	uptimekuma: 'Uptime Kuma',
+	datadog: 'Datadog',
+	zabbix: 'Zabbix',
+	custom: 'Custom',
+};
+
+export const normalizeIntegration = (value?: string | null): AlertIntegrationKind | undefined => {
+	if (!value) return undefined;
+	const normalized = value.toLowerCase();
+	if (normalized.includes('grafana')) return 'grafana';
+	if (normalized.includes('gcp') || normalized.includes('google')) return 'gcp';
+	if (normalized.includes('uptimekuma') || normalized.includes('uptime-kuma')) return 'uptimekuma';
+	if (normalized.includes('datadog')) return 'datadog';
+	if (normalized.includes('zabbix')) return 'zabbix';
+	if (normalized.includes('custom')) return 'custom';
+	return undefined;
+};
+
+export const resolveAlertIntegration = (alert: Alert): AlertIntegrationKind => {
+	return (
+		normalizeIntegration(alert.type) ||
+		normalizeIntegration(getAlertPrimaryTag(alert)) ||
+		normalizeIntegration(alert.id) ||
+		normalizeIntegration(alert.summary) ||
+		'custom'
+	);
+};
+
+export const getIntegrationLabel = (integration: AlertIntegrationKind): string => INTEGRATION_LABELS[integration];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
 export * from './logger';
 export * from './schemas';
 export * from './types';
+export * from './alerts/alertView';
+export * from './alerts/alertQuery';


### PR DESCRIPTION
## What — Phase 1 of the alerts scalability plan

The client downloaded **every** alert — 10–30K in real deployments — to show the 50–100 a filtered view actually contains, re-running filters in the browser on every poll. Filters, search, sort and paging now push down to the server.

**Measured against a live 10K-alert instance:**

| View | Before | After |
|---|---|---|
| Typical filtered view (167 alerts) | 310 KB, 165 ms | **5.4 KB, 7 ms** |
| Filtered page of 500 | 310 KB | 14.7 KB |
| Sidebar facet counts | derived from full download | 27 KB endpoint, exact over 10K |

## The design premise: one engine, zero drift

The server must never disagree with what the client would have computed. So the filter/search/sort/facet logic moved to `packages/shared` as the **single implementation both sides import**:

- `alerts/alertView.ts` — severity, fix, owner, tags, tag-key columns, integration kinds
- `alerts/alertQuery.ts` — the engine: sidebar-filter matching (incl. `!field` exclusions), time-window overlap + firing-episode rewrite, search, total-order sort (id tiebreak), keyset paging, faceted counts, tag-key collection

Client modules now delegate to these. **The untouched client test suite passing over the shared implementations is the no-drift proof.**

## Server

- `GET /alerts` and `/alerts/resolved` accept `filters` (the dashboard's own record shape, JSON-encoded), `from`/`to`, `search`, `sort`/`dir`, `limit`, `cursor` — zod-parsed, executed over the Phase-0 snapshot; paged responses carry their own content ETag (304s on unchanged pages)
- New `GET /alerts/facets` + `/alerts/resolved/facets` — faceted counts (a facet is never constrained by its own filter), tag keys, and the silenced total over the raw list
- **No params → the legacy full-snapshot response, byte-identical** — old clients and the playground keep working

## Client

- The two alert hooks became one infinite query each; the server query always uses the **status-suspended filter record** — the superset of all three views — so one query serves Active/Resolved/All with the existing client pipeline narrowing on top, idempotent by construction
- Rolling time presets round outward to the minute: stable query key, server window stays a superset, client narrows exactly
- Sidebar reads server facets (exact counts over the full dataset); client derivation kept as fallback; playground serves facets from a mock handler over the same shared engine
- Past 500 loaded rows: banner ("Showing the N most recent of T…") + the virtualized table fetches the next page near the scroll end
- **Views under 500 matches — the common case — load completely and behave exactly as before**: client-side grouping, instant sort flips, complete select-all

## Verified live (10K seeded alerts, real browser)

- Unfiltered view: banner + infinite scroll 500 → 3,500, tracking live
- svc filter → exactly 500, banner gone; + env filter → exactly 167
- Sidebar counts exact over 10K with only a page loaded (Severity 3334/3333/3333)
- Every request (list, resolved, facets) carries the filter record

## Tests

- 8 engine tests (paging, cursor recovery when a row disappears, facet self-exemption)
- 9 HTTP-contract tests (param parsing, envelope, ETag/304, legacy path, 400s)
- Full suite: 177 server + 145 client, lint 0 errors, forced uncached build green

## Known scope cuts (deliberate, follow-ups)

- Table sort stays client-side over the loaded set; beyond the page limit, the page is always the newest matches
- Select-all applies to loaded rows (complete whenever no banner is shown)
- Group-by groups the loaded set; exact group counts beyond the limit come with the group-summaries endpoint (next phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side filtering, searching, sorting, and time-range support for active and resolved alerts.
  * Added paginated alert loading with automatic additional results as users scroll.
  * Added facet counts and dynamic filter options for alert views.
  * Added partial-results messaging when more matching alerts are available.
  * Search now updates smoothly as you type.
  * Bulk selection now indicates when matching alerts remain unloaded.
* **Bug Fixes**
  * Improved consistency of alert filtering, sorting, tags, severity, ownership, and integration details across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->