### PR TITLE
feat(alerts): server group summaries — true header counts at any scale (Phase 2a)

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -12,6 +12,7 @@ import { useDashboard } from '@/context/DashboardContext';
 import { deserializeTimeRange, readLegacySeverityColors, serializeTimeRange } from '@/context/DashboardContext.utils';
 import {
 	useAlertFacets,
+	useAlertGroupSummaries,
 	useAlerts,
 	useResolvedAlerts,
 	useDeleteResolvedAlert,
@@ -29,7 +30,7 @@ import { AlertFacetsResponse } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { Bell, BellOff, CheckCircle2, ChevronDown, Columns2, LayoutList, Palette, WrapText } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { AlertsFilterPanel } from '.';
 import { AlertDetailsPanel } from './AlertDetails';
 import { AlertsSelectionBar } from './AlertsSelectionBar';
@@ -39,7 +40,7 @@ import { AssignmentPane } from './AssignmentPane';
 import { VerticalSplit } from './VerticalSplit';
 import { ACTIONS_COLUMN } from './AlertsTable/AlertsTable.constants';
 import { areSilencedAlertsShown, toggleSilencedAlerts } from './utils/silenced.utils';
-import { AlertTab } from './AlertsTable/AlertsTable.types';
+import { AlertTab, GroupStatus } from './AlertsTable/AlertsTable.types';
 import { SearchBar } from './AlertsTable/SearchBar';
 import { TimeFilter, createEmptyTimeRange } from './AlertsTable/TimeFilter';
 import { resolveTimeRange } from './AlertsTable/TimeFilter/TimeFilter.utils';
@@ -72,6 +73,11 @@ const SERVER_PAGE_SIZE = 500;
 // Grouping loads the whole matching set, so a 5s poll would re-download all of it every
 // tick. A grouped overview doesn't need second-by-second freshness — poll it slower.
 const GROUPED_POLL_MS = 20 * 1000;
+
+// Grouped views up to this size load whole (complete client-side grouping, the original
+// UX). Above it — resolved tabs holding 50-60k in real deployments — rows page in like a
+// flat view while group headers read TRUE totals from the server summaries endpoint.
+const GROUP_LOAD_ALL_MAX = 5000;
 
 // Rolling presets re-anchor to "now" continuously; a raw resolved window in the query
 // would mint a new cache key every tick. Rounding the window OUTWARD to the minute keeps
@@ -172,6 +178,11 @@ const Alerts = () => {
 	const activeViewed = activeTab === AlertTab.Active || activeTab === AlertTab.All;
 	const resolvedViewed = activeTab === AlertTab.Resolved || activeTab === AlertTab.All;
 
+	// Last-known per-list totals (Infinity = not yet known). Written after the queries
+	// below resolve; their arrival re-renders, so the next render reads fresh values.
+	const lastActiveTotal = useRef(Number.POSITIVE_INFINITY);
+	const lastResolvedTotal = useRef(Number.POSITIVE_INFINITY);
+
 	const baseQuery = useMemo(() => {
 		const window = toCoarseWindow(dashboardState.timeRange);
 		return {
@@ -184,13 +195,22 @@ const Alerts = () => {
 		};
 	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort]);
 
+	// Load-all is gated on the last-known total staying under GROUP_LOAD_ALL_MAX: page
+	// one's response carries the total (regardless of limit), and when it's small enough
+	// the query re-keys to unlimited and grouping is complete — the original UX, at the
+	// cost of one extra fetch when grouping turns on. Totals above the threshold keep
+	// paging; the summaries endpoint supplies true header counts instead. Unknown totals
+	// (first render) page conservatively.
+	const activeGroupLoadAll = isGrouping && activeViewed && lastActiveTotal.current <= GROUP_LOAD_ALL_MAX;
+	const resolvedGroupLoadAll = isGrouping && resolvedViewed && lastResolvedTotal.current <= GROUP_LOAD_ALL_MAX;
+
 	const activeQuery = useMemo(
-		() => ({ ...baseQuery, limit: isGrouping && activeViewed ? undefined : SERVER_PAGE_SIZE }),
-		[baseQuery, isGrouping, activeViewed]
+		() => ({ ...baseQuery, limit: activeGroupLoadAll ? undefined : SERVER_PAGE_SIZE }),
+		[baseQuery, activeGroupLoadAll]
 	);
 	const resolvedQuery = useMemo(
-		() => ({ ...baseQuery, limit: isGrouping && resolvedViewed ? undefined : SERVER_PAGE_SIZE }),
-		[baseQuery, isGrouping, resolvedViewed]
+		() => ({ ...baseQuery, limit: resolvedGroupLoadAll ? undefined : SERVER_PAGE_SIZE }),
+		[baseQuery, resolvedGroupLoadAll]
 	);
 
 	const {
@@ -211,6 +231,56 @@ const Alerts = () => {
 	} = useResolvedAlerts(resolvedQuery, {
 		refetchIntervalMs: isGrouping && resolvedViewed ? GROUPED_POLL_MS : undefined,
 	});
+	lastActiveTotal.current = activeTotal;
+	lastResolvedTotal.current = resolvedTotal;
+
+	// True group-header counts for grouped views too large to load whole. Fetched per
+	// list only when that list is grouped-but-paged; joined onto headers by group key.
+	const activeSummaries = useAlertGroupSummaries(dashboardState.groupBy, baseQuery, {
+		enabled: isGrouping && activeViewed && !activeGroupLoadAll,
+	});
+	const resolvedSummaries = useAlertGroupSummaries(dashboardState.groupBy, baseQuery, {
+		resolved: true,
+		enabled: isGrouping && resolvedViewed && !resolvedGroupLoadAll,
+	});
+
+	// The tab's summary map for header overrides. The All view renders one tree over
+	// active+resolved rows, so its buckets are the SUM of both lists' summaries.
+	const groupSummaryByKey = useMemo(() => {
+		if (!isGrouping) return undefined;
+		const wantActive = activeViewed && !activeGroupLoadAll;
+		const wantResolved = resolvedViewed && !resolvedGroupLoadAll;
+		if (!wantActive && !wantResolved) return undefined;
+		const merged = new Map<string, { count: number; status: GroupStatus }>();
+		const precedence: GroupStatus[] = ['firing', 'muted', 'resolved', 'silenced'];
+		const fold = (map?: Map<string, { count: number; status: GroupStatus }>) => {
+			map?.forEach((node, key) => {
+				const existing = merged.get(key);
+				if (!existing) {
+					merged.set(key, { count: node.count, status: node.status });
+				} else {
+					merged.set(key, {
+						count: existing.count + node.count,
+						status:
+							precedence.indexOf(node.status) < precedence.indexOf(existing.status)
+								? node.status
+								: existing.status,
+					});
+				}
+			});
+		};
+		if (wantActive) fold(activeSummaries.byKey);
+		if (wantResolved) fold(resolvedSummaries.byKey);
+		return merged.size > 0 ? merged : undefined;
+	}, [
+		isGrouping,
+		activeViewed,
+		resolvedViewed,
+		activeGroupLoadAll,
+		resolvedGroupLoadAll,
+		activeSummaries.byKey,
+		resolvedSummaries.byKey,
+	]);
 
 	const [selectedAlerts, setSelectedAlerts] = useState<Alert[]>([]);
 	const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
@@ -573,6 +643,7 @@ const Alerts = () => {
 		<AlertsTable
 			alerts={list}
 			onEndReached={loadMoreActive}
+			groupSummaryByKey={groupSummaryByKey}
 			sortField={alertSort.field}
 			sortDirection={alertSort.dir}
 			onSortChange={(field, dir) => setAlertSort({ field, dir })}
@@ -929,6 +1000,7 @@ const Alerts = () => {
 								<AlertsTable
 									alerts={resolvedViewAlerts}
 									onEndReached={loadMoreResolved}
+									groupSummaryByKey={groupSummaryByKey}
 									sortField={alertSort.field}
 									sortDirection={alertSort.dir}
 									onSortChange={(field, dir) => setAlertSort({ field, dir })}
@@ -972,6 +1044,7 @@ const Alerts = () => {
 								<AlertsTable
 									alerts={filteredAllAlerts}
 									onEndReached={loadMoreAll}
+									groupSummaryByKey={groupSummaryByKey}
 									sortField={alertSort.field}
 									sortDirection={alertSort.dir}
 									onSortChange={(field, dir) => setAlertSort({ field, dir })}

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -234,22 +234,38 @@ const Alerts = () => {
 	lastActiveTotal.current = activeTotal;
 	lastResolvedTotal.current = resolvedTotal;
 
-	// True group-header counts for grouped views too large to load whole. Fetched per
-	// list only when that list is grouped-but-paged; joined onto headers by group key.
-	const activeSummaries = useAlertGroupSummaries(dashboardState.groupBy, baseQuery, {
-		enabled: isGrouping && activeViewed && !activeGroupLoadAll,
+	// True group-header counts for grouped views too large to load whole.
+	//
+	// Filters must match what the TAB actually renders: the Active view narrows rows by
+	// the full filter record (status included), so its summaries query the full record
+	// too — a suspended-status summary would count statuses the table excludes. The All
+	// view (and Resolved) render with status suspended, so those summaries stay on the
+	// suspended record.
+	//
+	// The All view renders ONE tree over both lists, so when it needs an override at
+	// all, BOTH lists' summaries are fetched — merging only the paged side would
+	// undercount buckets that exist in both lists.
+	const allNeedsSummaries = activeTab === AlertTab.All && (!activeGroupLoadAll || !resolvedGroupLoadAll);
+	const activeSummaryQuery = useMemo(
+		() => (activeTab === AlertTab.Active ? { ...baseQuery, filters: dashboardState.filters } : baseQuery),
+		[activeTab, baseQuery, dashboardState.filters]
+	);
+	const activeSummaries = useAlertGroupSummaries(dashboardState.groupBy, activeSummaryQuery, {
+		enabled: isGrouping && ((activeTab === AlertTab.Active && !activeGroupLoadAll) || allNeedsSummaries),
 	});
 	const resolvedSummaries = useAlertGroupSummaries(dashboardState.groupBy, baseQuery, {
 		resolved: true,
-		enabled: isGrouping && resolvedViewed && !resolvedGroupLoadAll,
+		enabled: isGrouping && ((activeTab === AlertTab.Resolved && !resolvedGroupLoadAll) || allNeedsSummaries),
 	});
 
 	// The tab's summary map for header overrides. The All view renders one tree over
 	// active+resolved rows, so its buckets are the SUM of both lists' summaries.
 	const groupSummaryByKey = useMemo(() => {
 		if (!isGrouping) return undefined;
-		const wantActive = activeViewed && !activeGroupLoadAll;
-		const wantResolved = resolvedViewed && !resolvedGroupLoadAll;
+		const onAll = activeTab === AlertTab.All;
+		const anyPagedOnAll = onAll && (!activeGroupLoadAll || !resolvedGroupLoadAll);
+		const wantActive = anyPagedOnAll || (activeTab === AlertTab.Active && !activeGroupLoadAll);
+		const wantResolved = anyPagedOnAll || (activeTab === AlertTab.Resolved && !resolvedGroupLoadAll);
 		if (!wantActive && !wantResolved) return undefined;
 		const merged = new Map<string, { count: number; status: GroupStatus }>();
 		const precedence: GroupStatus[] = ['firing', 'muted', 'resolved', 'silenced'];
@@ -274,8 +290,7 @@ const Alerts = () => {
 		return merged.size > 0 ? merged : undefined;
 	}, [
 		isGrouping,
-		activeViewed,
-		resolvedViewed,
+		activeTab,
 		activeGroupLoadAll,
 		resolvedGroupLoadAll,
 		activeSummaries.byKey,

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -52,6 +52,7 @@ export const AlertsTable = ({
 	sortField: controlledSortField,
 	sortDirection: controlledSortDirection,
 	onSortChange,
+	groupSummaryByKey,
 	onSilenceAlert,
 	onUnsilenceAlert,
 	onDeleteAlert,
@@ -133,12 +134,25 @@ export const AlertsTable = ({
 		controlledSortDirection,
 		onSortChange
 	);
-	const { groupByColumns, setGroupByColumns, flatRows, toggleGroup, expandAll, collapseAll } = useAlertGrouping(
-		sortedAlerts,
-		allColumnLabels,
-		controlledGroupBy,
-		onGroupByChange
-	);
+	const {
+		groupByColumns,
+		setGroupByColumns,
+		flatRows: groupedRows,
+		toggleGroup,
+		expandAll,
+		collapseAll,
+	} = useAlertGrouping(sortedAlerts, allColumnLabels, controlledGroupBy, onGroupByChange);
+	// When server summaries are supplied, group headers show the TRUE totals over the
+	// full matching set instead of counting only the loaded page. Same length and keys,
+	// so the virtualizer and sticky headers are unaffected.
+	const flatRows = useMemo(() => {
+		if (!groupSummaryByKey || groupSummaryByKey.size === 0) return groupedRows;
+		return groupedRows.map((item) => {
+			if (item.type !== 'group') return item;
+			const summary = groupSummaryByKey.get(item.key);
+			return summary ? { ...item, count: summary.count, groupStatus: summary.status } : item;
+		});
+	}, [groupedRows, groupSummaryByKey]);
 	const { allSelected, handleSelectAll, handleSelectAlert } = useAlertSelection({
 		sortedAlerts,
 		selectedAlerts,
@@ -210,7 +224,14 @@ export const AlertsTable = ({
 		const maybeFire = () => {
 			if (!onEndReached) return;
 			if (!isScrollable()) {
-				onEndReached();
+				// Auto-fetch on a non-scrollable list is the FLAT-view recovery path
+				// (client-side status narrowing can leave a page too short to scroll).
+				// In grouped mode a short list is the NORMAL collapsed-headers state —
+				// headers carry true totals from the server summaries — and auto-fetching
+				// here would chain-load the entire dataset page by page.
+				if (groupByColumns.length === 0) {
+					onEndReached();
+				}
 				return;
 			}
 			if (scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - NEAR_BOTTOM_PX) {
@@ -220,7 +241,7 @@ export const AlertsTable = ({
 		maybeFire();
 		scroller.addEventListener('scroll', maybeFire, { passive: true });
 		return () => scroller.removeEventListener('scroll', maybeFire);
-	}, [onEndReached, flatRows.length]);
+	}, [onEndReached, flatRows.length, groupByColumns.length]);
 	const activeStickyHeaders = useStickyHeaders({ flatRows, groupByColumns, virtualItems, virtualizer });
 
 	const orderedColumns = useMemo(() => {

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.types.ts
@@ -40,6 +40,10 @@ export interface AlertsTableProps {
 	sortField?: AlertSortField;
 	sortDirection?: SortDirection;
 	onSortChange?: (field: AlertSortField, direction: SortDirection) => void;
+	// Server-computed group summaries (true counts + rollup status over the FULL matching
+	// set), joined onto rendered group headers by key. Provided when the grouped view is
+	// too large to load whole, so headers stay honest while rows page in progressively.
+	groupSummaryByKey?: Map<string, { count: number; status: GroupStatus }>;
 	onColumnToggle?: (column: string) => void;
 	// Persists a user-arranged base-column order (from the column settings drag list).
 	onColumnOrderChange?: (columns: string[]) => void;

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
@@ -1,12 +1,7 @@
 import { UserInfo } from '@/hooks/queries/users';
 import { formatDateTime, formatTime, isSameLocalDay } from '@/lib/datetime';
-import { Alert, searchAlerts, sortAlertsBy } from '@OpsiMate/shared';
+import { Alert, getAlertGroupValue, searchAlerts, sortAlertsBy } from '@OpsiMate/shared';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
-import { getIntegrationLabel, resolveAlertIntegration } from '../IntegrationAvatar';
-import { getAlertTagsString } from '../utils/alertTags.utils';
-import { getOwnerDisplayName, getOwnerSortKey } from '../utils/owner.utils';
-import { getAlertFix, FIX_LABELS, FIX_RANK } from '../utils/fix.utils';
-import { getAlertSeverity, SEVERITY_LABELS, SEVERITY_RANK } from '../utils/severity.utils';
 import { AlertSortField, FlatGroupItem, GroupNode, GroupStatus, SortDirection } from './AlertsTable.types';
 
 // Search lives in @OpsiMate/shared (searchAlerts) so a server-side search matches this
@@ -29,20 +24,6 @@ export const sortAlerts = (
 	users: UserInfo[] = []
 ): Alert[] => sortAlertsBy(alerts, sortField, sortDirection, users);
 
-// Timestamps from today render time-only — the date part is noise for the rows users
-// care about most; older timestamps keep the full date. Sorting is unaffected: it runs
-// on the raw epoch value (getSortValue), never on this display string.
-// Grouping key for time columns: the LOCAL calendar day (YYYY-MM-DD), matching the
-// local time the cells render (formatDate). A UTC day key could disagree with the
-// displayed date near timezone boundaries.
-const toLocalDayKey = (dateString: string): string => {
-	const date = new Date(dateString);
-	if (isNaN(date.getTime())) return 'Unknown';
-	const month = String(date.getMonth() + 1).padStart(2, '0');
-	const day = String(date.getDate()).padStart(2, '0');
-	return `${date.getFullYear()}-${month}-${day}`;
-};
-
 // The full date+time, for tooltips and copy-to-clipboard. Returns undefined for an
 // unparseable value so callers can fall back to the raw string.
 export const formatFullTimestamp = (dateString: string): string | undefined => {
@@ -58,36 +39,11 @@ export const formatDate = (dateString: string): string => {
 	return isSameLocalDay(dateString) ? formatTime(dateString) : full;
 };
 
-export const getAlertValue = (alert: Alert, field: string, users: UserInfo[] = []): string => {
-	if (isTagKeyColumn(field)) {
-		return getTagKeyValue(alert, field) || 'N/A';
-	}
-
-	switch (field) {
-		case 'alertName':
-			return alert.alertName;
-		case 'status':
-			return alert.isSilenced ? 'Silenced' : alert.isMuted ? 'Muted' : 'Firing';
-		case 'severity':
-			return SEVERITY_LABELS[getAlertSeverity(alert)];
-		case 'fix': {
-			const fix = getAlertFix(alert);
-			return fix ? FIX_LABELS[fix] : 'No fix type';
-		}
-		case 'summary':
-			return alert.summary || 'Unknown';
-		case 'startsAt':
-			return toLocalDayKey(alert.startsAt);
-		case 'updatedAt':
-			return toLocalDayKey(alert.updatedAt);
-		case 'type':
-			return getIntegrationLabel(resolveAlertIntegration(alert));
-		case 'owner':
-			return getOwnerDisplayName(alert.ownerId, users);
-		default:
-			return 'Unknown';
-	}
-};
+// Grouping values live in @OpsiMate/shared (getAlertGroupValue) so server-computed
+// group summaries land on exactly the buckets these rows group into. Default day-key:
+// the viewer's local timezone.
+export const getAlertValue = (alert: Alert, field: string, users: UserInfo[] = []): string =>
+	getAlertGroupValue(alert, field, users);
 
 export const createTagKeyValueGetter = (_columnLabels: Record<string, string>, users: UserInfo[] = []) => {
 	return (alert: Alert, field: string): string => getAlertValue(alert, field, users);

--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.utils.ts
@@ -1,6 +1,6 @@
 import { UserInfo } from '@/hooks/queries/users';
 import { formatDateTime, formatTime, isSameLocalDay } from '@/lib/datetime';
-import { Alert, getAlertGroupValue, searchAlerts, sortAlertsBy } from '@OpsiMate/shared';
+import { Alert, getAlertGroupValue, groupKeySegment, searchAlerts, sortAlertsBy } from '@OpsiMate/shared';
 import { extractTagKeyFromColumnId, isTagKeyColumn } from '@/types';
 import { AlertSortField, FlatGroupItem, GroupNode, GroupStatus, SortDirection } from './AlertsTable.types';
 
@@ -77,7 +77,7 @@ const groupAlertsRecursive = (options: GroupAlertsRecursiveOptions): GroupNode[]
 	const sortedKeys = Object.keys(groups).sort();
 
 	return sortedKeys.map((value) => {
-		const groupKey = `${parentKey}:${value}`;
+		const groupKey = groupKeySegment(parentKey, value);
 		const groupAlertsList = groups[value];
 		const children = groupAlertsRecursive({
 			alerts: groupAlertsList,

--- a/apps/client/src/hooks/queries/alerts/index.ts
+++ b/apps/client/src/hooks/queries/alerts/index.ts
@@ -1,5 +1,6 @@
 export { useAlerts } from './useAlerts';
 export { useAlertFacets } from './useAlertFacets';
+export { useAlertGroupSummaries } from './useAlertGroupSummaries';
 export { useResolvedAlerts } from './useResolvedAlerts';
 export { useDeleteAlert } from './useDeleteAlert';
 export { useDeleteResolvedAlert } from './useDeleteResolvedAlert';

--- a/apps/client/src/hooks/queries/alerts/useAlertGroupSummaries.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertGroupSummaries.ts
@@ -1,0 +1,53 @@
+import { alertsApi, AlertQueryParams } from '@/lib/api';
+import { AlertGroupSummaryNode } from '@OpsiMate/shared';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { queryKeys } from '../queryKeys';
+
+// Server-computed group counts + rollup status over the FULL matching set. Used when a
+// grouped view is too large to load whole: rows page in progressively, but the group
+// headers read these true totals — a header can never claim fewer alerts than exist.
+export const useAlertGroupSummaries = (
+	groupBy: string[],
+	params: Omit<AlertQueryParams, 'limit' | 'cursor' | 'sort' | 'dir'>,
+	options?: { resolved?: boolean; enabled?: boolean }
+) => {
+	const { data } = useQuery({
+		queryKey: [
+			...queryKeys.alerts,
+			'groups',
+			options?.resolved ? 'resolved' : 'active',
+			groupBy,
+			params.filters ?? null,
+			params.from ?? null,
+			params.to ?? null,
+			params.search ?? null,
+		],
+		enabled: (options?.enabled ?? true) && groupBy.length > 0,
+		queryFn: async () => {
+			const response = await alertsApi.getAlertGroupSummaries(groupBy, params, options);
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to fetch group summaries');
+			}
+			return response.data.groups;
+		},
+		staleTime: 10 * 1000,
+		refetchInterval: 20 * 1000,
+	});
+
+	// Flattened for O(1) join onto rendered group headers by key.
+	const byKey = useMemo(() => {
+		if (!data) return undefined;
+		const map = new Map<string, AlertGroupSummaryNode>();
+		const walk = (nodes: AlertGroupSummaryNode[]) => {
+			for (const node of nodes) {
+				map.set(node.key, node);
+				walk(node.children);
+			}
+		};
+		walk(data);
+		return map;
+	}, [data]);
+
+	return { groups: data, byKey };
+};

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { CustomAction } from '@OpsiMate/custom-actions';
 import {
+	AlertGroupSummaryNode,
 	Action,
 	ActionConfig,
 	ActionOverrides,
@@ -566,6 +567,24 @@ export const alertsApi = {
 	// Get alerts; with params the server filters/sorts/pages, without them the full list.
 	async getAllAlerts(params?: AlertQueryParams): Promise<ApiResponse<AlertListResponse>> {
 		return await apiRequest<AlertListResponse>(`/alerts${alertQueryString(params)}`);
+	},
+
+	// Group counts + rollup status over the full matching set — no alerts in the payload.
+	async getAlertGroupSummaries(
+		groupBy: string[],
+		params: Omit<AlertQueryParams, 'limit' | 'cursor' | 'sort' | 'dir'>,
+		options?: AlertFacetsOptions
+	): Promise<ApiResponse<{ groups: AlertGroupSummaryNode[] }>> {
+		const q = new URLSearchParams();
+		q.set('groupBy', JSON.stringify(groupBy));
+		if (params.filters && Object.keys(params.filters).length > 0) q.set('filters', JSON.stringify(params.filters));
+		if (params.from) q.set('from', params.from);
+		if (params.to) q.set('to', params.to);
+		if (params.search?.trim()) q.set('search', params.search);
+		const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+		if (timeZone) q.set('timeZone', timeZone);
+		const base = options?.resolved ? '/alerts/resolved/groups' : '/alerts/groups';
+		return await apiRequest<{ groups: AlertGroupSummaryNode[] }>(`${base}?${q.toString()}`);
 	},
 
 	// Faceted sidebar counts + tag keys over the raw dataset, computed server-side.

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -1,11 +1,12 @@
 import {
-	alertMatchesFilters,
-	computeAlertFacets,
-	computeAlertGroupSummaries,
+	Alert,
 	AlertHistoryData,
 	AlertHistoryEventType,
 	AlertStatus,
 	OncallTeam,
+	applyAlertListQuery,
+	computeAlertFacets,
+	computeAlertGroupSummaries,
 } from '@OpsiMate/shared';
 import { http, HttpResponse } from 'msw';
 import { getPlaygroundUser, OncallTeamState, playgroundState, randomId } from './state';
@@ -173,6 +174,30 @@ const parseFacetsParams = (url: URL): { filters: Record<string, string[]>; field
 	}
 };
 
+// Mirrors the server's group-summaries contract: the FULL query (filters, time window,
+// search) constrains the summarized set — exactly what applyAlertListQuery does server-
+// side — and malformed JSON is a 400.
+const mockGroupSummaries = (request: Request, alerts: Alert[]) => {
+	const url = new URL(request.url);
+	try {
+		const groupBy = JSON.parse(url.searchParams.get('groupBy') ?? '[]') as string[];
+		const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
+		const timeZone = url.searchParams.get('timeZone') ?? undefined;
+		const { items } = applyAlertListQuery(alerts, [], {
+			filters,
+			from: url.searchParams.get('from'),
+			to: url.searchParams.get('to'),
+			search: url.searchParams.get('search') ?? undefined,
+		});
+		return HttpResponse.json({
+			success: true,
+			data: { groups: computeAlertGroupSummaries(items, groupBy, [], timeZone) },
+		});
+	} catch {
+		return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
+	}
+};
+
 export const handlers = [
 	// ==================== ALERTS ====================
 	http.get(`${API_BASE}/alerts`, () => {
@@ -195,22 +220,13 @@ export const handlers = [
 		});
 	}),
 
-	http.get(`${API_BASE}/alerts/groups`, ({ request }) => {
-		const url = new URL(request.url);
-		try {
-			const groupBy = JSON.parse(url.searchParams.get('groupBy') ?? '[]') as string[];
-			const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
-			const timeZone = url.searchParams.get('timeZone') ?? undefined;
-			const alerts = playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment);
-			const matching = alerts.filter((a) => alertMatchesFilters(a, filters, []));
-			return HttpResponse.json({
-				success: true,
-				data: { groups: computeAlertGroupSummaries(matching, groupBy, [], timeZone) },
-			});
-		} catch {
-			return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
-		}
-	}),
+	http.get(`${API_BASE}/alerts/groups`, ({ request }) =>
+		mockGroupSummaries(request, playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment))
+	),
+
+	http.get(`${API_BASE}/alerts/resolved/groups`, ({ request }) =>
+		mockGroupSummaries(request, playgroundState.resolvedAlerts.map(withLastComment))
+	),
 
 	http.get(`${API_BASE}/alerts/facets`, ({ request }) => {
 		const url = new URL(request.url);

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -1,4 +1,12 @@
-import { computeAlertFacets, AlertHistoryData, AlertHistoryEventType, AlertStatus, OncallTeam } from '@OpsiMate/shared';
+import {
+	alertMatchesFilters,
+	computeAlertFacets,
+	computeAlertGroupSummaries,
+	AlertHistoryData,
+	AlertHistoryEventType,
+	AlertStatus,
+	OncallTeam,
+} from '@OpsiMate/shared';
 import { http, HttpResponse } from 'msw';
 import { getPlaygroundUser, OncallTeamState, playgroundState, randomId } from './state';
 
@@ -185,6 +193,23 @@ export const handlers = [
 			success: true,
 			data: { alerts: playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment) },
 		});
+	}),
+
+	http.get(`${API_BASE}/alerts/groups`, ({ request }) => {
+		const url = new URL(request.url);
+		try {
+			const groupBy = JSON.parse(url.searchParams.get('groupBy') ?? '[]') as string[];
+			const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
+			const timeZone = url.searchParams.get('timeZone') ?? undefined;
+			const alerts = playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment);
+			const matching = alerts.filter((a) => alertMatchesFilters(a, filters, []));
+			return HttpResponse.json({
+				success: true,
+				data: { groups: computeAlertGroupSummaries(matching, groupBy, [], timeZone) },
+			});
+		} catch {
+			return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
+		}
 	}),
 
 	http.get(`${API_BASE}/alerts/facets`, ({ request }) => {

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -25,7 +25,12 @@ import {
 import { isZodError } from '../../../utils/isZodError.ts';
 import { ifNoneMatchSatisfied } from '../../../utils/etag';
 import crypto from 'crypto';
-import { ALERT_QUERY_PARAM_KEYS, AlertFacetsParamsSchema, AlertListQueryParamsSchema } from './models';
+import {
+	ALERT_QUERY_PARAM_KEYS,
+	AlertFacetsParamsSchema,
+	AlertGroupsParamsSchema,
+	AlertListQueryParamsSchema,
+} from './models';
 import { createHash } from 'crypto';
 import { AuthenticatedRequest } from '../../../middleware/auth.ts';
 
@@ -65,6 +70,34 @@ export class AlertController {
 				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error computing alert facets:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
+	async getAlertGroupSummaries(req: Request, res: Response) {
+		try {
+			const params = AlertGroupsParamsSchema.parse(req.query);
+			const groups = await this.alertBL.getAlertGroupSummaries(params, params.groupBy, params.timeZone);
+			return res.json({ success: true, data: { groups } });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
+			logger.error('Error computing alert group summaries:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
+	async getResolvedAlertGroupSummaries(req: Request, res: Response) {
+		try {
+			const params = AlertGroupsParamsSchema.parse(req.query);
+			const groups = await this.alertBL.getResolvedAlertGroupSummaries(params, params.groupBy, params.timeZone);
+			return res.json({ success: true, data: { groups } });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
+			logger.error('Error computing resolved alert group summaries:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
 	}

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -349,6 +349,16 @@ export const AlertFacetsParamsSchema = z.object({
 	fields: FieldsParamSchema.optional(),
 });
 
+export const AlertGroupsParamsSchema = z.object({
+	groupBy: FieldsParamSchema,
+	filters: FiltersParamSchema.optional(),
+	from: z.iso.datetime({ offset: true }).optional(),
+	to: z.iso.datetime({ offset: true }).optional(),
+	search: z.string().optional(),
+	// The viewer's IANA timezone, so date grouping buckets by THEIR day boundaries.
+	timeZone: z.string().max(64).optional(),
+});
+
 // Any of these present means the caller speaks the query contract; none means the
 // legacy full-snapshot response (older clients, playground harnesses).
 export const ALERT_QUERY_PARAM_KEYS = ['filters', 'from', 'to', 'search', 'sort', 'dir', 'limit', 'cursor'] as const;

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -7,6 +7,7 @@ export default function createAlertRouter(controller: AlertController) {
 	// CRUD
 	router.get('/', controller.getAlerts.bind(controller));
 	router.get('/facets', controller.getAlertFacets.bind(controller));
+	router.get('/groups', controller.getAlertGroupSummaries.bind(controller));
 
 	// Daily silence reset settings (admin; must be before /:alertId to avoid route conflicts)
 	router.get('/silence-reset', controller.getSilenceResetSettings.bind(controller));
@@ -15,6 +16,7 @@ export default function createAlertRouter(controller: AlertController) {
 	// Resolved alerts (must be before /:alertId to avoid route conflicts)
 	router.get('/resolved', controller.getResolvedAlerts.bind(controller));
 	router.get('/resolved/facets', controller.getResolvedAlertFacets.bind(controller));
+	router.get('/resolved/groups', controller.getResolvedAlertGroupSummaries.bind(controller));
 	router.delete('/resolved/:alertId', controller.deleteResolvedAlert.bind(controller));
 	router.patch('/resolved/:id/owner', controller.setResolvedAlertOwner.bind(controller));
 	router.patch('/resolved/:id/unresolve', controller.unresolveAlert.bind(controller));

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -22,11 +22,13 @@ import { MutePolicyBL } from '../mute-policies/mutePolicy.bl';
 import { Snapshot, SnapshotCache } from './snapshotCache';
 import {
 	AlertFacetsResult,
+	AlertGroupSummaryNode,
 	AlertListPage,
 	AlertListQuery,
 	AlertOwnerInfo,
 	applyAlertListQuery,
 	computeAlertFacets,
+	computeAlertGroupSummaries,
 } from '@OpsiMate/shared';
 
 const logger = new Logger('bl/alert.bl');
@@ -104,6 +106,38 @@ export class AlertBL {
 	async getResolvedAlertFacets(filters: Record<string, string[]>, fields?: string[]): Promise<AlertFacetsResult> {
 		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.getOwnerInfos()]);
 		return computeAlertFacets(snapshot.value, filters, fields, owners);
+	}
+
+	// Group counts + rollup status over the FULL matching set, no alerts in the payload.
+	// The list query (filters/search/time window) runs first with the same shared engine
+	// the paged rows use, then the same grouping code the client renders with — so a
+	// header count can never disagree with the rows beneath it.
+	async getAlertGroupSummaries(
+		query: AlertListQuery,
+		groupBy: string[],
+		timeZone?: string
+	): Promise<AlertGroupSummaryNode[]> {
+		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
+		const { items } = applyAlertListQuery(snapshot.value, owners, {
+			...query,
+			limit: undefined,
+			cursor: undefined,
+		});
+		return computeAlertGroupSummaries(items, groupBy, owners, timeZone);
+	}
+
+	async getResolvedAlertGroupSummaries(
+		query: AlertListQuery,
+		groupBy: string[],
+		timeZone?: string
+	): Promise<AlertGroupSummaryNode[]> {
+		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.getOwnerInfos()]);
+		const { items } = applyAlertListQuery(snapshot.value, owners, {
+			...query,
+			limit: undefined,
+			cursor: undefined,
+		});
+		return computeAlertGroupSummaries(items, groupBy, owners, timeZone);
 	}
 
 	// Best-effort history logging: never let a failed history write break the underlying

--- a/apps/server/tests/alertsQueryApi.test.ts
+++ b/apps/server/tests/alertsQueryApi.test.ts
@@ -173,17 +173,31 @@ describe('GET /alerts/groups', () => {
 		expect(res.body.data.groups[0].count).toBe(10);
 	});
 
-	test('date grouping honors the viewer timeZone', async () => {
+	test('date grouping buckets by the VIEWER timezone, not the server clock', async () => {
+		// 20:00 UTC is the same instant but a different calendar day in Tokyo (+9,
+		// next day) vs Los Angeles (-7/-8, same day) — an implementation that ignores
+		// timeZone cannot bucket this alert differently per zone.
+		insertAlert('tz-boundary', 'TZ Boundary Alert', { env: 'prod' }, '2026-03-15T20:00:00.000Z');
 		const groupBy = encodeURIComponent(JSON.stringify(['startsAt']));
-		// Fixture alerts start at 12:00 local-server days 1..30; two zones far apart
-		// must both return valid YYYY-MM-DD buckets summing to the full count.
-		for (const tz of ['Asia/Tokyo', 'America/Los_Angeles']) {
-			const res = await get(`/api/v1/alerts/groups?groupBy=${groupBy}&timeZone=${tz}`);
-			expect(res.status).toBe(200);
-			const groups = res.body.data.groups;
-			expect(groups.every((g: { value: string }) => /^\d{4}-\d{2}-\d{2}$/.test(g.value))).toBe(true);
-			expect(groups.reduce((n: number, g: { count: number }) => n + g.count, 0)).toBe(30);
-		}
+		const search = 'TZ%20Boundary';
+
+		const tokyo = await get(`/api/v1/alerts/groups?groupBy=${groupBy}&search=${search}&timeZone=Asia/Tokyo`);
+		expect(tokyo.status).toBe(200);
+		expect(tokyo.body.data.groups.map((g: { value: string }) => g.value)).toEqual(['2026-03-16']);
+
+		const la = await get(`/api/v1/alerts/groups?groupBy=${groupBy}&search=${search}&timeZone=America/Los_Angeles`);
+		expect(la.body.data.groups.map((g: { value: string }) => g.value)).toEqual(['2026-03-15']);
+
+		db.prepare('DELETE FROM alerts WHERE id = ?').run('tz-boundary');
+	});
+
+	test('group keys are collision-safe when values contain the delimiter', async () => {
+		insertAlert('colon-tag', 'Colon Tag Alert', { env: 'a:b' }, new Date(2026, 0, 2, 12, 0, 0).toISOString());
+		const groupBy = encodeURIComponent(JSON.stringify(['tagKey:env']));
+		const res = await get(`/api/v1/alerts/groups?groupBy=${groupBy}`);
+		const colonGroup = res.body.data.groups.find((g: { value: string }) => g.value === 'a:b');
+		expect(colonGroup.key).toBe('root:a%3Ab');
+		db.prepare('DELETE FROM alerts WHERE id = ?').run('colon-tag');
 	});
 
 	test('groupBy is required and malformed params are a 400', async () => {

--- a/apps/server/tests/alertsQueryApi.test.ts
+++ b/apps/server/tests/alertsQueryApi.test.ts
@@ -139,3 +139,62 @@ describe('GET /alerts/resolved with query params', () => {
 		expect(res.body.data).toHaveProperty('nextCursor');
 	});
 });
+
+describe('GET /alerts/groups', () => {
+	test('returns group counts + rollup status over the whole matching set, no alerts', async () => {
+		const groupBy = encodeURIComponent(JSON.stringify(['tagKey:env']));
+		const res = await get(`/api/v1/alerts/groups?groupBy=${groupBy}`);
+		expect(res.status).toBe(200);
+		const groups = res.body.data.groups;
+		expect(groups.map((g: { value: string; count: number }) => [g.value, g.count])).toEqual([
+			['prod', 10],
+			['staging', 20],
+		]);
+		expect(groups[0].status).toBe('firing');
+		expect(groups[0].key).toBe('root:prod');
+		expect(groups[0]).not.toHaveProperty('alerts');
+	});
+
+	test('nested groupBy nests counts under parent keys', async () => {
+		const groupBy = encodeURIComponent(JSON.stringify(['tagKey:env', 'severity']));
+		const res = await get(`/api/v1/alerts/groups?groupBy=${groupBy}`);
+		const prod = res.body.data.groups.find((g: { value: string }) => g.value === 'prod');
+		expect(prod.children.length).toBeGreaterThan(0);
+		expect(prod.children[0].key.startsWith('root:prod:')).toBe(true);
+		const childSum = prod.children.reduce((n: number, c: { count: number }) => n + c.count, 0);
+		expect(childSum).toBe(prod.count);
+	});
+
+	test('filters and search constrain the summaries like the list', async () => {
+		const groupBy = encodeURIComponent(JSON.stringify(['tagKey:env']));
+		const filters = encodeURIComponent(JSON.stringify({ 'tagKey:env': ['prod'] }));
+		const res = await get(`/api/v1/alerts/groups?groupBy=${groupBy}&filters=${filters}`);
+		expect(res.body.data.groups).toHaveLength(1);
+		expect(res.body.data.groups[0].count).toBe(10);
+	});
+
+	test('date grouping honors the viewer timeZone', async () => {
+		const groupBy = encodeURIComponent(JSON.stringify(['startsAt']));
+		// Fixture alerts start at 12:00 local-server days 1..30; two zones far apart
+		// must both return valid YYYY-MM-DD buckets summing to the full count.
+		for (const tz of ['Asia/Tokyo', 'America/Los_Angeles']) {
+			const res = await get(`/api/v1/alerts/groups?groupBy=${groupBy}&timeZone=${tz}`);
+			expect(res.status).toBe(200);
+			const groups = res.body.data.groups;
+			expect(groups.every((g: { value: string }) => /^\d{4}-\d{2}-\d{2}$/.test(g.value))).toBe(true);
+			expect(groups.reduce((n: number, g: { count: number }) => n + g.count, 0)).toBe(30);
+		}
+	});
+
+	test('groupBy is required and malformed params are a 400', async () => {
+		expect((await get('/api/v1/alerts/groups')).status).toBe(400);
+		expect((await get('/api/v1/alerts/groups?groupBy=not-json')).status).toBe(400);
+	});
+
+	test('resolved endpoint exists with the same contract', async () => {
+		const groupBy = encodeURIComponent(JSON.stringify(['severity']));
+		const res = await get(`/api/v1/alerts/resolved/groups?groupBy=${groupBy}`);
+		expect(res.status).toBe(200);
+		expect(Array.isArray(res.body.data.groups)).toBe(true);
+	});
+});

--- a/packages/shared/src/alerts/alertGroups.ts
+++ b/packages/shared/src/alerts/alertGroups.ts
@@ -1,4 +1,4 @@
-import { Alert } from '../types';
+import { Alert, AlertStatus } from '../types';
 import {
 	AlertOwnerInfo,
 	FIX_LABELS,
@@ -95,7 +95,7 @@ export interface AlertGroupSummaryNode {
 const leafStatus = (alert: Alert): AlertGroupStatus => {
 	if (alert.isSilenced) return 'silenced';
 	if (alert.isMuted) return 'muted';
-	return alert.status === 'firing' ? 'firing' : 'resolved';
+	return alert.status === AlertStatus.FIRING ? 'firing' : 'resolved';
 };
 
 // Rollup precedence mirrors the client's getGroupStatus: firing > muted > resolved,

--- a/packages/shared/src/alerts/alertGroups.ts
+++ b/packages/shared/src/alerts/alertGroups.ts
@@ -80,9 +80,16 @@ export const getAlertGroupValue = (
 
 export type AlertGroupStatus = 'firing' | 'muted' | 'resolved' | 'silenced';
 
+// One path segment of a group key. Values are URI-encoded so a value containing ':'
+// (tag values like "env:prod" exist in the wild) cannot collide with a nested path —
+// 'root:a%3Ab' and 'root:a:b' stay distinct. Both group builders (this one and the
+// client's row tree) use it, so summary joins by key are unambiguous.
+export const groupKeySegment = (parentKey: string, value: string): string =>
+	`${parentKey}:${encodeURIComponent(value)}`;
+
 export interface AlertGroupSummaryNode {
-	// Same key scheme the client's group tree uses ('root:<value>:<child value>…'), so
-	// summary counts can be joined onto rendered group headers by key.
+	// Same key scheme the client's group tree uses (see groupKeySegment), so summary
+	// counts can be joined onto rendered group headers by key.
 	key: string;
 	field: string;
 	value: string;
@@ -136,7 +143,7 @@ const summarizeRecursive = (
 	return Object.keys(buckets)
 		.sort()
 		.map((value) => {
-			const groupKey = `${parentKey}:${value}`;
+			const groupKey = groupKeySegment(parentKey, value);
 			const members = buckets[value];
 			const children = summarizeRecursive(members, restFields, level + 1, groupKey, users, dayKey);
 			return {

--- a/packages/shared/src/alerts/alertGroups.ts
+++ b/packages/shared/src/alerts/alertGroups.ts
@@ -1,0 +1,163 @@
+import { Alert } from '../types';
+import {
+	AlertOwnerInfo,
+	FIX_LABELS,
+	getAlertFix,
+	getAlertSeverity,
+	getIntegrationLabel,
+	getOwnerDisplayName,
+	getTagKeyValue,
+	isTagKeyColumn,
+	resolveAlertIntegration,
+	SEVERITY_LABELS,
+} from './alertView';
+
+// Grouping semantics — the value an alert groups under, and group summaries (counts +
+// rolled-up status) computed WITHOUT shipping the alerts. One implementation for both
+// sides: the client groups loaded rows with it, and the server serves summary counts
+// over the full dataset with it, so a header count can never land on a different bucket
+// than the rows beneath it.
+
+// Day bucket for date grouping, in the VIEWER's timezone. The client passes nothing
+// (runtime local = the viewer); the server passes the IANA timezone the client sent —
+// a fixed UTC offset would mis-bucket dates across DST boundaries, an IANA zone won't.
+// 'en-CA' formats as YYYY-MM-DD, matching the key shape grouping has always used.
+export const makeDayKeyFn = (timeZone?: string) => {
+	return (dateString: string): string => {
+		const date = new Date(dateString);
+		if (isNaN(date.getTime())) return 'Unknown';
+		try {
+			return date.toLocaleDateString('en-CA', timeZone ? { timeZone } : undefined);
+		} catch {
+			// Unknown/invalid zone name: fall back to the runtime's local zone rather
+			// than failing the whole summaries request.
+			return date.toLocaleDateString('en-CA');
+		}
+	};
+};
+
+const defaultDayKey = makeDayKeyFn();
+
+// The value an alert presents for a GROUPING field. Note the deliberate differences from
+// the filter-field values (getAlertFilterFieldValue): missing tag values group under
+// 'N/A' (filters use ''), unknown fields group under 'Unknown' (filters never constrain),
+// and status buckets any non-silenced/non-muted alert as 'Firing' — a long-standing
+// behavior ported as-is so server summaries match the client's buckets exactly.
+export const getAlertGroupValue = (
+	alert: Alert,
+	field: string,
+	users: AlertOwnerInfo[],
+	dayKey: (dateString: string) => string = defaultDayKey
+): string => {
+	if (isTagKeyColumn(field)) {
+		return getTagKeyValue(alert, field) || 'N/A';
+	}
+	switch (field) {
+		case 'alertName':
+			return alert.alertName;
+		case 'status':
+			return alert.isSilenced ? 'Silenced' : alert.isMuted ? 'Muted' : 'Firing';
+		case 'severity':
+			return SEVERITY_LABELS[getAlertSeverity(alert)];
+		case 'fix': {
+			const fix = getAlertFix(alert);
+			return fix ? FIX_LABELS[fix] : 'No fix type';
+		}
+		case 'summary':
+			return alert.summary || 'Unknown';
+		case 'startsAt':
+			return dayKey(alert.startsAt);
+		case 'updatedAt':
+			return dayKey(alert.updatedAt);
+		case 'type':
+			return getIntegrationLabel(resolveAlertIntegration(alert));
+		case 'owner':
+			return getOwnerDisplayName(alert.ownerId, users);
+		default:
+			return 'Unknown';
+	}
+};
+
+export type AlertGroupStatus = 'firing' | 'muted' | 'resolved' | 'silenced';
+
+export interface AlertGroupSummaryNode {
+	// Same key scheme the client's group tree uses ('root:<value>:<child value>…'), so
+	// summary counts can be joined onto rendered group headers by key.
+	key: string;
+	field: string;
+	value: string;
+	count: number;
+	status: AlertGroupStatus;
+	level: number;
+	children: AlertGroupSummaryNode[];
+}
+
+const leafStatus = (alert: Alert): AlertGroupStatus => {
+	if (alert.isSilenced) return 'silenced';
+	if (alert.isMuted) return 'muted';
+	return alert.status === 'firing' ? 'firing' : 'resolved';
+};
+
+// Rollup precedence mirrors the client's getGroupStatus: firing > muted > resolved,
+// with an all-silenced group reading silenced.
+const rollupStatus = (statuses: Iterable<AlertGroupStatus>): AlertGroupStatus => {
+	let hasFiring = false;
+	let hasMuted = false;
+	let hasResolved = false;
+	for (const s of statuses) {
+		if (s === 'firing') hasFiring = true;
+		else if (s === 'muted') hasMuted = true;
+		else if (s === 'resolved') hasResolved = true;
+	}
+	if (hasFiring) return 'firing';
+	if (hasMuted) return 'muted';
+	if (hasResolved) return 'resolved';
+	return 'silenced';
+};
+
+const summarizeRecursive = (
+	alerts: Alert[],
+	groupBy: string[],
+	level: number,
+	parentKey: string,
+	users: AlertOwnerInfo[],
+	dayKey: (dateString: string) => string
+): AlertGroupSummaryNode[] => {
+	if (groupBy.length === 0) return [];
+	const [currentField, ...restFields] = groupBy;
+
+	const buckets: Record<string, Alert[]> = {};
+	for (const alert of alerts) {
+		const value = getAlertGroupValue(alert, currentField, users, dayKey);
+		(buckets[value] ??= []).push(alert);
+	}
+
+	// Lexicographic key order — the client's group tree sorts the same way.
+	return Object.keys(buckets)
+		.sort()
+		.map((value) => {
+			const groupKey = `${parentKey}:${value}`;
+			const members = buckets[value];
+			const children = summarizeRecursive(members, restFields, level + 1, groupKey, users, dayKey);
+			return {
+				key: groupKey,
+				field: currentField,
+				value,
+				count: members.length,
+				status: rollupStatus(members.map(leafStatus)),
+				level,
+				children,
+			};
+		});
+};
+
+// Group counts + rollup status over a full dataset, no alerts in the payload — what the
+// client needs to render honest group headers when it has only a page of rows loaded.
+export const computeAlertGroupSummaries = (
+	alerts: Alert[],
+	groupBy: string[],
+	users: AlertOwnerInfo[],
+	timeZone?: string
+): AlertGroupSummaryNode[] => {
+	return summarizeRecursive(alerts, groupBy, 0, 'root', users, makeDayKeyFn(timeZone));
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from './schemas';
 export * from './types';
 export * from './alerts/alertView';
 export * from './alerts/alertQuery';
+export * from './alerts/alertGroups';


### PR DESCRIPTION
## What — Phase 2a of the alerts scalability plan

Grouping loads the whole matching set for complete counts — right for the common case, wrong at the extreme: real deployments hold **50–60k resolved alerts**, and grouping that tab downloaded all of them.

Grouped views now split on a threshold (`GROUP_LOAD_ALL_MAX = 5000`):

| View size | Behavior |
|---|---|
| ≤ 5000 (active tabs, filtered views — the everyday case) | Query re-keys to unlimited once the first page reports the total → **complete client-side grouping, the original UX** |
| > 5000 | Rows stay **paged** like a flat view; group headers read **true totals** from the new summaries endpoints; expanding a group shows loaded members and scrolling pages in more |

## New endpoints

`GET /alerts/groups` + `GET /alerts/resolved/groups` — group counts + rollup status (firing > muted > resolved > silenced) over the **full matching set** (same filters/search/time-window contract as the list), **no alerts in the payload**. Nested `groupBy` supported; keys use the client's `root:<value>:…` scheme so counts join onto rendered headers by key.

## Zero-drift, again

The grouping-value semantics (including long-standing quirks: `N/A` buckets, status hardcoding `Firing` for non-silenced/muted) moved to `packages/shared/alertGroups`, and the client's `getAlertValue` **delegates to it** — a header count cannot land on a different bucket than the rows beneath it. The untouched client suite passing over the shared implementation is the proof.

**Timezone-correct date grouping:** the client sends its IANA timezone; the shared day-key function buckets by the *viewer's* day boundaries (DST-correct via `Intl`), not the server's clock.

The All view merges both lists' summaries (counts sum, status by precedence). The playground serves summaries from a mock handler over the same shared engine.

## A real bug caught live and fixed here

The flat-view non-scrollable auto-fetch (the stall-recovery from #828) chain-loaded the **entire dataset** in grouped mode — three collapsed headers are legitimately non-scrollable, and each fetched page kept it that way. Auto-fetch is now suppressed while grouped; scroll-driven load-more still works inside expanded groups.

## Verified on a live 10k instance

- Grouping 9,999 by severity: rows stay paged (`limit=500`, one page cached), headers read 3,332 / 3,334 / 3,333 from `/alerts/groups` (request carries filters + `timeZone=Asia/Jerusalem`)
- Filtering to 3,332 (under threshold): re-keys to load-all, complete grouping, ~3.3k rows in the client
- Expanded groups: true count on the header, loaded members shown, scrollable for progressive fill

## Tests

6 new HTTP-contract tests (counts/rollup/nesting sum-to-parent, filters+search constraining, per-timezone date buckets, 400s, resolved parity). Full suite: **188 server + 145 client**, lint 0 errors, forced build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grouped alert summaries with counts and status rollups.
  * Added nested grouping, filtering, date ranges, search, and time-zone-aware date buckets.
  * Added grouped pagination for large alert datasets while preserving accurate totals.
  * Combined active and resolved summaries in the All view with consistent status handling.

* **Bug Fixes**
  * Improved grouped alert display accuracy across active, resolved, and combined views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->