### PR TITLE
feat(alerts): bulk actions by filter — act on every matching alert in one request (Phase 2b)

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -13,7 +13,9 @@ import { deserializeTimeRange, readLegacySeverityColors, serializeTimeRange } fr
 import {
 	useAlertFacets,
 	useAlertGroupSummaries,
+	useAlertMatchCount,
 	useAlerts,
+	useBulkAlertAction,
 	useResolvedAlerts,
 	useDeleteResolvedAlert,
 	useMarkAlertRead,
@@ -30,7 +32,7 @@ import { AlertFacetsResponse } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { Alert } from '@OpsiMate/shared';
 import { Bell, BellOff, CheckCircle2, ChevronDown, Columns2, LayoutList, Palette, WrapText } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AlertsFilterPanel } from '.';
 import { AlertDetailsPanel } from './AlertDetails';
 import { AlertsSelectionBar } from './AlertsSelectionBar';
@@ -298,6 +300,18 @@ const Alerts = () => {
 	]);
 
 	const [selectedAlerts, setSelectedAlerts] = useState<Alert[]>([]);
+	// "Select all N matching" scope: when armed, bulk actions act on EVERY alert matching
+	// the Active view's query — resolved server-side against the full dataset — not just
+	// the loaded selection. Any change to the selection or to what the view shows drops
+	// the flag: the N the user confirmed is no longer what the query means.
+	const [allMatchingSelected, setAllMatchingSelected] = useState(false);
+	const handleSelectAlerts = (next: Alert[]) => {
+		setSelectedAlerts(next);
+		setAllMatchingSelected(false);
+	};
+	useEffect(() => {
+		setAllMatchingSelected(false);
+	}, [activeTab, dashboardState.filters, dashboardState.query, dashboardState.timeRange]);
 	const [selectedAlert, setSelectedAlert] = useState<Alert | null>(null);
 	const [showDashboardSettings, setShowDashboardSettings] = useState(false);
 	const [pendingAction, setPendingAction] = useState<PendingAlertAction | null>(null);
@@ -447,6 +461,25 @@ const Alerts = () => {
 		updateDashboardField('filters', newFilters);
 	};
 
+	// Scope of "apply to all N matching": the Active view's FULL query — the complete
+	// filter record (status included, exactly what narrows the rows the user sees), the
+	// time window and the search — which the server resolves against the whole dataset.
+	const bulkScopeQuery = useMemo(() => {
+		const window = toCoarseWindow(dashboardState.timeRange);
+		return {
+			filters: dashboardState.filters,
+			from: window.from ?? undefined,
+			to: window.to ?? undefined,
+			search: dashboardState.query || undefined,
+		};
+	}, [dashboardState.filters, dashboardState.timeRange, dashboardState.query]);
+	// The N above, from the same server engine that will resolve the bulk action. Only
+	// fetched while an Active-tab selection is open.
+	const bulkMatchCount = useAlertMatchCount(
+		bulkScopeQuery,
+		activeTab === AlertTab.Active && selectedAlerts.length > 0
+	);
+
 	// Derived from the filters themselves rather than tracked separately, so the button and
 	// the sidebar's Status section always describe the same thing. The count comes from the
 	// unfiltered active list — the point of the button is to reveal alerts the current
@@ -485,37 +518,73 @@ const Alerts = () => {
 		[allViewActiveAlerts, resolvedViewAlerts]
 	);
 
-	const {
-		handleSilenceAlert,
-		handleUnsilenceAlert,
-		handleDeleteAlert,
-		handleUnresolveAlert,
-		handleSilenceAll,
-		handleUnsilenceAll,
-		handleAssignOwnerAll,
-		handleResolveAll,
-		handleCommentAll,
-		handleDeleteForeverAll,
-	} = useAlertActions();
+	const { handleSilenceAlert, handleUnsilenceAlert, handleDeleteAlert, handleUnresolveAlert, handleDeleteForeverAll } =
+		useAlertActions();
 	const deleteResolvedAlertMutation = useDeleteResolvedAlert();
 	const markAlertReadMutation = useMarkAlertRead();
+	const bulkAction = useBulkAlertAction();
 
-	const handleSilenceAllSelected = async (silencedUntil?: string | null, comment?: string) => {
-		await handleSilenceAll(selectedAlerts, () => setSelectedAlerts([]), silencedUntil, comment);
+	// Bulk actions run as ONE server request: over the explicit ids of the loaded
+	// selection, or — when "all matching" is armed — over the view's query, resolved
+	// server-side against the full dataset. The response counts drive the toast, so it
+	// reports what actually happened rather than what the client hoped.
+	const runBulkAction = async (
+		vars: {
+			action: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
+			silencedUntil?: string | null;
+			comment?: string;
+			ownerId?: string | null;
+		},
+		labels: { title: string; verb: string }
+	) => {
+		const scope = allMatchingSelected ? { query: bulkScopeQuery } : { ids: selectedAlerts.map((a) => a.id) };
+		try {
+			const result = await bulkAction.mutateAsync({ ...vars, ...scope });
+			toast(
+				result.failed > 0
+					? {
+							title: `Partial ${labels.title.toLowerCase()}`,
+							description: `${labels.verb} ${result.succeeded} of ${result.matched} alerts, ${result.failed} failed`,
+							variant: 'destructive',
+						}
+					: {
+							title: labels.title,
+							description: `${labels.verb} ${result.succeeded} alert${result.succeeded !== 1 ? 's' : ''}`,
+						}
+			);
+		} catch (err) {
+			toast({
+				title: 'Bulk action failed',
+				description: err instanceof Error ? err.message : 'Unknown error',
+				variant: 'destructive',
+			});
+		}
+		setSelectedAlerts([]);
+		setAllMatchingSelected(false);
 	};
 
-	const handleAssignOwnerAllSelected = async (ownerId: string | null) => {
-		await handleAssignOwnerAll(selectedAlerts, ownerId, () => setSelectedAlerts([]));
-	};
+	const handleSilenceAllSelected = (silencedUntil?: string | null, comment?: string) =>
+		runBulkAction(
+			{ action: 'silence', silencedUntil: silencedUntil ?? null, comment },
+			{ title: 'Alerts silenced', verb: 'Silenced' }
+		);
 
-	const handleResolveAllSelected = async (comment?: string) => {
+	const handleAssignOwnerAllSelected = (ownerId: string | null) =>
+		runBulkAction(
+			{ action: 'assignOwner', ownerId },
+			{ title: ownerId ? 'Owner assigned' : 'Owner removed', verb: 'Updated owner on' }
+		);
+
+	const handleResolveAllSelected = (comment?: string) => {
 		setSelectedAlert(null);
-		await handleResolveAll(selectedAlerts, () => setSelectedAlerts([]), comment);
+		return runBulkAction({ action: 'resolve', comment }, { title: 'Alerts resolved', verb: 'Resolved' });
 	};
 
+	// Permanent delete stays scoped to the LOADED selection on purpose: an irreversible
+	// action must never apply to alerts the user hasn't at least had the chance to see.
 	const handleDeleteAllSelected = async () => {
 		setSelectedAlert(null);
-		await handleDeleteForeverAll(selectedAlerts, () => setSelectedAlerts([]));
+		await handleDeleteForeverAll(selectedAlerts, () => handleSelectAlerts([]));
 	};
 
 	const handleDeleteResolvedAlert = async (alertId: string) => {
@@ -579,13 +648,23 @@ const Alerts = () => {
 
 	// Direct (no confirmation dialog), matching the single-row unsilence: it's
 	// non-destructive and instantly reversible by silencing again.
-	const handleUnsilenceAllSelected = () => void handleUnsilenceAll(selectedAlerts, () => setSelectedAlerts([]));
+	const handleUnsilenceAllSelected = () =>
+		void runBulkAction({ action: 'unsilence' }, { title: 'Alerts unsilenced', verb: 'Unsilenced' });
+
+	// What the confirmation dialogs promise: the loaded selection's size, or — with "all
+	// matching" armed — the server-counted total the user clicked, plus an explicit scope
+	// note so "37 alerts" is never silently "37 you can see plus 3,000 you can't".
+	const bulkCount = allMatchingSelected ? (bulkMatchCount ?? selectedAlerts.length) : selectedAlerts.length;
+	const bulkScopeNote = allMatchingSelected
+		? ' This applies to every alert matching the current filters, including ones not loaded into the list.'
+		: '';
 
 	const confirmSilenceAllSelected = () =>
 		setPendingAction({
-			title: `Silence ${selectedAlerts.length} alert${selectedAlerts.length !== 1 ? 's' : ''}?`,
+			title: `Silence ${bulkCount} alert${bulkCount !== 1 ? 's' : ''}?`,
 			description:
-				'The selected alerts stay in the list but stop notifying for the chosen duration. You can unsilence them at any time, and silencing again restarts the timer.',
+				'The selected alerts stay in the list but stop notifying for the chosen duration. You can unsilence them at any time, and silencing again restarts the timer.' +
+				bulkScopeNote,
 			confirmLabel: 'Silence all',
 			withSilenceDuration: true,
 			withComment: true,
@@ -594,14 +673,14 @@ const Alerts = () => {
 			run: (comment, silencedUntil) => void handleSilenceAllSelected(silencedUntil, comment),
 		});
 
-	const handleCommentAllSelected = async (comment: string) => {
-		await handleCommentAll(selectedAlerts, comment, () => setSelectedAlerts([]));
-	};
+	const handleCommentAllSelected = (comment: string) =>
+		runBulkAction({ action: 'comment', comment }, { title: 'Comment added', verb: 'Commented on' });
 
 	const confirmCommentAllSelected = () =>
 		setPendingAction({
-			title: `Comment on ${selectedAlerts.length} alert${selectedAlerts.length !== 1 ? 's' : ''}?`,
-			description: 'The same comment is added to every selected alert, visible in its comments and history.',
+			title: `Comment on ${bulkCount} alert${bulkCount !== 1 ? 's' : ''}?`,
+			description:
+				'The same comment is added to every selected alert, visible in its comments and history.' + bulkScopeNote,
 			confirmLabel: 'Comment',
 			withComment: true,
 			requireComment: true,
@@ -614,9 +693,10 @@ const Alerts = () => {
 
 	const confirmResolveAllSelected = () =>
 		setPendingAction({
-			title: `Resolve ${selectedAlerts.length} alert${selectedAlerts.length !== 1 ? 's' : ''}?`,
+			title: `Resolve ${bulkCount} alert${bulkCount !== 1 ? 's' : ''}?`,
 			description:
-				'The selected alerts move to the Resolved list. You can unresolve them later if needed. An optional comment will be added to every resolved alert.',
+				'The selected alerts move to the Resolved list. You can unresolve them later if needed. An optional comment will be added to every resolved alert.' +
+				bulkScopeNote,
 			confirmLabel: 'Resolve',
 			withComment: true,
 			commentLabel: 'Resolve comment',
@@ -665,7 +745,7 @@ const Alerts = () => {
 			onSilenceAlert={confirmSilenceAlert}
 			onUnsilenceAlert={handleUnsilenceAlert}
 			onDeleteAlert={confirmResolveAlert}
-			onSelectAlerts={setSelectedAlerts}
+			onSelectAlerts={handleSelectAlerts}
 			selectedAlerts={selectedAlerts}
 			isLoading={isLoading}
 			visibleColumns={visibleColumns}
@@ -858,7 +938,7 @@ const Alerts = () => {
 											onValueChange={(value) => {
 												setActiveTab(value as AlertTab);
 												setSelectedAlert(null);
-												setSelectedAlerts([]);
+												handleSelectAlerts([]);
 											}}
 										>
 											{ALERT_TAB_OPTIONS.map(({ value, label, Icon }) => (
@@ -990,14 +1070,28 @@ const Alerts = () => {
 								<div className="shrink-0">
 									<AlertsSelectionBar
 										selectedAlerts={selectedAlerts}
-										hasUnloadedMatches={showPartialNotice}
-										onClearSelection={() => setSelectedAlerts([])}
+										hasUnloadedMatches={showPartialNotice && !allMatchingSelected}
+										matchingTotal={bulkMatchCount}
+										allMatchingSelected={allMatchingSelected}
+										// Offered Gmail-style: the whole loaded list is selected and the
+										// server counts more alerts matching this exact view.
+										onSelectAllMatching={
+											!allMatchingSelected &&
+											selectedAlerts.length >= filteredAlerts.length &&
+											bulkMatchCount !== undefined &&
+											bulkMatchCount > selectedAlerts.length
+												? () => setAllMatchingSelected(true)
+												: undefined
+										}
+										onClearSelection={() => handleSelectAlerts([])}
 										onSilenceAll={confirmSilenceAllSelected}
 										onUnsilenceAll={handleUnsilenceAllSelected}
 										onAssignOwnerAll={handleAssignOwnerAllSelected}
 										onResolveAll={confirmResolveAllSelected}
 										onCommentAll={confirmCommentAllSelected}
-										onDeleteAll={handleDeleteAllSelected}
+										// Permanent delete never runs by-filter — it stays on the loaded
+										// selection, so it's hidden while "all matching" is armed.
+										onDeleteAll={allMatchingSelected ? undefined : handleDeleteAllSelected}
 									/>
 								</div>
 							</>

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -464,7 +464,10 @@ const Alerts = () => {
 	// Scope of "apply to all N matching": the Active view's FULL query — the complete
 	// filter record (status included, exactly what narrows the rows the user sees), the
 	// time window and the search — which the server resolves against the whole dataset.
-	const bulkScopeQuery = useMemo(() => {
+	// Built as a FUNCTION so the mutation resolves the rolling window at action time: a
+	// memo would freeze "last 15 minutes" at mount (the preset's object identity never
+	// changes) and a selection left open for an hour would act on an hour-stale window.
+	const buildBulkScopeQuery = () => {
 		const window = toCoarseWindow(dashboardState.timeRange);
 		return {
 			filters: dashboardState.filters,
@@ -472,13 +475,23 @@ const Alerts = () => {
 			to: window.to ?? undefined,
 			search: dashboardState.query || undefined,
 		};
-	}, [dashboardState.filters, dashboardState.timeRange, dashboardState.query]);
-	// The N above, from the same server engine that will resolve the bulk action. Only
-	// fetched while an Active-tab selection is open.
-	const bulkMatchCount = useAlertMatchCount(
-		bulkScopeQuery,
-		activeTab === AlertTab.Active && selectedAlerts.length > 0
+	};
+	// The count query needs a STABLE object for its key, so it memoizes — with a slow
+	// tick re-resolving the rolling window, keeping the displayed N within a minute of
+	// what the action would do. The tick only runs while a selection is open.
+	const bulkCountEnabled = activeTab === AlertTab.Active && selectedAlerts.length > 0;
+	const [bulkWindowTick, setBulkWindowTick] = useState(0);
+	useEffect(() => {
+		if (!bulkCountEnabled) return;
+		const timer = setInterval(() => setBulkWindowTick((t) => t + 1), 30 * 1000);
+		return () => clearInterval(timer);
+	}, [bulkCountEnabled]);
+	const bulkCountQuery = useMemo(
+		() => buildBulkScopeQuery(),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[dashboardState.filters, dashboardState.timeRange, dashboardState.query, bulkWindowTick]
 	);
+	const bulkMatchCount = useAlertMatchCount(bulkCountQuery, bulkCountEnabled);
 
 	// Derived from the filters themselves rather than tracked separately, so the button and
 	// the sidebar's Status section always describe the same thing. The count comes from the
@@ -518,8 +531,13 @@ const Alerts = () => {
 		[allViewActiveAlerts, resolvedViewAlerts]
 	);
 
-	const { handleSilenceAlert, handleUnsilenceAlert, handleDeleteAlert, handleUnresolveAlert, handleDeleteForeverAll } =
-		useAlertActions();
+	const {
+		handleSilenceAlert,
+		handleUnsilenceAlert,
+		handleDeleteAlert,
+		handleUnresolveAlert,
+		handleDeleteForeverAll,
+	} = useAlertActions();
 	const deleteResolvedAlertMutation = useDeleteResolvedAlert();
 	const markAlertReadMutation = useMarkAlertRead();
 	const bulkAction = useBulkAlertAction();
@@ -537,7 +555,9 @@ const Alerts = () => {
 		},
 		labels: { title: string; verb: string }
 	) => {
-		const scope = allMatchingSelected ? { query: bulkScopeQuery } : { ids: selectedAlerts.map((a) => a.id) };
+		// The query is built HERE, not from a memo — the rolling window must be the one
+		// the user is looking at when they confirm, not the one from when they selected.
+		const scope = allMatchingSelected ? { query: buildBulkScopeQuery() } : { ids: selectedAlerts.map((a) => a.id) };
 		try {
 			const result = await bulkAction.mutateAsync({ ...vars, ...scope });
 			toast(
@@ -659,11 +679,21 @@ const Alerts = () => {
 		? ' This applies to every alert matching the current filters, including ones not loaded into the list.'
 		: '';
 
+	// Gate for offering "Select all N matching": every VISIBLE row must be selected.
+	// Membership, not a length comparison — a filter change keeps the old selection, so
+	// a stale 10-row selection over a 3-row list must not read as "the page is selected".
+	const allVisibleSelected = useMemo(() => {
+		if (filteredAlerts.length === 0) return false;
+		const selectedIds = new Set(selectedAlerts.map((a) => a.id));
+		return filteredAlerts.every((a) => selectedIds.has(a.id));
+	}, [filteredAlerts, selectedAlerts]);
+
 	const confirmSilenceAllSelected = () =>
 		setPendingAction({
 			title: `Silence ${bulkCount} alert${bulkCount !== 1 ? 's' : ''}?`,
 			description:
-				'The selected alerts stay in the list but stop notifying for the chosen duration. You can unsilence them at any time, and silencing again restarts the timer.' +
+				'The selected alerts stay in the list but stop notifying for the chosen duration. You can unsilence them at any time, and silencing again restarts the timer. You take ownership of every silenced alert' +
+				(allMatchingSelected ? ', and matches that are already silenced restart their timer.' : '.') +
 				bulkScopeNote,
 			confirmLabel: 'Silence all',
 			withSilenceDuration: true,
@@ -680,7 +710,8 @@ const Alerts = () => {
 		setPendingAction({
 			title: `Comment on ${bulkCount} alert${bulkCount !== 1 ? 's' : ''}?`,
 			description:
-				'The same comment is added to every selected alert, visible in its comments and history.' + bulkScopeNote,
+				'The same comment is added to every selected alert, visible in its comments and history.' +
+				bulkScopeNote,
 			confirmLabel: 'Comment',
 			withComment: true,
 			requireComment: true,
@@ -1073,11 +1104,13 @@ const Alerts = () => {
 										hasUnloadedMatches={showPartialNotice && !allMatchingSelected}
 										matchingTotal={bulkMatchCount}
 										allMatchingSelected={allMatchingSelected}
-										// Offered Gmail-style: the whole loaded list is selected and the
-										// server counts more alerts matching this exact view.
+										// Offered Gmail-style: every VISIBLE row is selected (membership,
+										// not a length compare — a filter change can leave a stale larger
+										// selection over a smaller list) and the server counts more
+										// matching this exact view.
 										onSelectAllMatching={
 											!allMatchingSelected &&
-											selectedAlerts.length >= filteredAlerts.length &&
+											allVisibleSelected &&
 											bulkMatchCount !== undefined &&
 											bulkMatchCount > selectedAlerts.length
 												? () => setAllMatchingSelected(true)

--- a/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
+++ b/apps/client/src/components/Alerts/AlertsSelectionBar/AlertsSelectionBar.tsx
@@ -31,6 +31,13 @@ export interface AlertsSelectionBarProps {
 	// must be explicit — otherwise "Silence all" on a select-all reads as "silence every
 	// matching alert" when it silences only the loaded page.
 	hasUnloadedMatches?: boolean;
+	// Total alerts matching the view's full query (server-counted), when known.
+	matchingTotal?: number;
+	// True when the bulk scope is "every matching alert", not just the loaded selection.
+	allMatchingSelected?: boolean;
+	// Offered when the whole loaded list is selected but more alerts match the query —
+	// arming it widens every bulk action to all matchingTotal alerts (Gmail's pattern).
+	onSelectAllMatching?: () => void;
 }
 
 export const AlertsSelectionBar = ({
@@ -43,6 +50,9 @@ export const AlertsSelectionBar = ({
 	onCommentAll,
 	onDeleteAll,
 	hasUnloadedMatches,
+	matchingTotal,
+	allMatchingSelected,
+	onSelectAllMatching,
 }: AlertsSelectionBarProps) => {
 	const { data: users = [] } = useUsers();
 	const [confirmDelete, setConfirmDelete] = useState(false);
@@ -118,12 +128,33 @@ export const AlertsSelectionBar = ({
 			</div>
 
 			<span className="min-w-0 text-sm font-medium">
-				<span className="whitespace-nowrap">
-					{selectedAlerts.length} Alert{selectedAlerts.length !== 1 ? 's' : ''} selected
-				</span>
-				{hasUnloadedMatches && (
-					<span className="ml-2 text-xs text-muted-foreground">
-						— actions apply to the loaded alerts only; scroll to load more first
+				{allMatchingSelected ? (
+					<span className="whitespace-nowrap">
+						All {(matchingTotal ?? selectedAlerts.length).toLocaleString()} matching alert
+						{(matchingTotal ?? selectedAlerts.length) !== 1 ? 's' : ''} selected
+						<span className="ml-2 text-xs text-muted-foreground">
+							— actions apply to every match, loaded or not
+						</span>
+					</span>
+				) : (
+					<span className="whitespace-nowrap">
+						{selectedAlerts.length} Alert{selectedAlerts.length !== 1 ? 's' : ''} selected
+						{onSelectAllMatching && matchingTotal !== undefined ? (
+							<Button
+								variant="link"
+								size="sm"
+								onClick={onSelectAllMatching}
+								className="ml-1 h-auto p-0 text-sm"
+							>
+								Select all {matchingTotal.toLocaleString()} matching
+							</Button>
+						) : (
+							hasUnloadedMatches && (
+								<span className="ml-2 text-xs text-muted-foreground">
+									— actions apply to the loaded alerts only; scroll to load more first
+								</span>
+							)
+						)}
 					</span>
 				)}
 			</span>

--- a/apps/client/src/components/Alerts/hooks/useAlertActions.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertActions.ts
@@ -2,23 +2,21 @@ import {
 	useDeleteAlert,
 	useDeleteResolvedAlert,
 	useSilenceAlert,
-	useSetAlertOwner,
 	useUnresolveAlert,
 	useUnsilenceAlert,
 } from '@/hooks/queries/alerts';
-import { useCreateAlertComment } from '@/hooks/queries/alertComments';
 import { useToast } from '@/hooks/use-toast';
-import { getCurrentUser } from '@/lib/auth';
 import { Alert } from '@OpsiMate/shared';
 
+// Single-alert actions plus the one bulk action that stays client-fanned (permanent
+// delete). Every other bulk action goes through useBulkAlertAction — one server request
+// over ids or over every alert matching a query.
 export const useAlertActions = () => {
 	const silenceAlertMutation = useSilenceAlert();
 	const unsilenceAlertMutation = useUnsilenceAlert();
 	const deleteAlertMutation = useDeleteAlert();
-	const setAlertOwnerMutation = useSetAlertOwner();
 	const deleteResolvedAlertMutation = useDeleteResolvedAlert();
 	const unresolveAlertMutation = useUnresolveAlert();
-	const createCommentMutation = useCreateAlertComment();
 	const { toast } = useToast();
 
 	const handleSilenceAlert = async (alertId: string, silencedUntil?: string | null, comment?: string) => {
@@ -79,81 +77,6 @@ export const useAlertActions = () => {
 		}
 	};
 
-	const handleSilenceAll = async (
-		selectedAlerts: Alert[],
-		onComplete: () => void,
-		silencedUntil?: string | null,
-		comment?: string
-	) => {
-		const silencePromises = selectedAlerts.map((alert) => handleSilenceAlert(alert.id, silencedUntil, comment));
-		const results = await Promise.allSettled(silencePromises);
-
-		results.forEach((result, index) => {
-			if (result.status === 'rejected') {
-				const alert = selectedAlerts[index];
-				// Silently handle failed silencings
-				void alert;
-				void result;
-			}
-		});
-
-		onComplete();
-	};
-
-	// Mirror of handleSilenceAll for the way back: selections of already-silenced
-	// alerts get a one-click bulk unsilence.
-	const handleUnsilenceAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
-		await Promise.allSettled(selectedAlerts.map((alert) => unsilenceAlertMutation.mutateAsync(alert.id)));
-		onComplete();
-	};
-
-	const handleAssignOwnerAll = async (selectedAlerts: Alert[], ownerId: string | null, onComplete: () => void) => {
-		const assignPromises = selectedAlerts.map((alert) =>
-			setAlertOwnerMutation.mutateAsync({ alertId: alert.id, ownerId })
-		);
-		const results = await Promise.allSettled(assignPromises);
-
-		const successCount = results.filter((r) => r.status === 'fulfilled').length;
-		const failCount = results.filter((r) => r.status === 'rejected').length;
-
-		if (failCount > 0) {
-			toast({
-				title: 'Partial assignment',
-				description: `Assigned ${successCount} alerts, ${failCount} failed`,
-				variant: 'destructive',
-			});
-		} else {
-			toast({
-				title: 'Owner assigned',
-				description: `Successfully assigned ${successCount} alert${successCount !== 1 ? 's' : ''}`,
-			});
-		}
-
-		onComplete();
-	};
-
-	// Bulk-resolve the selected active alerts (active "delete" == resolve).
-	const handleResolveAll = async (selectedAlerts: Alert[], onComplete: () => void, comment?: string) => {
-		const results = await Promise.allSettled(
-			selectedAlerts.map((alert) => deleteAlertMutation.mutateAsync({ alertId: alert.id, comment }))
-		);
-		const successCount = results.filter((r) => r.status === 'fulfilled').length;
-		const failCount = results.length - successCount;
-		toast(
-			failCount > 0
-				? {
-						title: 'Partial resolve',
-						description: `Resolved ${successCount} alerts, ${failCount} failed`,
-						variant: 'destructive',
-					}
-				: {
-						title: 'Alerts resolved',
-						description: `Moved ${successCount} alert${successCount !== 1 ? 's' : ''} to Resolved`,
-					}
-		);
-		onComplete();
-	};
-
 	// Permanently delete the selected active alerts: resolve each one, then remove it from
 	// the resolve (permanent delete only exists for resolved alerts).
 	const handleDeleteForeverAll = async (selectedAlerts: Alert[], onComplete: () => void) => {
@@ -180,50 +103,11 @@ export const useAlertActions = () => {
 		onComplete();
 	};
 
-	// Post the same comment on every selected alert, as the current user (mirrors the
-	// bulk resolve/silence pattern: fan out, then a single success/partial toast).
-	const handleCommentAll = async (selectedAlerts: Alert[], comment: string, onComplete: () => void) => {
-		const currentUser = getCurrentUser();
-		if (!currentUser) {
-			toast({
-				title: 'Not signed in',
-				description: 'Sign in again to comment on alerts',
-				variant: 'destructive',
-			});
-			return;
-		}
-		const results = await Promise.allSettled(
-			selectedAlerts.map((alert) =>
-				createCommentMutation.mutateAsync({ alertId: alert.id, userId: String(currentUser.id), comment })
-			)
-		);
-		const successCount = results.filter((r) => r.status === 'fulfilled').length;
-		const failCount = results.length - successCount;
-		toast(
-			failCount > 0
-				? {
-						title: 'Partial comment',
-						description: `Commented on ${successCount} alerts, ${failCount} failed`,
-						variant: 'destructive',
-					}
-				: {
-						title: 'Comment added',
-						description: `Commented on ${successCount} alert${successCount !== 1 ? 's' : ''}`,
-					}
-		);
-		onComplete();
-	};
-
 	return {
 		handleSilenceAlert,
 		handleUnsilenceAlert,
 		handleDeleteAlert,
 		handleUnresolveAlert,
-		handleSilenceAll,
-		handleUnsilenceAll,
-		handleAssignOwnerAll,
-		handleResolveAll,
-		handleCommentAll,
 		handleDeleteForeverAll,
 	};
 };

--- a/apps/client/src/hooks/queries/alerts/index.ts
+++ b/apps/client/src/hooks/queries/alerts/index.ts
@@ -1,6 +1,8 @@
 export { useAlerts } from './useAlerts';
 export { useAlertFacets } from './useAlertFacets';
 export { useAlertGroupSummaries } from './useAlertGroupSummaries';
+export { useAlertMatchCount } from './useAlertMatchCount';
+export { useBulkAlertAction } from './useBulkAlertAction';
 export { useResolvedAlerts } from './useResolvedAlerts';
 export { useDeleteAlert } from './useDeleteAlert';
 export { useDeleteResolvedAlert } from './useDeleteResolvedAlert';

--- a/apps/client/src/hooks/queries/alerts/useAlertMatchCount.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertMatchCount.ts
@@ -1,0 +1,34 @@
+import { alertsApi, AlertQueryParams } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+// How many active alerts match a query — the N in "Select all N matching". A limit-1
+// list request whose response carries the true total, so the count comes from the same
+// server engine that will resolve the bulk action; the one row in the payload is noise.
+// Only fetched while a selection is open (see `enabled`), so it costs nothing otherwise.
+export const useAlertMatchCount = (
+	params: Pick<AlertQueryParams, 'filters' | 'from' | 'to' | 'search'>,
+	enabled: boolean
+) => {
+	const { data } = useQuery({
+		queryKey: [
+			...queryKeys.alerts,
+			'matchCount',
+			params.filters ?? null,
+			params.from ?? null,
+			params.to ?? null,
+			params.search ?? null,
+		],
+		enabled,
+		queryFn: async () => {
+			const response = await alertsApi.getAllAlerts({ ...params, limit: 1 });
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Failed to count matching alerts');
+			}
+			return response.data.total ?? response.data.alerts.length;
+		},
+		staleTime: 10 * 1000,
+		refetchInterval: 20 * 1000,
+	});
+	return data;
+};

--- a/apps/client/src/hooks/queries/alerts/useAlerts.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlerts.ts
@@ -5,9 +5,9 @@ import { useMemo } from 'react';
 import { queryKeys } from '../queryKeys';
 
 // One infinite query serves both worlds. With a server query, each page is a filtered
-// slice and nextCursor drives the scroll; the playground's mock handler ignores the
-// params and returns the full list as a single page (nextCursor undefined), which is
-// exactly the legacy behavior — no separate code path to drift.
+// slice and nextCursor drives the scroll; the playground's mock handler speaks the same
+// query contract through the shared engine, so paging and totals behave identically —
+// no separate code path to drift.
 export const useAlerts = (query?: AlertQueryParams, options?: { refetchIntervalMs?: number }) => {
 	const playgroundMode = isPlaygroundMode();
 

--- a/apps/client/src/hooks/queries/alerts/useBulkAlertAction.ts
+++ b/apps/client/src/hooks/queries/alerts/useBulkAlertAction.ts
@@ -1,0 +1,38 @@
+import { alertsApi, AlertQueryParams } from '@/lib/api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../queryKeys';
+
+export interface BulkAlertActionVariables {
+	action: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
+	// Exactly one scope: the loaded selection's ids, or the view's query — the server
+	// resolves the query against the full dataset ("apply to all N matching").
+	ids?: string[];
+	query?: Pick<AlertQueryParams, 'filters' | 'from' | 'to' | 'search'>;
+	silencedUntil?: string | null;
+	comment?: string;
+	ownerId?: string | null;
+}
+
+// One request for a whole bulk action instead of a fan-out of per-alert calls. The
+// result carries how many alerts matched and how many succeeded, so callers can toast
+// an honest count.
+export const useBulkAlertAction = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (variables: BulkAlertActionVariables) => {
+			const response = await alertsApi.bulkAlertAction(variables);
+			if (!response.success || !response.data) {
+				throw new Error(response.error || 'Bulk alert action failed');
+			}
+			return response.data;
+		},
+		onSuccess: () => {
+			// Every bulk action changes list membership, counts, or row fields — refresh
+			// the lists plus everything derived from them (facets, group summaries), all
+			// keyed under queryKeys.alerts. History/comments are per-alert panels; the open
+			// one refreshes on its own poll, and a bulk action closes the selection anyway.
+			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+		},
+	});
+};

--- a/apps/client/src/hooks/queries/alerts/useBulkAlertAction.ts
+++ b/apps/client/src/hooks/queries/alerts/useBulkAlertAction.ts
@@ -1,17 +1,7 @@
-import { alertsApi, AlertQueryParams } from '@/lib/api';
+import { alertsApi } from '@/lib/api';
+import { AlertBulkActionRequest } from '@OpsiMate/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../queryKeys';
-
-export interface BulkAlertActionVariables {
-	action: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
-	// Exactly one scope: the loaded selection's ids, or the view's query — the server
-	// resolves the query against the full dataset ("apply to all N matching").
-	ids?: string[];
-	query?: Pick<AlertQueryParams, 'filters' | 'from' | 'to' | 'search'>;
-	silencedUntil?: string | null;
-	comment?: string;
-	ownerId?: string | null;
-}
 
 // One request for a whole bulk action instead of a fan-out of per-alert calls. The
 // result carries how many alerts matched and how many succeeded, so callers can toast
@@ -20,7 +10,7 @@ export const useBulkAlertAction = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: async (variables: BulkAlertActionVariables) => {
+		mutationFn: async (variables: AlertBulkActionRequest) => {
 			const response = await alertsApi.bulkAlertAction(variables);
 			if (!response.success || !response.data) {
 				throw new Error(response.error || 'Bulk alert action failed');

--- a/apps/client/src/hooks/queries/alerts/useBulkAlertAction.ts
+++ b/apps/client/src/hooks/queries/alerts/useBulkAlertAction.ts
@@ -29,10 +29,15 @@ export const useBulkAlertAction = () => {
 		},
 		onSuccess: () => {
 			// Every bulk action changes list membership, counts, or row fields — refresh
-			// the lists plus everything derived from them (facets, group summaries), all
-			// keyed under queryKeys.alerts. History/comments are per-alert panels; the open
-			// one refreshes on its own poll, and a bulk action closes the selection anyway.
+			// the active lists and everything derived from them (facets, group summaries),
+			// the resolved list (bulk resolve moves rows there; it lives under its own
+			// root key), and the per-alert history/comment panels, which have no poll of
+			// their own and would otherwise show stale content if one of the targets is
+			// open in the details panel.
 			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+			queryClient.invalidateQueries({ queryKey: queryKeys.resolvedAlerts });
+			queryClient.invalidateQueries({ queryKey: queryKeys.alertComments });
+			queryClient.invalidateQueries({ queryKey: ['alertHistory'] });
 		},
 	});
 };

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -1,5 +1,7 @@
 import { CustomAction } from '@OpsiMate/custom-actions';
 import {
+	AlertBulkActionRequest,
+	AlertBulkActionResult,
 	AlertGroupSummaryNode,
 	Action,
 	ActionConfig,
@@ -590,14 +592,7 @@ export const alertsApi = {
 	// One request mutates many active alerts at once — scoped by explicit ids (the loaded
 	// selection, one request instead of N) or by a query the server resolves against the
 	// full dataset ("apply to all N matching"). Exactly one scope must be set.
-	async bulkAlertAction(body: {
-		action: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
-		ids?: string[];
-		query?: Pick<AlertQueryParams, 'filters' | 'from' | 'to' | 'search'>;
-		silencedUntil?: string | null;
-		comment?: string;
-		ownerId?: string | null;
-	}): Promise<ApiResponse<{ matched: number; succeeded: number; failed: number }>> {
+	async bulkAlertAction(body: AlertBulkActionRequest): Promise<ApiResponse<AlertBulkActionResult>> {
 		// The server's query schema rejects null/empty members the dashboard state may
 		// carry (from/to null when "All time", empty search) — send only concrete values.
 		const query = body.query
@@ -620,11 +615,11 @@ export const alertsApi = {
 			const totals = { matched: 0, succeeded: 0, failed: 0 };
 			for (let i = 0; i < body.ids.length; i += 10000) {
 				const chunk = body.ids.slice(i, i + 10000);
-				const response = await apiRequest<{ matched: number; succeeded: number; failed: number }>(
-					'/alerts/bulk',
-					'POST',
-					{ ...body, ids: chunk, query: undefined }
-				);
+				const response = await apiRequest<AlertBulkActionResult>('/alerts/bulk', 'POST', {
+					...body,
+					ids: chunk,
+					query: undefined,
+				});
 				if (!response.success || !response.data) {
 					const remaining = body.ids.length - i;
 					totals.matched += remaining;
@@ -637,7 +632,7 @@ export const alertsApi = {
 			}
 			return { success: true, data: totals };
 		}
-		return await apiRequest<{ matched: number; succeeded: number; failed: number }>('/alerts/bulk', 'POST', {
+		return await apiRequest<AlertBulkActionResult>('/alerts/bulk', 'POST', {
 			...body,
 			query,
 		});

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -587,6 +587,54 @@ export const alertsApi = {
 		return await apiRequest<{ groups: AlertGroupSummaryNode[] }>(`${base}?${q.toString()}`);
 	},
 
+	// One request mutates many active alerts at once — scoped by explicit ids (the loaded
+	// selection, one request instead of N) or by a query the server resolves against the
+	// full dataset ("apply to all N matching"). Exactly one scope must be set.
+	async bulkAlertAction(body: {
+		action: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
+		ids?: string[];
+		query?: Pick<AlertQueryParams, 'filters' | 'from' | 'to' | 'search'>;
+		silencedUntil?: string | null;
+		comment?: string;
+		ownerId?: string | null;
+	}): Promise<ApiResponse<{ matched: number; succeeded: number; failed: number }>> {
+		// The server's query schema rejects null/empty members the dashboard state may
+		// carry (from/to null when "All time", empty search) — send only concrete values.
+		const query = body.query
+			? {
+					...(body.query.filters && Object.keys(body.query.filters).length > 0
+						? { filters: body.query.filters }
+						: {}),
+					...(body.query.from ? { from: body.query.from } : {}),
+					...(body.query.to ? { to: body.query.to } : {}),
+					...(body.query.search?.trim() ? { search: body.query.search } : {}),
+				}
+			: undefined;
+		// The server caps a single request at 10k ids; a deep-scrolled select-all can
+		// exceed that, so oversized id lists go up in sequential chunks with the counts
+		// summed — one logical action to the caller either way.
+		if (body.ids && body.ids.length > 10000) {
+			const totals = { matched: 0, succeeded: 0, failed: 0 };
+			for (let i = 0; i < body.ids.length; i += 10000) {
+				const chunk = body.ids.slice(i, i + 10000);
+				const response = await apiRequest<{ matched: number; succeeded: number; failed: number }>(
+					'/alerts/bulk',
+					'POST',
+					{ ...body, ids: chunk, query: undefined }
+				);
+				if (!response.success || !response.data) return response;
+				totals.matched += response.data.matched;
+				totals.succeeded += response.data.succeeded;
+				totals.failed += response.data.failed;
+			}
+			return { success: true, data: totals };
+		}
+		return await apiRequest<{ matched: number; succeeded: number; failed: number }>('/alerts/bulk', 'POST', {
+			...body,
+			query,
+		});
+	},
+
 	// Faceted sidebar counts + tag keys over the raw dataset, computed server-side.
 	async getAlertFacets(
 		filters: Record<string, string[]>,

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -612,7 +612,10 @@ export const alertsApi = {
 			: undefined;
 		// The server caps a single request at 10k ids; a deep-scrolled select-all can
 		// exceed that, so oversized id lists go up in sequential chunks with the counts
-		// summed — one logical action to the caller either way.
+		// summed — one logical action to the caller either way. A chunk that fails must
+		// NOT discard the counts of chunks that already applied: earlier mutations are
+		// real, so the unprocessed remainder folds into `failed` and the caller's toast
+		// reports an honest partial result instead of a blanket error.
 		if (body.ids && body.ids.length > 10000) {
 			const totals = { matched: 0, succeeded: 0, failed: 0 };
 			for (let i = 0; i < body.ids.length; i += 10000) {
@@ -622,7 +625,12 @@ export const alertsApi = {
 					'POST',
 					{ ...body, ids: chunk, query: undefined }
 				);
-				if (!response.success || !response.data) return response;
+				if (!response.success || !response.data) {
+					const remaining = body.ids.length - i;
+					totals.matched += remaining;
+					totals.failed += remaining;
+					return { success: true, data: totals };
+				}
 				totals.matched += response.data.matched;
 				totals.succeeded += response.data.succeeded;
 				totals.failed += response.data.failed;

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import {
 	Alert,
+	AlertBulkActionRequest,
 	AlertHistoryData,
 	AlertHistoryEventType,
 	AlertStatus,
@@ -466,16 +467,17 @@ export const handlers = [
 	// One request over many alerts — by explicit ids or by a query resolved against the
 	// full playground dataset (mirrors the server, where bulk loops the single-alert ops).
 	http.post(`${API_BASE}/alerts/bulk`, async ({ request }) => {
-		const body = (await request.json().catch(() => null)) as {
-			action?: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
-			ids?: string[];
-			query?: { filters?: Record<string, string[]>; from?: string; to?: string; search?: string };
-			silencedUntil?: string | null;
-			comment?: string;
-			ownerId?: string | null;
-		} | null;
-		// Exactly one scope, same contract the server's schema enforces.
-		if (!body?.action || (body.ids == null) === (body.query == null)) {
+		const body = (await request.json().catch(() => null)) as Partial<AlertBulkActionRequest> | null;
+		// Same validation contract the server's AlertBulkActionSchema enforces: exactly
+		// one scope, a comment action needs a body, assignOwner needs a numeric-or-null
+		// ownerId — the playground must reject what production rejects.
+		if (
+			!body?.action ||
+			(body.ids == null) === (body.query == null) ||
+			(body.action === 'comment' && !body.comment?.trim()) ||
+			(body.action === 'assignOwner' &&
+				(body.ownerId === undefined || (body.ownerId !== null && !/^\d+$/.test(body.ownerId))))
+		) {
 			return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
 		}
 		let targetIds: string[];

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -198,9 +198,151 @@ const mockGroupSummaries = (request: Request, alerts: Alert[]) => {
 	}
 };
 
+// The playground's single-alert mutations, shared by the per-alert routes and the bulk
+// route so both paths change state identically (mirrors the server, where the bulk
+// endpoint loops the same single-alert methods the individual routes use). Each returns
+// the mutated alert (or true for pure side-effects), null/false when the id is unknown.
+
+const silencePlaygroundAlert = (alertId: string, silencedUntil: string | null, comment?: string) => {
+	const alert = playgroundState.alerts.find((a) => a.id === alertId);
+	if (!alert) return null;
+	// silencedUntil is always overwritten so re-silencing restarts the timer; the
+	// optional note becomes a regular comment.
+	const silenceComment = typeof comment === 'string' ? comment.trim() : '';
+	alert.isSilenced = true;
+	alert.silencedUntil = silencedUntil;
+	alert.updatedAt = nowIso();
+	pushAlertEvent(alertId, {
+		date: nowIso(),
+		eventType: AlertHistoryEventType.SILENCED,
+		actorName: PLAYGROUND_ACTOR,
+		description: alert.silencedUntil ? `Alert silenced until ${alert.silencedUntil}` : 'Alert silenced',
+	});
+	// The silencer takes ownership of the alert (mirrors the server).
+	alert.ownerId = getPlaygroundUser().id;
+	pushAlertEvent(alertId, {
+		date: nowIso(),
+		eventType: AlertHistoryEventType.OWNER_ASSIGNED,
+		actorName: PLAYGROUND_ACTOR,
+		description: `Assigned to ${PLAYGROUND_ACTOR}`,
+	});
+	if (silenceComment) {
+		playgroundState.alertComments.push({
+			id: `comment-${randomId()}`,
+			alertId,
+			userId: getPlaygroundUser().id,
+			comment: silenceComment,
+			createdAt: nowIso(),
+			updatedAt: nowIso(),
+		});
+	}
+	return alert;
+};
+
+const unsilencePlaygroundAlert = (alertId: string) => {
+	const alert = playgroundState.alerts.find((a) => a.id === alertId);
+	if (!alert) return null;
+	alert.isSilenced = false;
+	alert.silencedUntil = null;
+	alert.updatedAt = nowIso();
+	pushAlertEvent(alertId, {
+		date: nowIso(),
+		eventType: AlertHistoryEventType.UNSILENCED,
+		actorName: PLAYGROUND_ACTOR,
+		description: 'Alert unsilenced',
+	});
+	return alert;
+};
+
+const assignPlaygroundAlertOwner = (alertId: string, ownerId: string | null) => {
+	const alert = playgroundState.alerts.find((a) => a.id === alertId);
+	if (!alert) return null;
+	alert.ownerId = ownerId;
+	alert.updatedAt = nowIso();
+	pushAlertEvent(alertId, recordOwnerEvent(ownerId));
+	return alert;
+};
+
+const resolvePlaygroundAlert = (alertId: string, comment?: string): boolean => {
+	const alertIndex = playgroundState.alerts.findIndex((a) => a.id === alertId);
+	if (alertIndex === -1) return false;
+	const resolveComment = typeof comment === 'string' ? comment.trim() : '';
+	const alert = { ...playgroundState.alerts[alertIndex] };
+	// Resolving pins the status and clears silence — an alert is either silenced or
+	// resolved, never both.
+	alert.status = AlertStatus.RESOLVED;
+	alert.isSilenced = false;
+	alert.silencedUntil = null;
+	alert.updatedAt = nowIso();
+	// The resolver takes ownership of the alert (mirrors the server).
+	alert.ownerId = getPlaygroundUser().id;
+	playgroundState.alerts.splice(alertIndex, 1);
+	playgroundState.resolvedAlerts.unshift(alert);
+	// The playground "Resolve" action is always a manual resolve by the playground user.
+	pushAlertEvent(alertId, {
+		date: nowIso(),
+		eventType: AlertHistoryEventType.RESOLVED,
+		actorName: PLAYGROUND_ACTOR,
+		description: 'Alert resolved manually',
+	});
+	if (resolveComment) {
+		playgroundState.alertComments.push({
+			id: `comment-${randomId()}`,
+			alertId,
+			userId: getPlaygroundUser().id,
+			comment: resolveComment,
+			createdAt: nowIso(),
+			updatedAt: nowIso(),
+		});
+	}
+	return true;
+};
+
+const commentPlaygroundAlert = (alertId: string, comment: string): boolean => {
+	if (!playgroundState.alerts.some((a) => a.id === alertId)) return false;
+	playgroundState.alertComments.push({
+		id: `comment-${randomId()}`,
+		alertId,
+		userId: getPlaygroundUser().id,
+		comment,
+		createdAt: nowIso(),
+		updatedAt: nowIso(),
+	});
+	return true;
+};
+
+// Mirrors the server's routing: any query param present means the caller speaks the
+// list-query contract and gets a filtered/sorted/paged response with a true total;
+// none means the legacy full-list response.
+const mockAlertsList = (request: Request, alerts: Alert[]) => {
+	const url = new URL(request.url);
+	const hasQueryParams = ['filters', 'from', 'to', 'search', 'sort', 'dir', 'limit', 'cursor'].some(
+		(key) => url.searchParams.get(key) !== null
+	);
+	if (!hasQueryParams) {
+		return HttpResponse.json({ success: true, data: { alerts } });
+	}
+	try {
+		const rawLimit = url.searchParams.get('limit');
+		const { items, total, nextCursor } = applyAlertListQuery(alerts, [], {
+			filters: JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>,
+			from: url.searchParams.get('from'),
+			to: url.searchParams.get('to'),
+			search: url.searchParams.get('search') ?? undefined,
+			sort: url.searchParams.get('sort') ?? undefined,
+			dir: (url.searchParams.get('dir') as 'asc' | 'desc' | null) ?? undefined,
+			limit: rawLimit != null ? Number(rawLimit) : undefined,
+			cursor: url.searchParams.get('cursor') ?? undefined,
+		});
+		return HttpResponse.json({ success: true, data: { alerts: items, total, nextCursor } });
+	} catch {
+		return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
+	}
+};
+
 export const handlers = [
 	// ==================== ALERTS ====================
-	http.get(`${API_BASE}/alerts`, () => {
+	http.get(`${API_BASE}/alerts`, ({ request }) => {
 		// Timed silences expire lazily on read (mirrors the server sweep).
 		const now = nowIso();
 		for (const alert of playgroundState.alerts) {
@@ -214,10 +356,7 @@ export const handlers = [
 				});
 			}
 		}
-		return HttpResponse.json({
-			success: true,
-			data: { alerts: playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment) },
-		});
+		return mockAlertsList(request, playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment));
 	}),
 
 	http.get(`${API_BASE}/alerts/groups`, ({ request }) =>
@@ -250,78 +389,28 @@ export const handlers = [
 		});
 	}),
 
-	http.get(`${API_BASE}/alerts/resolved`, () => {
-		return HttpResponse.json({
-			success: true,
-			data: { alerts: playgroundState.resolvedAlerts.map(withLastComment) },
-		});
+	http.get(`${API_BASE}/alerts/resolved`, ({ request }) => {
+		return mockAlertsList(request, playgroundState.resolvedAlerts.map(withLastComment));
 	}),
 
 	http.patch(`${API_BASE}/alerts/:alertId/silence`, async ({ params, request }) => {
-		const alertId = params.alertId as string;
-		const alert = playgroundState.alerts.find((a) => a.id === alertId);
-
-		if (!alert) {
-			return HttpResponse.json({ success: false, error: 'Alert not found' }, { status: 404 });
-		}
-
-		// Optional duration + note in the body (mirrors the server): silencedUntil is
-		// always overwritten so re-silencing restarts the timer; the note becomes a comment.
+		// Optional duration + note in the body (mirrors the server).
 		const body = (await request.json().catch(() => null)) as {
 			silencedUntil?: string | null;
 			comment?: string;
 		} | null;
-		const silenceComment = typeof body?.comment === 'string' ? body.comment.trim() : '';
-
-		alert.isSilenced = true;
-		alert.silencedUntil = body?.silencedUntil ?? null;
-		alert.updatedAt = nowIso();
-		pushAlertEvent(alertId, {
-			date: nowIso(),
-			eventType: AlertHistoryEventType.SILENCED,
-			actorName: PLAYGROUND_ACTOR,
-			description: alert.silencedUntil ? `Alert silenced until ${alert.silencedUntil}` : 'Alert silenced',
-		});
-		// The silencer takes ownership of the alert (mirrors the server).
-		alert.ownerId = getPlaygroundUser().id;
-		pushAlertEvent(alertId, {
-			date: nowIso(),
-			eventType: AlertHistoryEventType.OWNER_ASSIGNED,
-			actorName: PLAYGROUND_ACTOR,
-			description: `Assigned to ${PLAYGROUND_ACTOR}`,
-		});
-		if (silenceComment) {
-			playgroundState.alertComments.push({
-				id: `comment-${randomId()}`,
-				alertId,
-				userId: getPlaygroundUser().id,
-				comment: silenceComment,
-				createdAt: nowIso(),
-				updatedAt: nowIso(),
-			});
+		const alert = silencePlaygroundAlert(params.alertId as string, body?.silencedUntil ?? null, body?.comment);
+		if (!alert) {
+			return HttpResponse.json({ success: false, error: 'Alert not found' }, { status: 404 });
 		}
-
 		return HttpResponse.json({ success: true, data: { alert } });
 	}),
 
 	http.patch(`${API_BASE}/alerts/:alertId/unsilence`, ({ params }) => {
-		const alertId = params.alertId as string;
-		const alert = playgroundState.alerts.find((a) => a.id === alertId);
-
+		const alert = unsilencePlaygroundAlert(params.alertId as string);
 		if (!alert) {
 			return HttpResponse.json({ success: false, error: 'Alert not found' }, { status: 404 });
 		}
-
-		alert.isSilenced = false;
-		alert.silencedUntil = null;
-		alert.updatedAt = nowIso();
-		pushAlertEvent(alertId, {
-			date: nowIso(),
-			eventType: AlertHistoryEventType.UNSILENCED,
-			actorName: PLAYGROUND_ACTOR,
-			description: 'Alert unsilenced',
-		});
-
 		return HttpResponse.json({ success: true, data: { alert } });
 	}),
 
@@ -336,18 +425,11 @@ export const handlers = [
 	}),
 
 	http.patch(`${API_BASE}/alerts/:alertId/owner`, async ({ params, request }) => {
-		const alertId = params.alertId as string;
 		const body = (await request.json()) as { ownerId: string | null };
-		const alert = playgroundState.alerts.find((a) => a.id === alertId);
-
+		const alert = assignPlaygroundAlertOwner(params.alertId as string, body.ownerId);
 		if (!alert) {
 			return HttpResponse.json({ success: false, error: 'Alert not found' }, { status: 404 });
 		}
-
-		alert.ownerId = body.ownerId;
-		alert.updatedAt = nowIso();
-		pushAlertEvent(alertId, recordOwnerEvent(body.ownerId));
-
 		return HttpResponse.json({ success: true, data: { alert } });
 	}),
 
@@ -368,48 +450,64 @@ export const handlers = [
 	}),
 
 	http.delete(`${API_BASE}/alerts/:alertId`, async ({ params, request }) => {
-		const alertId = params.alertId as string;
-		const alertIndex = playgroundState.alerts.findIndex((a) => a.id === alertId);
-
-		if (alertIndex === -1) {
-			return HttpResponse.json({ success: true, message: 'Alert not found, nothing to resolve' });
-		}
-
 		// Optional resolve note in the body (mirrors the server: stored as a comment).
 		const body = (await request.json().catch(() => null)) as { comment?: string } | null;
-		const resolveComment = typeof body?.comment === 'string' ? body.comment.trim() : '';
-
-		const alert = { ...playgroundState.alerts[alertIndex] };
-		// Resolving pins the status and clears silence — an alert is either silenced or
-		// resolved, never both.
-		alert.status = AlertStatus.RESOLVED;
-		alert.isSilenced = false;
-		alert.silencedUntil = null;
-		alert.updatedAt = nowIso();
-		// The resolver takes ownership of the alert (mirrors the server).
-		alert.ownerId = getPlaygroundUser().id;
-
-		playgroundState.alerts.splice(alertIndex, 1);
-		playgroundState.resolvedAlerts.unshift(alert);
-		// The playground "Resolve" action is always a manual resolve by the playground user.
-		pushAlertEvent(alertId, {
-			date: nowIso(),
-			eventType: AlertHistoryEventType.RESOLVED,
-			actorName: PLAYGROUND_ACTOR,
-			description: 'Alert resolved manually',
-		});
-		if (resolveComment) {
-			playgroundState.alertComments.push({
-				id: `comment-${randomId()}`,
-				alertId,
-				userId: getPlaygroundUser().id,
-				comment: resolveComment,
-				createdAt: nowIso(),
-				updatedAt: nowIso(),
-			});
+		if (!resolvePlaygroundAlert(params.alertId as string, body?.comment)) {
+			return HttpResponse.json({ success: true, message: 'Alert not found, nothing to resolve' });
 		}
-
 		return HttpResponse.json({ success: true, message: 'Alert deleted successfully' });
+	}),
+
+	// One request over many alerts — by explicit ids or by a query resolved against the
+	// full playground dataset (mirrors the server, where bulk loops the single-alert ops).
+	http.post(`${API_BASE}/alerts/bulk`, async ({ request }) => {
+		const body = (await request.json().catch(() => null)) as {
+			action?: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
+			ids?: string[];
+			query?: { filters?: Record<string, string[]>; from?: string; to?: string; search?: string };
+			silencedUntil?: string | null;
+			comment?: string;
+			ownerId?: string | null;
+		} | null;
+		// Exactly one scope, same contract the server's schema enforces.
+		if (!body?.action || (body.ids == null) === (body.query == null)) {
+			return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
+		}
+		let targetIds: string[];
+		if (body.ids) {
+			targetIds = [...new Set(body.ids)];
+		} else {
+			const alerts = playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment);
+			const { items } = applyAlertListQuery(alerts, [], {
+				filters: body.query?.filters ?? {},
+				from: body.query?.from ?? null,
+				to: body.query?.to ?? null,
+				search: body.query?.search,
+			});
+			targetIds = items.map((a) => a.id);
+		}
+		let succeeded = 0;
+		for (const id of targetIds) {
+			const applied = (() => {
+				switch (body.action) {
+					case 'silence':
+						return silencePlaygroundAlert(id, body.silencedUntil ?? null, body.comment) != null;
+					case 'unsilence':
+						return unsilencePlaygroundAlert(id) != null;
+					case 'resolve':
+						return resolvePlaygroundAlert(id, body.comment);
+					case 'assignOwner':
+						return assignPlaygroundAlertOwner(id, body.ownerId ?? null) != null;
+					case 'comment':
+						return body.comment ? commentPlaygroundAlert(id, body.comment) : false;
+				}
+			})();
+			if (applied) succeeded++;
+		}
+		return HttpResponse.json({
+			success: true,
+			data: { matched: targetIds.length, succeeded, failed: targetIds.length - succeeded },
+		});
 	}),
 
 	http.patch(`${API_BASE}/alerts/resolved/:alertId/unresolve`, ({ params }) => {

--- a/apps/client/src/mocks/handlers.ts
+++ b/apps/client/src/mocks/handlers.ts
@@ -183,7 +183,7 @@ const mockGroupSummaries = (request: Request, alerts: Alert[]) => {
 		const groupBy = JSON.parse(url.searchParams.get('groupBy') ?? '[]') as string[];
 		const filters = JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>;
 		const timeZone = url.searchParams.get('timeZone') ?? undefined;
-		const { items } = applyAlertListQuery(alerts, [], {
+		const { items } = applyAlertListQuery(alerts, playgroundState.users, {
 			filters,
 			from: url.searchParams.get('from'),
 			to: url.searchParams.get('to'),
@@ -191,7 +191,7 @@ const mockGroupSummaries = (request: Request, alerts: Alert[]) => {
 		});
 		return HttpResponse.json({
 			success: true,
-			data: { groups: computeAlertGroupSummaries(items, groupBy, [], timeZone) },
+			data: { groups: computeAlertGroupSummaries(items, groupBy, playgroundState.users, timeZone) },
 		});
 	} catch {
 		return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
@@ -324,7 +324,12 @@ const mockAlertsList = (request: Request, alerts: Alert[]) => {
 	}
 	try {
 		const rawLimit = url.searchParams.get('limit');
-		const { items, total, nextCursor } = applyAlertListQuery(alerts, [], {
+		// The server 400s on a non-numeric limit; NaN here would silently slice to an
+		// empty page instead.
+		if (rawLimit != null && !Number.isFinite(Number(rawLimit))) {
+			return HttpResponse.json({ success: false, error: 'Validation error' }, { status: 400 });
+		}
+		const { items, total, nextCursor } = applyAlertListQuery(alerts, playgroundState.users, {
 			filters: JSON.parse(url.searchParams.get('filters') ?? '{}') as Record<string, string[]>,
 			from: url.searchParams.get('from'),
 			to: url.searchParams.get('to'),
@@ -374,7 +379,7 @@ export const handlers = [
 		const alerts = playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment);
 		return HttpResponse.json({
 			success: true,
-			data: computeAlertFacets(alerts, params.filters, params.fields, []),
+			data: computeAlertFacets(alerts, params.filters, params.fields, playgroundState.users),
 		});
 	}),
 
@@ -385,7 +390,7 @@ export const handlers = [
 		const alerts = playgroundState.resolvedAlerts.map(withLastComment);
 		return HttpResponse.json({
 			success: true,
-			data: computeAlertFacets(alerts, params.filters, params.fields, []),
+			data: computeAlertFacets(alerts, params.filters, params.fields, playgroundState.users),
 		});
 	}),
 
@@ -478,7 +483,7 @@ export const handlers = [
 			targetIds = [...new Set(body.ids)];
 		} else {
 			const alerts = playgroundState.alerts.map(withAppliedEnrichments).map(withLastComment);
-			const { items } = applyAlertListQuery(alerts, [], {
+			const { items } = applyAlertListQuery(alerts, playgroundState.users, {
 				filters: body.query?.filters ?? {},
 				from: body.query?.from ?? null,
 				to: body.query?.to ?? null,

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -123,8 +123,11 @@ export class AlertController {
 		try {
 			const body = AlertBulkActionSchema.parse(req.body ?? {});
 			// Comments must carry their author; every other action degrades to a null actor.
+			// 400, not 401: the client treats any 401 as an expired session and logs out,
+			// and this is a semantic problem with the request (api-token callers have no
+			// user identity to attribute a comment to), not an authentication failure.
 			if (body.action === 'comment' && req.user == null) {
-				return res.status(401).json({ success: false, error: 'Sign in to comment on alerts' });
+				return res.status(400).json({ success: false, error: 'The comment action requires a signed-in user' });
 			}
 			const result = await this.alertBL.bulkAlertAction(body, {
 				// String() — the JWT carries the id as a number; comments store it as TEXT.

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -27,6 +27,7 @@ import { ifNoneMatchSatisfied } from '../../../utils/etag';
 import crypto from 'crypto';
 import {
 	ALERT_QUERY_PARAM_KEYS,
+	AlertBulkActionSchema,
 	AlertFacetsParamsSchema,
 	AlertGroupsParamsSchema,
 	AlertListQueryParamsSchema,
@@ -112,6 +113,30 @@ export class AlertController {
 				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
 			}
 			logger.error('Error computing resolved alert facets:', error);
+			return res.status(500).json({ success: false, error: 'Internal server error' });
+		}
+	}
+
+	// One request acts on many alerts — by explicit ids (the loaded selection) or by a
+	// list query the BL resolves against the full dataset ("apply to all N matching").
+	async bulkAlertAction(req: AuthenticatedRequest, res: Response) {
+		try {
+			const body = AlertBulkActionSchema.parse(req.body ?? {});
+			// Comments must carry their author; every other action degrades to a null actor.
+			if (body.action === 'comment' && req.user == null) {
+				return res.status(401).json({ success: false, error: 'Sign in to comment on alerts' });
+			}
+			const result = await this.alertBL.bulkAlertAction(body, {
+				// String() — the JWT carries the id as a number; comments store it as TEXT.
+				id: req.user != null ? String(req.user.id) : null,
+				name: req.user?.fullName ?? null,
+			});
+			return res.json({ success: true, data: result });
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
+			logger.error('Error running bulk alert action:', error);
 			return res.status(500).json({ success: false, error: 'Internal server error' });
 		}
 	}

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -362,3 +362,42 @@ export const AlertGroupsParamsSchema = z.object({
 // Any of these present means the caller speaks the query contract; none means the
 // legacy full-snapshot response (older clients, playground harnesses).
 export const ALERT_QUERY_PARAM_KEYS = ['filters', 'from', 'to', 'search', 'sort', 'dir', 'limit', 'cursor'] as const;
+
+// ---------- bulk actions (Phase 2b: act on every alert matching a filter) ----------
+
+// One request mutates many active alerts at once — scoped either by an explicit id list
+// (the loaded selection, one request instead of N) or by the same query shape the list
+// endpoints speak (filters + time window + search), which the server resolves against
+// the full dataset. Exactly one scope must be present: accepting both would leave it
+// ambiguous which set the caller meant to act on.
+export const AlertBulkActionSchema = z
+	.object({
+		action: z.enum(['silence', 'unsilence', 'resolve', 'assignOwner', 'comment']),
+		ids: z.array(z.string().min(1)).min(1).max(10000).optional(),
+		query: z
+			.object({
+				filters: z.record(z.string(), z.array(z.string())).optional(),
+				from: z.iso.datetime({ offset: true }).optional(),
+				to: z.iso.datetime({ offset: true }).optional(),
+				search: z.string().optional(),
+			})
+			.optional(),
+		// silence: ISO auto-expiry; null or absent silences until manually unsilenced.
+		silencedUntil: isoDateString.nullable().optional(),
+		// silence/resolve: optional note stored as a comment on every alert.
+		// comment action: the comment body itself (required there).
+		comment: z.string().trim().max(5000).optional(),
+		// assignOwner: user id to assign, null to unassign.
+		ownerId: z.string().nullable().optional(),
+	})
+	.refine((v) => (v.ids != null) !== (v.query != null), {
+		message: 'Provide exactly one of ids or query',
+	})
+	.refine((v) => v.action !== 'comment' || (v.comment != null && v.comment.length > 0), {
+		message: 'The comment action requires a non-empty comment',
+	})
+	.refine((v) => v.action !== 'assignOwner' || v.ownerId !== undefined, {
+		message: 'The assignOwner action requires ownerId (null to unassign)',
+	});
+
+export type AlertBulkAction = z.infer<typeof AlertBulkActionSchema>;

--- a/apps/server/src/api/v1/alerts/models.ts
+++ b/apps/server/src/api/v1/alerts/models.ts
@@ -387,8 +387,9 @@ export const AlertBulkActionSchema = z
 		// silence/resolve: optional note stored as a comment on every alert.
 		// comment action: the comment body itself (required there).
 		comment: z.string().trim().max(5000).optional(),
-		// assignOwner: user id to assign, null to unassign.
-		ownerId: z.string().nullable().optional(),
+		// assignOwner: numeric user id to assign (the DB stores owners as integers, and
+		// a non-numeric string would parseInt to NaN), null to unassign.
+		ownerId: z.string().regex(/^\d+$/, 'ownerId must be a numeric user id').nullable().optional(),
 	})
 	.refine((v) => (v.ids != null) !== (v.query != null), {
 		message: 'Provide exactly one of ids or query',

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -9,6 +9,10 @@ export default function createAlertRouter(controller: AlertController) {
 	router.get('/facets', controller.getAlertFacets.bind(controller));
 	router.get('/groups', controller.getAlertGroupSummaries.bind(controller));
 
+	// Bulk actions — one request over an id list or over every alert matching a query
+	// (must be before /:alertId to avoid route conflicts)
+	router.post('/bulk', controller.bulkAlertAction.bind(controller));
+
 	// Daily silence reset settings (admin; must be before /:alertId to avoid route conflicts)
 	router.get('/silence-reset', controller.getSilenceResetSettings.bind(controller));
 	router.put('/silence-reset', controller.updateSilenceResetSettings.bind(controller));

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -105,7 +105,9 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	// open client — the highest-volume traffic this server produces, and it compresses
 	// roughly tenfold.
 	app.use(compression());
-	app.use(express.json());
+	// 2mb (default 100kb): a bulk action over an explicit selection can carry thousands
+	// of alert ids, and webhook batches (Grafana) grow with the sender's group size.
+	app.use(express.json({ limit: '2mb' }));
 
 	// Express 5 leaves req.body undefined when a request carries no body, where Express 4
 	// left an empty object. Controllers validate req.body directly, so keep the old shape

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -105,9 +105,13 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	// open client — the highest-volume traffic this server produces, and it compresses
 	// roughly tenfold.
 	app.use(compression());
-	// 2mb (default 100kb): a bulk action over an explicit selection can carry thousands
-	// of alert ids, and webhook batches (Grafana) grow with the sender's group size.
-	app.use(express.json({ limit: '2mb' }));
+	// The alerts routes accept large bodies — a bulk action over an explicit selection
+	// carries thousands of ids, and webhook batches (Grafana) grow with the sender's
+	// group size. Scoped to that router so the pre-auth surface (login, register,
+	// playground) keeps the default 100kb limit; express.json skips a body it already
+	// parsed, so the fallback below doesn't double-parse alerts requests.
+	app.use('/api/v1/alerts', express.json({ limit: '2mb' }));
+	app.use(express.json());
 
 	// Express 5 leaves req.body undefined when a request carries no body, where Express 4
 	// left an empty object. Controllers validate req.body directly, so keep the old shape

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -140,6 +140,77 @@ export class AlertBL {
 		return computeAlertGroupSummaries(items, groupBy, owners, timeZone);
 	}
 
+	// One call mutates every matching active alert. The scope is either an explicit id
+	// list (the client's loaded selection — one request instead of N) or a list query
+	// resolved server-side with the same shared engine the list endpoints use, so "act
+	// on all N matching" agrees exactly with what the view showed. Each target runs
+	// through the corresponding single-alert method — history events, ownership takeover
+	// and comment side-effects stay identical to acting one-by-one; a failure on one
+	// alert is counted and skipped, never aborting the rest of the batch.
+	async bulkAlertAction(
+		input: {
+			action: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
+			ids?: string[];
+			query?: Pick<AlertListQuery, 'filters' | 'from' | 'to' | 'search'>;
+			silencedUntil?: string | null;
+			comment?: string;
+			ownerId?: string | null;
+		},
+		actor: { id: string | null; name: string | null }
+	): Promise<{ matched: number; succeeded: number; failed: number }> {
+		let targetIds: string[];
+		if (input.ids) {
+			targetIds = [...new Set(input.ids)];
+		} else {
+			const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
+			const { items } = applyAlertListQuery(snapshot.value, owners, {
+				...(input.query ?? {}),
+				limit: undefined,
+				cursor: undefined,
+			});
+			targetIds = items.map((alert) => alert.id);
+		}
+
+		let succeeded = 0;
+		let failed = 0;
+		for (const id of targetIds) {
+			try {
+				// The single-alert methods signal "no such alert" by returning null/false
+				// rather than throwing — count that as failed too: succeeded must mean the
+				// action actually took effect.
+				let applied = true;
+				switch (input.action) {
+					case 'silence':
+						applied = (await this.silenceAlert(id, actor, input.silencedUntil ?? null, input.comment)) != null;
+						break;
+					case 'unsilence':
+						applied = (await this.unsilenceAlert(id, actor.name)) != null;
+						break;
+					case 'resolve':
+						applied = await this.resolveAlert(id, actor, input.comment);
+						break;
+					case 'assignOwner':
+						applied = (await this.setAlertOwner(id, input.ownerId ?? null, false, actor.name)) != null;
+						break;
+					case 'comment':
+						// Schema and controller guarantee a body and an acting user here.
+						await this.createComment(
+							{ alertId: id, userId: actor.id as string, comment: input.comment as string },
+							actor.name
+						);
+						break;
+				}
+				if (applied) succeeded++;
+				else failed++;
+			} catch (error) {
+				logger.error(`Bulk ${input.action} failed for alert ${id}`, error);
+				failed++;
+			}
+		}
+		logger.info(`Bulk ${input.action}: ${succeeded}/${targetIds.length} succeeded`);
+		return { matched: targetIds.length, succeeded, failed };
+	}
+
 	// Best-effort history logging: never let a failed history write break the underlying
 	// mutation (the event is informational, not transactional).
 	private async recordHistoryEvent(
@@ -424,7 +495,7 @@ export class AlertBL {
 		activeAlertId: string,
 		manualActor?: { id: string | null; name: string | null },
 		comment?: string
-	): Promise<void> {
+	): Promise<boolean> {
 		try {
 			logger.info(`Resolving alert with id: ${activeAlertId}`);
 
@@ -432,7 +503,7 @@ export class AlertBL {
 			const alert = await this.alertRepo.getAlert(activeAlertId);
 			if (!alert) {
 				logger.warn(`Alert with id ${activeAlertId} not found, nothing to resolve`);
-				return;
+				return false;
 			}
 
 			// Insert into resolved table
@@ -465,6 +536,7 @@ export class AlertBL {
 			}
 
 			logger.info(`Resolved alert ${activeAlertId}`);
+			return true;
 		} catch (error) {
 			logger.error(`Error resolving alert ${activeAlertId}`, error);
 			throw error;

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -181,7 +181,8 @@ export class AlertBL {
 				let applied = true;
 				switch (input.action) {
 					case 'silence':
-						applied = (await this.silenceAlert(id, actor, input.silencedUntil ?? null, input.comment)) != null;
+						applied =
+							(await this.silenceAlert(id, actor, input.silencedUntil ?? null, input.comment)) != null;
 						break;
 					case 'unsilence':
 						applied = (await this.unsilenceAlert(id, actor.name)) != null;
@@ -193,11 +194,17 @@ export class AlertBL {
 						applied = (await this.setAlertOwner(id, input.ownerId ?? null, false, actor.name)) != null;
 						break;
 					case 'comment':
-						// Schema and controller guarantee a body and an acting user here.
-						await this.createComment(
-							{ alertId: id, userId: actor.id as string, comment: input.comment as string },
-							actor.name
-						);
+						// Schema and controller guarantee a body and an acting user here. The
+						// comments table deliberately has no FK on alert_id (comments outlive
+						// resolve), so existence is checked explicitly — an unknown id must
+						// count as failed, not insert an orphan row.
+						applied = (await this.alertRepo.getAlert(id)) != null;
+						if (applied) {
+							await this.createComment(
+								{ alertId: id, userId: actor.id as string, comment: input.comment as string },
+								actor.name
+							);
+						}
 						break;
 				}
 				if (applied) succeeded++;

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -21,6 +21,8 @@ import { EnrichmentBL } from '../enrichments/enrichment.bl';
 import { MutePolicyBL } from '../mute-policies/mutePolicy.bl';
 import { Snapshot, SnapshotCache } from './snapshotCache';
 import {
+	AlertBulkActionRequest,
+	AlertBulkActionResult,
 	AlertFacetsResult,
 	AlertGroupSummaryNode,
 	AlertListPage,
@@ -148,16 +150,9 @@ export class AlertBL {
 	// and comment side-effects stay identical to acting one-by-one; a failure on one
 	// alert is counted and skipped, never aborting the rest of the batch.
 	async bulkAlertAction(
-		input: {
-			action: 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
-			ids?: string[];
-			query?: Pick<AlertListQuery, 'filters' | 'from' | 'to' | 'search'>;
-			silencedUntil?: string | null;
-			comment?: string;
-			ownerId?: string | null;
-		},
+		input: AlertBulkActionRequest,
 		actor: { id: string | null; name: string | null }
-	): Promise<{ matched: number; succeeded: number; failed: number }> {
+	): Promise<AlertBulkActionResult> {
 		let targetIds: string[];
 		if (input.ids) {
 			targetIds = [...new Set(input.ids)];

--- a/apps/server/tests/alertsBulkApi.test.ts
+++ b/apps/server/tests/alertsBulkApi.test.ts
@@ -20,7 +20,8 @@ const insertAlert = (id: string, name: string, tags: Record<string, string>, sta
 };
 
 const get = (url: string) => app.get(url).set('Authorization', `Bearer ${jwtToken}`);
-const postBulk = (body: object) => app.post('/api/v1/alerts/bulk').set('Authorization', `Bearer ${jwtToken}`).send(body);
+const postBulk = (body: object) =>
+	app.post('/api/v1/alerts/bulk').set('Authorization', `Bearer ${jwtToken}`).send(body);
 
 beforeAll(async () => {
 	db = await setupDB();
@@ -77,6 +78,14 @@ describe('POST /alerts/bulk', () => {
 		const comments = await get('/api/v1/alerts/b-06/comments');
 		const bodies = (comments.body.data.comments as Array<{ comment: string }>).map((c) => c.comment);
 		expect(bodies).toContain('bulk note');
+	});
+
+	test('comment on an unknown id counts as failed and writes no orphan row', async () => {
+		const res = await postBulk({ action: 'comment', ids: ['ghost-alert'], comment: 'orphan?' });
+		expect(res.body.data).toEqual({ matched: 1, succeeded: 0, failed: 1 });
+
+		const comments = await get('/api/v1/alerts/ghost-alert/comments');
+		expect(comments.body.data.comments).toHaveLength(0);
 	});
 
 	test('resolve by query moves every matching alert to resolved — including unloaded ones', async () => {

--- a/apps/server/tests/alertsBulkApi.test.ts
+++ b/apps/server/tests/alertsBulkApi.test.ts
@@ -1,0 +1,153 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { SuperTest, Test } from 'supertest';
+import Database from 'better-sqlite3';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
+
+// HTTP contract of POST /alerts/bulk (Phase 2b): one request mutates many alerts,
+// scoped by explicit ids or by the same query the list endpoints speak. The underlying
+// single-alert semantics (history events, ownership takeover, comments) are covered by
+// their own suites — here we verify scoping, counts, and validation.
+
+let app: SuperTest<Test>;
+let db: Database.Database;
+let jwtToken: string;
+
+const insertAlert = (id: string, name: string, tags: Record<string, string>, startsAt: string) => {
+	db.prepare(
+		`INSERT INTO alerts (id, status, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed)
+		 VALUES (?, 'firing', ?, ?, ?, ?, ?, 'Summary', NULL, 0)`
+	).run(id, JSON.stringify(tags), startsAt, new Date().toISOString(), `https://example.com/${id}`, name);
+};
+
+const get = (url: string) => app.get(url).set('Authorization', `Bearer ${jwtToken}`);
+const postBulk = (body: object) => app.post('/api/v1/alerts/bulk').set('Authorization', `Bearer ${jwtToken}`).send(body);
+
+beforeAll(async () => {
+	db = await setupDB();
+	app = await setupExpressApp(db);
+	jwtToken = await setupUserWithToken(app);
+	for (let i = 1; i <= 20; i++) {
+		insertAlert(
+			`b-${String(i).padStart(2, '0')}`,
+			`Bulk Alert ${i}`,
+			{ env: i % 2 === 0 ? 'prod' : 'staging' },
+			new Date(2026, 0, i, 12, 0, 0).toISOString()
+		);
+	}
+});
+
+describe('POST /alerts/bulk', () => {
+	test('silence by explicit ids silences exactly those alerts and reports counts', async () => {
+		const res = await postBulk({ action: 'silence', ids: ['b-01', 'b-03'], silencedUntil: null });
+		expect(res.status).toBe(200);
+		expect(res.body.data).toEqual({ matched: 2, succeeded: 2, failed: 0 });
+
+		const list = await get('/api/v1/alerts?limit=100');
+		const byId = new Map(list.body.data.alerts.map((a: { id: string }) => [a.id, a]));
+		expect((byId.get('b-01') as { isSilenced: boolean }).isSilenced).toBe(true);
+		expect((byId.get('b-03') as { isSilenced: boolean }).isSilenced).toBe(true);
+		expect((byId.get('b-05') as { isSilenced: boolean }).isSilenced).toBe(false);
+	});
+
+	test('unknown ids count as failed, not silently succeeded', async () => {
+		const res = await postBulk({ action: 'unsilence', ids: ['b-01', 'no-such-alert'] });
+		expect(res.status).toBe(200);
+		expect(res.body.data).toEqual({ matched: 2, succeeded: 1, failed: 1 });
+	});
+
+	test('assignOwner by ids sets the owner on every target', async () => {
+		// The first registered user (the token's owner) gets id 1.
+		const res = await postBulk({ action: 'assignOwner', ids: ['b-02', 'b-04'], ownerId: '1' });
+		expect(res.body.data.succeeded).toBe(2);
+
+		const list = await get('/api/v1/alerts?limit=100');
+		const owned = list.body.data.alerts.filter((a: { id: string; ownerId: string | null }) =>
+			['b-02', 'b-04'].includes(a.id)
+		);
+		expect(owned).toHaveLength(2);
+		for (const alert of owned) {
+			expect(String(alert.ownerId)).toBe('1');
+		}
+	});
+
+	test('comment by ids adds the same comment to every target', async () => {
+		const res = await postBulk({ action: 'comment', ids: ['b-06', 'b-08'], comment: 'bulk note' });
+		expect(res.body.data).toEqual({ matched: 2, succeeded: 2, failed: 0 });
+
+		const comments = await get('/api/v1/alerts/b-06/comments');
+		const bodies = (comments.body.data.comments as Array<{ comment: string }>).map((c) => c.comment);
+		expect(bodies).toContain('bulk note');
+	});
+
+	test('resolve by query moves every matching alert to resolved — including unloaded ones', async () => {
+		const before = await get('/api/v1/alerts?limit=100');
+		const prodCount = before.body.data.alerts.filter(
+			(a: { tags: Record<string, string> }) => a.tags.env === 'prod'
+		).length;
+		expect(prodCount).toBeGreaterThan(0);
+
+		const res = await postBulk({
+			action: 'resolve',
+			query: { filters: { 'tagKey:env': ['prod'] } },
+			comment: 'resolved in bulk',
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.data.matched).toBe(prodCount);
+		expect(res.body.data.succeeded).toBe(prodCount);
+		expect(res.body.data.failed).toBe(0);
+
+		const after = await get('/api/v1/alerts?limit=100');
+		expect(after.body.data.alerts.some((a: { tags: Record<string, string> }) => a.tags.env === 'prod')).toBe(false);
+
+		const resolved = await get('/api/v1/alerts/resolved?limit=100');
+		const resolvedProd = resolved.body.data.alerts.filter(
+			(a: { tags: Record<string, string> }) => a.tags.env === 'prod'
+		);
+		expect(resolvedProd.length).toBe(prodCount);
+	});
+
+	test('query scope honors search the same way the list endpoint does', async () => {
+		// "Bulk Alert 11" is unique; the query must match exactly the list result.
+		const list = await get('/api/v1/alerts?search=alert%2011&limit=100');
+		const expected = list.body.data.total;
+		const res = await postBulk({ action: 'silence', query: { search: 'alert 11' }, silencedUntil: null });
+		expect(res.body.data.matched).toBe(expected);
+	});
+
+	test('an empty query is the whole active list, not an error', async () => {
+		const list = await get('/api/v1/alerts?limit=100');
+		const res = await postBulk({ action: 'unsilence', query: {} });
+		expect(res.status).toBe(200);
+		expect(res.body.data.matched).toBe(list.body.data.total);
+	});
+
+	test('providing both ids and query is a 400', async () => {
+		const res = await postBulk({ action: 'silence', ids: ['b-01'], query: {} });
+		expect(res.status).toBe(400);
+	});
+
+	test('providing neither ids nor query is a 400', async () => {
+		const res = await postBulk({ action: 'silence' });
+		expect(res.status).toBe(400);
+	});
+
+	test('comment action without a comment is a 400', async () => {
+		const res = await postBulk({ action: 'comment', ids: ['b-01'] });
+		expect(res.status).toBe(400);
+	});
+
+	test('assignOwner without ownerId is a 400 (null means unassign and is valid)', async () => {
+		const missing = await postBulk({ action: 'assignOwner', ids: ['b-02'] });
+		expect(missing.status).toBe(400);
+
+		// b-01 (staging) is still active at this point; the prod alerts were resolved above.
+		const unassign = await postBulk({ action: 'assignOwner', ids: ['b-01'], ownerId: null });
+		expect(unassign.status).toBe(200);
+		expect(unassign.body.data.succeeded).toBe(1);
+	});
+
+	test('unknown action is a 400', async () => {
+		const res = await postBulk({ action: 'explode', ids: ['b-01'] });
+		expect(res.status).toBe(400);
+	});
+});

--- a/packages/shared/src/alerts/alertQuery.ts
+++ b/packages/shared/src/alerts/alertQuery.ts
@@ -200,6 +200,33 @@ export const sortAlertsBy = (
 
 // ---------- paging ----------
 
+// ---------- bulk actions (one request mutates every alert in scope) ----------
+
+export type AlertBulkActionType = 'silence' | 'unsilence' | 'resolve' | 'assignOwner' | 'comment';
+
+// The bulk-action request contract, shared by the server's endpoint, the client's api
+// layer and the playground mock so the shape is declared exactly once. Exactly one of
+// ids/query must be present (the server's schema enforces it): ids is the loaded
+// selection, query is resolved server-side against the full dataset.
+export interface AlertBulkActionRequest {
+	action: AlertBulkActionType;
+	ids?: string[];
+	query?: Pick<AlertListQuery, 'filters' | 'from' | 'to' | 'search'>;
+	// silence: ISO auto-expiry; null or absent silences until manually unsilenced.
+	silencedUntil?: string | null;
+	// silence/resolve: optional note stored as a comment; comment action: the body itself.
+	comment?: string;
+	// assignOwner: numeric user id to assign, null to unassign.
+	ownerId?: string | null;
+}
+
+// succeeded means the action actually took effect; unknown ids count as failed.
+export interface AlertBulkActionResult {
+	matched: number;
+	succeeded: number;
+	failed: number;
+}
+
 export interface AlertListQuery {
 	filters?: AlertListFilters;
 	// Concrete window — rolling presets are resolved by the CALLER at request time, so


### PR DESCRIPTION
## What

Phase 2b of the alerts scalability epic (after #827 snapshot cache, #828 server-side querying, #829 group summaries).

Bulk actions on alerts used to fan out **one HTTP request per alert** and could only touch **loaded rows** — the selection bar even warned "actions apply to the loaded alerts only; scroll to load more first". On a 10K instance that meant silencing a filtered set was either 500 requests (one page) or impossible without scrolling everything in.

### Server
- **`POST /api/v1/alerts/bulk`** — actions `silence | unsilence | resolve | assignOwner | comment`, scoped by **exactly one** of:
  - `ids` — the loaded selection (one request instead of N; capped at 10k per request)
  - `query` — the same `filters`/`from`/`to`/`search` shapes the list endpoints speak, resolved server-side against the full dataset with the shared engine, so "act on all N matching" agrees exactly with what the view shows
- The BL **loops the existing single-alert methods** — history events, ownership takeover on silence/resolve, and comment side-effects stay identical to acting one-by-one. Zero new mutation semantics.
- Honest counts: response is `{matched, succeeded, failed}`; unknown ids count as **failed** (the single methods return null rather than throwing), and `resolveAlert` now returns whether it actually resolved.
- `express.json` limit raised to 2mb (default 100kb rejects a few thousand ids).

### Client
- **Gmail pattern** in the selection bar: select the whole loaded page while the server counts more matching → "**Select all 2,500 matching**". Arming it banners the scope ("actions apply to every match, loaded or not") and widens every bulk action to the query.
- The N comes from a limit-1 list request (`useAlertMatchCount`) — same engine, true total, fetched only while a selection is open.
- Confirmation dialogs say the real number and call out the widened scope explicitly.
- **Permanent delete stays loaded-selection only** on purpose — an irreversible action never applies to alerts the user hasn't had a chance to see; the button hides while "all matching" is armed.
- Regular selections also go through the bulk endpoint with ids — silencing a 500-row selection is now **1 request, not 500**.
- Armed scope drops on any selection/filter/search/window/tab change — the N the user confirmed must stay the N that runs.
- Playground mock speaks the same contract through shared single-op helpers (no drift), and its list routes now honor the query contract (paged responses with true totals).

## Verified live on the 10K instance
- Selected 500 loaded of 2,500 matching "Memory" → "Select all 2,500 matching" → armed banner → Silence all → dialog "Silence 2500 alerts?" with scope note → **one** `POST /alerts/bulk` → toast "Silenced 2500 alerts", sidebar Silenced 2500, every row silenced.
- Restore via bulk unsilence-by-query: 2,500 alerts in **0.4s**.
- ids path: 2-row selection → Comment → one request → "Commented on 2 alerts".

## Tests
- 12 new server tests (`alertsBulkApi.test.ts`): id/query scoping, search parity with the list endpoint, honest failed counts for unknown ids, empty-query = whole list, all validation 400s.
- 201 server + 145 client tests green, lint 0 errors.

## Trade-offs
- A bulk action is a loop of single-alert mutations server-side (SQLite ops are sync/fast; 2,500 silences incl. history events + ownership ≈ instant, restore measured at 0.4s). Write-time batching belongs to Phase 2c if ever needed.
- `assignOwner` and `unsilence` run without a confirm dialog (matching their existing loaded-selection behavior) even when "all matching" is armed — both are reversible.
- The match count uses the coarse (minute-rounded) time window the queries already use; on rolling presets the acted-on set is consistent with the displayed N by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk alert actions for silencing, unsilencing, resolving, assigning, and commenting.
  * Select all matching alerts across filtered results, with match counts and scope confirmation.
  * Display success and failure counts for partially completed bulk actions.
* **Bug Fixes**
  * Prevented permanent deletion outside the currently loaded selection.
  * Reset selections when switching views or changing filters.
  * Improved validation for bulk action requests and targeting scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->