### PR TITLE
feat(actions): template-variable picker in every action form, templated HTTP URLs surfaced

### DIFF
--- a/apps/client/src/components/Actions/ActionFormDialog.tsx
+++ b/apps/client/src/components/Actions/ActionFormDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { cleanMatcherGroups, MatcherGroupsEditor } from '@/components/shared/MatcherGroupsEditor';
+import { TemplateVariablePicker } from '@/components/shared';
 import { useAlerts } from '@/hooks/queries/alerts';
 import { useAlertTagKeys } from '@/components/Alerts/hooks';
 import { Label } from '@/components/ui/label';
@@ -21,6 +22,8 @@ import { ActionPayload } from '@/lib/api';
 import {
 	Action,
 	ActionType,
+	ALERT_TEMPLATE_VARIABLES,
+	alertTagTemplateVariable,
 	HttpActionConfig,
 	HttpActionMethod,
 	JiraActionConfig,
@@ -29,7 +32,7 @@ import {
 } from '@OpsiMate/shared';
 import { ActionTypeIcon } from '@/components/Actions/ActionTypeIcon';
 import { Filter, Loader2, Play, Plus, Send, Trash2, Zap } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 interface ActionFormDialogProps {
 	open: boolean;
@@ -100,6 +103,23 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 	const [httpMethod, setHttpMethod] = useState<HttpActionMethod>('POST');
 	const [httpHeaders, setHttpHeaders] = useState<HeaderRow[]>([]);
 	const [httpBody, setHttpBody] = useState('');
+
+	// Template variables offered by the picker under each templated field: the fixed
+	// alert fields plus one alert.tags.<key> per tag key seen on current alerts.
+	const templateVariables = useMemo(
+		() => [...ALERT_TEMPLATE_VARIABLES, ...matcherSuggestions.map((tk) => alertTagTemplateVariable(tk.key))],
+		[matcherSuggestions]
+	);
+
+	// Refs for the templated fields, so the picker can insert at the caret of whichever
+	// one is focused (falling back to the type's main template field).
+	const slackMessageRef = useRef<HTMLTextAreaElement>(null);
+	const teamsTitleRef = useRef<HTMLInputElement>(null);
+	const teamsMessageRef = useRef<HTMLTextAreaElement>(null);
+	const jiraSummaryRef = useRef<HTMLInputElement>(null);
+	const jiraDescriptionRef = useRef<HTMLTextAreaElement>(null);
+	const httpUrlRef = useRef<HTMLInputElement>(null);
+	const httpBodyRef = useRef<HTMLTextAreaElement>(null);
 
 	const resetTypeFields = () => {
 		setSlackWebhookUrl('');
@@ -313,8 +333,9 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 						{isEdit ? 'Edit action' : 'New action'}
 					</DialogTitle>
 					<DialogDescription>
-						Configure a reusable action. You'll be able to run it against alerts from the alert view.
-						Templates may reference alert fields like {'{{alert.name}}'} once wired to an alert.
+						Configure a reusable action. You'll be able to run it against alerts from the alert view. Every
+						template field resolves alert variables like {'{{alert.name}}'} — for HTTP requests that
+						includes the URL and header values, so endpoints like /alerts/{'{{alert.id}}'}/ack work.
 					</DialogDescription>
 				</DialogHeader>
 
@@ -385,12 +406,17 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									</Label>
 									<Textarea
 										id="slack-message"
+										ref={slackMessageRef}
 										placeholder="🔔 {{alert.name}} fired on {{alert.service}}"
 										value={slackMessage}
 										onChange={(e) => setSlackMessage(e.target.value)}
 										rows={3}
 									/>
 								</div>
+								<TemplateVariablePicker
+									variables={templateVariables}
+									targets={[{ ref: slackMessageRef, value: slackMessage, onChange: setSlackMessage }]}
+								/>
 							</>
 						)}
 
@@ -413,6 +439,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									</Label>
 									<Input
 										id="teams-title"
+										ref={teamsTitleRef}
 										placeholder="Alert: {{alert.name}}"
 										value={teamsTitle}
 										onChange={(e) => setTeamsTitle(e.target.value)}
@@ -424,12 +451,20 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									</Label>
 									<Textarea
 										id="teams-message"
+										ref={teamsMessageRef}
 										placeholder="{{alert.name}} fired on {{alert.service}}"
 										value={teamsMessage}
 										onChange={(e) => setTeamsMessage(e.target.value)}
 										rows={3}
 									/>
 								</div>
+								<TemplateVariablePicker
+									variables={templateVariables}
+									targets={[
+										{ ref: teamsMessageRef, value: teamsMessage, onChange: setTeamsMessage },
+										{ ref: teamsTitleRef, value: teamsTitle, onChange: setTeamsTitle },
+									]}
+								/>
 							</>
 						)}
 
@@ -502,6 +537,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									</Label>
 									<Input
 										id="jira-summary"
+										ref={jiraSummaryRef}
 										placeholder="{{alert.name}} on {{alert.service}}"
 										value={jiraSummary}
 										onChange={(e) => setJiraSummary(e.target.value)}
@@ -513,12 +549,24 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									</Label>
 									<Textarea
 										id="jira-description"
+										ref={jiraDescriptionRef}
 										placeholder="Triggered at {{alert.startsAt}}. Details: {{alert.summary}}"
 										value={jiraDescription}
 										onChange={(e) => setJiraDescription(e.target.value)}
 										rows={3}
 									/>
 								</div>
+								<TemplateVariablePicker
+									variables={templateVariables}
+									targets={[
+										{
+											ref: jiraDescriptionRef,
+											value: jiraDescription,
+											onChange: setJiraDescription,
+										},
+										{ ref: jiraSummaryRef, value: jiraSummary, onChange: setJiraSummary },
+									]}
+								/>
 							</>
 						)}
 
@@ -545,11 +593,12 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									</div>
 									<div className="space-y-2">
 										<Label htmlFor="http-url" className="text-xs">
-											URL
+											URL — variables resolve here too
 										</Label>
 										<Input
 											id="http-url"
-											placeholder="https://api.example.com/webhook"
+											ref={httpUrlRef}
+											placeholder="https://api.example.com/alerts/{{alert.id}}/ack"
 											value={httpUrl}
 											onChange={(e) => setHttpUrl(e.target.value)}
 										/>
@@ -624,6 +673,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									</Label>
 									<Textarea
 										id="http-body"
+										ref={httpBodyRef}
 										placeholder={'{\n  "text": "{{alert.name}} fired"\n}'}
 										value={httpBody}
 										onChange={(e) => setHttpBody(e.target.value)}
@@ -631,6 +681,14 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 										className="font-mono text-xs"
 									/>
 								</div>
+								<TemplateVariablePicker
+									variables={templateVariables}
+									targets={[
+										{ ref: httpBodyRef, value: httpBody, onChange: setHttpBody },
+										{ ref: httpUrlRef, value: httpUrl, onChange: setHttpUrl },
+									]}
+									caption="Available variables — click to insert into the body, or focus the URL first to build a templated endpoint (header values resolve them too):"
+								/>
 							</>
 						)}
 

--- a/apps/client/src/components/Actions/ActionFormDialog.tsx
+++ b/apps/client/src/components/Actions/ActionFormDialog.tsx
@@ -334,8 +334,8 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 					</DialogTitle>
 					<DialogDescription>
 						Configure a reusable action. You'll be able to run it against alerts from the alert view. Every
-						template field resolves alert variables like {'{{alert.name}}'} — for HTTP requests that
-						includes the URL and header values, so endpoints like /alerts/{'{{alert.id}}'}/ack work.
+						template field resolves alert variables like {'{{name}}'} and {'{{label.env}}'} — for HTTP
+						requests that includes the URL and header values, so endpoints like /alerts/{'{{id}}'}/ack work.
 					</DialogDescription>
 				</DialogHeader>
 
@@ -407,7 +407,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									<Textarea
 										id="slack-message"
 										ref={slackMessageRef}
-										placeholder="🔔 {{alert.name}} fired on {{alert.service}}"
+										placeholder="🔔 {{name}} fired on {{service}}"
 										value={slackMessage}
 										onChange={(e) => setSlackMessage(e.target.value)}
 										rows={3}
@@ -440,7 +440,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									<Input
 										id="teams-title"
 										ref={teamsTitleRef}
-										placeholder="Alert: {{alert.name}}"
+										placeholder="Alert: {{name}}"
 										value={teamsTitle}
 										onChange={(e) => setTeamsTitle(e.target.value)}
 									/>
@@ -452,7 +452,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									<Textarea
 										id="teams-message"
 										ref={teamsMessageRef}
-										placeholder="{{alert.name}} fired on {{alert.service}}"
+										placeholder="{{name}} fired on {{service}}"
 										value={teamsMessage}
 										onChange={(e) => setTeamsMessage(e.target.value)}
 										rows={3}
@@ -538,7 +538,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									<Input
 										id="jira-summary"
 										ref={jiraSummaryRef}
-										placeholder="{{alert.name}} on {{alert.service}}"
+										placeholder="{{name}} on {{service}}"
 										value={jiraSummary}
 										onChange={(e) => setJiraSummary(e.target.value)}
 									/>
@@ -550,7 +550,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									<Textarea
 										id="jira-description"
 										ref={jiraDescriptionRef}
-										placeholder="Triggered at {{alert.startsAt}}. Details: {{alert.summary}}"
+										placeholder="Triggered at {{startsAt}}. Details: {{summary}}"
 										value={jiraDescription}
 										onChange={(e) => setJiraDescription(e.target.value)}
 										rows={3}
@@ -598,7 +598,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 										<Input
 											id="http-url"
 											ref={httpUrlRef}
-											placeholder="https://api.example.com/alerts/{{alert.id}}/ack"
+											placeholder="https://api.example.com/alerts/{{id}}/ack"
 											value={httpUrl}
 											onChange={(e) => setHttpUrl(e.target.value)}
 										/>
@@ -674,7 +674,7 @@ export const ActionFormDialog = ({ open, onOpenChange, action }: ActionFormDialo
 									<Textarea
 										id="http-body"
 										ref={httpBodyRef}
-										placeholder={'{\n  "text": "{{alert.name}} fired"\n}'}
+										placeholder={'{\n  "text": "{{name}} fired"\n}'}
 										value={httpBody}
 										onChange={(e) => setHttpBody(e.target.value)}
 										rows={4}

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { cleanMatcherGroups, MatcherGroupsEditor } from '@/components/shared/MatcherGroupsEditor';
+import { TemplateVariablePicker } from '@/components/shared';
 import { useAlertTagKeys } from '@/components/Alerts/hooks';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -18,7 +19,7 @@ import { useAlerts } from '@/hooks/queries/alerts';
 import { useCreateEnrichment, useUpdateEnrichment } from '@/hooks/queries/enrichments';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { EnrichmentPayload } from '@/lib/api';
-import { AlertEnrichment, AlertLink } from '@OpsiMate/shared';
+import { AlertEnrichment, AlertLink, ALERT_TEMPLATE_VARIABLES, alertTagTemplateVariable } from '@OpsiMate/shared';
 import { Plus, Sparkles, Tag, Trash2, Wand2 } from 'lucide-react';
 import { AlertLinkIcon } from '@/components/Alerts/AlertLinkIcon';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -203,34 +204,17 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 	const [summaryTemplate, setSummaryTemplate] = useState('');
 	const [priority, setPriority] = useState('0');
 
-	// Label keys present on current alerts, offered as insertable placeholders.
+	// Alert data feeds both the matcher suggestions and the template-variable picker —
+	// the SAME canonical alert.* vocabulary the action forms offer (the enrichment
+	// resolver accepts it alongside the legacy un-namespaced variables).
 	const { data: alerts = [] } = useAlerts();
-	const labelKeys = useMemo(() => {
-		const keys = new Set<string>();
-		alerts.forEach((a) => Object.keys(a.tags ?? {}).forEach((k) => keys.add(k)));
-		return Array.from(keys).sort();
-	}, [alerts]);
 	const matcherSuggestions = useAlertTagKeys(alerts);
+	const templateVariables = useMemo(
+		() => [...ALERT_TEMPLATE_VARIABLES, ...matcherSuggestions.map((tk) => alertTagTemplateVariable(tk.key))],
+		[matcherSuggestions]
+	);
 
 	const summaryRef = useRef<HTMLTextAreaElement>(null);
-
-	// Insert a placeholder into the summary template at the cursor (replacing any selection),
-	// then restore focus with the caret placed after the inserted text. When the textarea
-	// isn't focused its selection is 0, so append at the end instead of the start.
-	const insertIntoSummary = (placeholder: string) => {
-		const el = summaryRef.current;
-		const isFocused = el != null && document.activeElement === el;
-		const start = isFocused ? el.selectionStart : summaryTemplate.length;
-		const end = isFocused ? el.selectionEnd : summaryTemplate.length;
-		const next = summaryTemplate.slice(0, start) + placeholder + summaryTemplate.slice(end);
-		setSummaryTemplate(next);
-		requestAnimationFrame(() => {
-			if (!el) return;
-			el.focus();
-			const caret = start + placeholder.length;
-			el.setSelectionRange(caret, caret);
-		});
-	};
 
 	useEffect(() => {
 		if (!open) return;
@@ -439,38 +423,17 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 								rows={3}
 							/>
 							<p className="text-xs text-muted-foreground">
-								Replaces the alert summary. Use {'{{summary}}'} for the current summary, plus{' '}
-								{'{{name}}'}, {'{{status}}'}, and any label as {'{{label.<key>}}'}. New lines and basic
-								HTML ({'<b>'}, {'<a>'}, lists) are rendered in the alert details.
+								Replaces the alert summary. Use {'{{summary}}'} for the current summary; alert fields
+								and labels are available as the same {'{{alert.*}}'} variables action templates use (the
+								older {'{{name}}'}, {'{{status}}'} and {'{{label.<key>}}'} forms keep working). New
+								lines and basic HTML ({'<b>'}, {'<a>'}, lists) are rendered in the alert details.
 							</p>
 						</div>
 
-						{labelKeys.length > 0 && (
-							<div className="space-y-1.5">
-								<p className="text-xs text-muted-foreground">
-									Available labels (click to insert a placeholder):
-								</p>
-								<div className="flex flex-wrap gap-1.5">
-									{labelKeys.map((key) => {
-										const placeholder = `{{label.${key}}}`;
-										return (
-											<button
-												key={key}
-												type="button"
-												// Keep focus in the textarea so the caret position is preserved
-												// and the placeholder inserts where the user was typing.
-												onMouseDown={(e) => e.preventDefault()}
-												onClick={() => insertIntoSummary(placeholder)}
-												className="px-2 py-0.5 rounded-full border bg-background hover:bg-muted text-[11px] font-mono"
-												title={`Insert ${placeholder}`}
-											>
-												{placeholder}
-											</button>
-										);
-									})}
-								</div>
-							</div>
-						)}
+						<TemplateVariablePicker
+							variables={['summary', ...templateVariables]}
+							targets={[{ ref: summaryRef, value: summaryTemplate, onChange: setSummaryTemplate }]}
+						/>
 					</div>
 				</div>
 

--- a/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
+++ b/apps/client/src/components/Enrichments/EnrichmentFormDialog.tsx
@@ -423,15 +423,15 @@ export const EnrichmentFormDialog = ({ open, onOpenChange, enrichment, duplicate
 								rows={3}
 							/>
 							<p className="text-xs text-muted-foreground">
-								Replaces the alert summary. Use {'{{summary}}'} for the current summary; alert fields
-								and labels are available as the same {'{{alert.*}}'} variables action templates use (the
-								older {'{{name}}'}, {'{{status}}'} and {'{{label.<key>}}'} forms keep working). New
-								lines and basic HTML ({'<b>'}, {'<a>'}, lists) are rendered in the alert details.
+								Replaces the alert summary. Use {'{{summary}}'} for the current summary, plus alert
+								fields like {'{{name}}'} and {'{{severity}}'} and any label as {'{{label.<key>}}'} — the
+								same variables action templates use. New lines and basic HTML ({'<b>'}, {'<a>'}, lists)
+								are rendered in the alert details.
 							</p>
 						</div>
 
 						<TemplateVariablePicker
-							variables={['summary', ...templateVariables]}
+							variables={templateVariables}
 							targets={[{ ref: summaryRef, value: summaryTemplate, onChange: setSummaryTemplate }]}
 						/>
 					</div>

--- a/apps/client/src/components/shared/TemplateVariablePicker.tsx
+++ b/apps/client/src/components/shared/TemplateVariablePicker.tsx
@@ -1,0 +1,68 @@
+import { RefObject } from 'react';
+
+export interface TemplateFieldTarget {
+	// The input/textarea the placeholder lands in.
+	ref: RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+	value: string;
+	onChange: (next: string) => void;
+}
+
+export interface TemplateVariablePickerProps {
+	// Variables offered as chips, WITHOUT braces (e.g. 'alert.name').
+	variables: string[];
+	// Candidate fields, most-likely-to-be-templated first: a click inserts into the
+	// FOCUSED target, falling back to the first one when none is focused.
+	targets: TemplateFieldTarget[];
+	caption?: string;
+}
+
+// Clickable {{variable}} chips that insert into a template field at the caret,
+// replacing any selection — the enrichments dialog's label picker, generalized to
+// multiple fields and to plain inputs as well as textareas. The chips preventDefault
+// on mousedown so the click never steals focus: whichever field the user was typing
+// in is still document.activeElement when the click handler picks its target.
+export const TemplateVariablePicker = ({ variables, targets, caption }: TemplateVariablePickerProps) => {
+	const insert = (placeholder: string) => {
+		const focused = targets.find((t) => t.ref.current != null && t.ref.current === document.activeElement);
+		const target = focused ?? targets[0];
+		if (!target) return;
+		const el = target.ref.current;
+		// Unfocused fields report selection 0 — append at the end instead of the start.
+		const start = focused && el ? (el.selectionStart ?? target.value.length) : target.value.length;
+		const end = focused && el ? (el.selectionEnd ?? target.value.length) : target.value.length;
+		target.onChange(target.value.slice(0, start) + placeholder + target.value.slice(end));
+		requestAnimationFrame(() => {
+			if (!el) return;
+			el.focus();
+			const caret = start + placeholder.length;
+			el.setSelectionRange(caret, caret);
+		});
+	};
+
+	if (variables.length === 0) return null;
+
+	return (
+		<div className="space-y-1">
+			<p className="text-[11px] text-muted-foreground">
+				{caption ?? 'Available variables — click to insert into the field you are editing:'}
+			</p>
+			<div className="flex flex-wrap gap-1">
+				{variables.map((variable) => {
+					const placeholder = `{{${variable}}}`;
+					return (
+						<button
+							key={variable}
+							type="button"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={() => insert(placeholder)}
+							className="px-2 py-0.5 rounded-full border bg-background hover:bg-muted text-[11px] font-mono"
+							title={`Insert ${placeholder}`}
+						>
+							{placeholder}
+						</button>
+					);
+				})}
+			</div>
+		</div>
+	);
+};

--- a/apps/client/src/components/shared/TemplateVariablePicker/TemplateVariablePicker.tsx
+++ b/apps/client/src/components/shared/TemplateVariablePicker/TemplateVariablePicker.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from 'react';
+import { RefObject, useRef } from 'react';
 
 export interface TemplateFieldTarget {
 	// The input/textarea the placeholder lands in.
@@ -8,7 +8,7 @@ export interface TemplateFieldTarget {
 }
 
 export interface TemplateVariablePickerProps {
-	// Variables offered as chips, WITHOUT braces (e.g. 'alert.name').
+	// Variables offered as chips, WITHOUT braces (e.g. 'name', 'label.env').
 	variables: string[];
 	// Candidate fields, most-likely-to-be-templated first: a click inserts into the
 	// FOCUSED target, falling back to the first one when none is focused.
@@ -19,17 +19,28 @@ export interface TemplateVariablePickerProps {
 // Clickable {{variable}} chips that insert into a template field at the caret,
 // replacing any selection — the enrichments dialog's label picker, generalized to
 // multiple fields and to plain inputs as well as textareas. The chips preventDefault
-// on mousedown so the click never steals focus: whichever field the user was typing
-// in is still document.activeElement when the click handler picks its target.
+// on mousedown so a CLICK never steals focus: whichever field the user was typing in
+// is still document.activeElement when the click handler picks its target. Keyboard
+// users Tab to a chip instead, which does move focus off the field — the chip's
+// focus event remembers where focus came from (relatedTarget) so Enter still inserts
+// into the field they were editing.
 export const TemplateVariablePicker = ({ variables, targets, caption }: TemplateVariablePickerProps) => {
+	const lastFieldRef = useRef<EventTarget | null>(null);
+
 	const insert = (placeholder: string) => {
-		const focused = targets.find((t) => t.ref.current != null && t.ref.current === document.activeElement);
-		const target = focused ?? targets[0];
+		const target =
+			targets.find((t) => t.ref.current != null && t.ref.current === document.activeElement) ??
+			targets.find((t) => t.ref.current != null && t.ref.current === lastFieldRef.current) ??
+			targets[0];
 		if (!target) return;
 		const el = target.ref.current;
-		// Unfocused fields report selection 0 — append at the end instead of the start.
-		const start = focused && el ? (el.selectionStart ?? target.value.length) : target.value.length;
-		const end = focused && el ? (el.selectionEnd ?? target.value.length) : target.value.length;
+		// The caret position is only meaningful when the field is focused (click path)
+		// or is the field keyboard-focus just left (a blurred field keeps its last
+		// selection). A field the user never touched reports 0/0 — append instead of
+		// inserting at the start of existing content.
+		const caretTrusted = el != null && (document.activeElement === el || lastFieldRef.current === el);
+		const start = caretTrusted ? (el.selectionStart ?? target.value.length) : target.value.length;
+		const end = caretTrusted ? (el.selectionEnd ?? target.value.length) : target.value.length;
 		target.onChange(target.value.slice(0, start) + placeholder + target.value.slice(end));
 		requestAnimationFrame(() => {
 			if (!el) return;
@@ -54,6 +65,9 @@ export const TemplateVariablePicker = ({ variables, targets, caption }: Template
 							key={variable}
 							type="button"
 							onMouseDown={(e) => e.preventDefault()}
+							onFocus={(e) => {
+								if (e.relatedTarget) lastFieldRef.current = e.relatedTarget;
+							}}
 							onClick={() => insert(placeholder)}
 							className="px-2 py-0.5 rounded-full border bg-background hover:bg-muted text-[11px] font-mono"
 							title={`Insert ${placeholder}`}

--- a/apps/client/src/components/shared/TemplateVariablePicker/TemplateVariablePicker.tsx
+++ b/apps/client/src/components/shared/TemplateVariablePicker/TemplateVariablePicker.tsx
@@ -66,7 +66,12 @@ export const TemplateVariablePicker = ({ variables, targets, caption }: Template
 							type="button"
 							onMouseDown={(e) => e.preventDefault()}
 							onFocus={(e) => {
-								if (e.relatedTarget) lastFieldRef.current = e.relatedTarget;
+								// Remember only REGISTERED fields: tabbing from chip to chip must
+								// not overwrite the remembered field with the previous chip.
+								const from = e.relatedTarget;
+								if (from && targets.some((t) => t.ref.current === from)) {
+									lastFieldRef.current = from;
+								}
 							}}
 							onClick={() => insert(placeholder)}
 							className="px-2 py-0.5 rounded-full border bg-background hover:bg-muted text-[11px] font-mono"

--- a/apps/client/src/components/shared/TemplateVariablePicker/index.ts
+++ b/apps/client/src/components/shared/TemplateVariablePicker/index.ts
@@ -1,0 +1,2 @@
+export { TemplateVariablePicker } from './TemplateVariablePicker';
+export type { TemplateFieldTarget, TemplateVariablePickerProps } from './TemplateVariablePicker';

--- a/apps/client/src/components/shared/index.ts
+++ b/apps/client/src/components/shared/index.ts
@@ -5,3 +5,5 @@ export type { ActiveFilters, FilterFacet, FilterFacets, FilterPanelConfig } from
 export { FilterSidebar } from './FilterSidebar';
 export { UnsavedChangesDialog } from './UnsavedChangesDialog';
 export { PlaygroundBanner } from './PlaygroundBanner';
+export { TemplateVariablePicker } from './TemplateVariablePicker';
+export type { TemplateFieldTarget, TemplateVariablePickerProps } from './TemplateVariablePicker';

--- a/apps/server/src/bl/actions/actionExecutor.ts
+++ b/apps/server/src/bl/actions/actionExecutor.ts
@@ -39,48 +39,71 @@ export interface AlertContextInput {
 	tags?: Record<string, string> | null;
 }
 
-// Sample alert context used when testing an action, so templates render with realistic
-// values. Covers EVERY variable in ALERT_TEMPLATE_VARIABLES (asserted by test) — a test
-// run must resolve the same variables a real run would, or a template that works in Test
-// ships with literal {{...}} left in it.
-export const buildSampleContext = (): Record<string, string> => ({
-	'alert.name': 'Test alert from OpsiMate',
-	'alert.id': 'test-alert-1',
-	'alert.status': 'firing',
-	'alert.type': 'custom',
-	'alert.summary': 'This is a test action triggered from OpsiMate.',
-	'alert.severity': 'critical',
-	'alert.service': 'demo-service',
-	'alert.startsAt': new Date().toISOString(),
-	'alert.updatedAt': new Date().toISOString(),
-	'alert.createdAt': new Date().toISOString(),
-	'alert.url': 'https://example.com/alerts/test-alert-1',
-	'alert.runbookUrl': 'https://example.com/runbooks/demo-service',
-	'alert.tags.env': 'prod',
-	'alert.tags.team': 'platform',
-});
-
-// Context built from a real alert, used when running an action against an alert.
-export const buildAlertContext = (alert: AlertContextInput): Record<string, string> => {
-	const ctx: Record<string, string> = {
-		'alert.name': alert.alertName ?? '',
-		'alert.id': alert.id ?? '',
-		'alert.status': alert.status ?? '',
-		'alert.type': alert.type ?? '',
-		'alert.summary': alert.summary ?? '',
-		'alert.startsAt': alert.startsAt ?? '',
-		'alert.updatedAt': alert.updatedAt ?? '',
-		'alert.createdAt': alert.createdAt ?? '',
-		'alert.url': alert.alertUrl ?? '',
-		'alert.runbookUrl': alert.runbookUrl ?? '',
-		// First-class severity wins; the tag is kept as a fallback for older callers.
-		'alert.severity': alert.severity ?? alert.tags?.severity ?? '',
-		'alert.service': alert.tags?.service ?? '',
-	};
-	for (const [key, value] of Object.entries(alert.tags ?? {})) {
+// Expands a base field/tag map into the full variable context: every field under its
+// short canonical name ({{name}}) AND the alert.* alias; every tag as {{label.<key>}}
+// with {{tag.<key>}} and {{alert.tags.<key>}} aliases. Short names are what the picker
+// offers; the aliases keep every previously-written template resolving.
+const expandContext = (fields: Record<string, string>, tags: Record<string, string>): Record<string, string> => {
+	const ctx: Record<string, string> = {};
+	for (const [key, value] of Object.entries(fields)) {
+		ctx[key] = value;
+		ctx[`alert.${key}`] = value;
+	}
+	for (const [key, value] of Object.entries(tags)) {
+		ctx[`label.${key}`] = String(value);
+		ctx[`tag.${key}`] = String(value);
 		ctx[`alert.tags.${key}`] = String(value);
 	}
 	return ctx;
+};
+
+// Sample alert context used when testing an action, so templates render with realistic
+// values. Covers EVERY variable in ALERT_TEMPLATE_VARIABLES (asserted by test) — a test
+// run must resolve the same variables a real run would, or a template that works in Test
+// ships with literal {{...}} left in it. Timestamps are chronological: created/started
+// in the past, updated now.
+export const buildSampleContext = (): Record<string, string> => {
+	const now = Date.now();
+	const fiveMinutesAgo = new Date(now - 5 * 60 * 1000).toISOString();
+	return expandContext(
+		{
+			name: 'Test alert from OpsiMate',
+			id: 'test-alert-1',
+			status: 'firing',
+			type: 'custom',
+			summary: 'This is a test action triggered from OpsiMate.',
+			severity: 'critical',
+			service: 'demo-service',
+			startsAt: fiveMinutesAgo,
+			updatedAt: new Date(now).toISOString(),
+			createdAt: fiveMinutesAgo,
+			url: 'https://example.com/alerts/test-alert-1',
+			runbookUrl: 'https://example.com/runbooks/demo-service',
+		},
+		{ env: 'prod', team: 'platform' }
+	);
+};
+
+// Context built from a real alert, used when running an action against an alert.
+export const buildAlertContext = (alert: AlertContextInput): Record<string, string> => {
+	return expandContext(
+		{
+			name: alert.alertName ?? '',
+			id: alert.id ?? '',
+			status: alert.status ?? '',
+			type: alert.type ?? '',
+			summary: alert.summary ?? '',
+			startsAt: alert.startsAt ?? '',
+			updatedAt: alert.updatedAt ?? '',
+			createdAt: alert.createdAt ?? '',
+			url: alert.alertUrl ?? '',
+			runbookUrl: alert.runbookUrl ?? '',
+			// First-class severity wins; the tag is kept as a fallback for older callers.
+			severity: alert.severity ?? alert.tags?.severity ?? '',
+			service: alert.tags?.service ?? '',
+		},
+		alert.tags ?? {}
+	);
 };
 
 const resolvePlaceholders = (template: string | null | undefined, ctx: Record<string, string>): string => {

--- a/apps/server/src/bl/actions/actionExecutor.ts
+++ b/apps/server/src/bl/actions/actionExecutor.ts
@@ -37,14 +37,25 @@ export interface AlertContextInput {
 	tags?: Record<string, string>;
 }
 
-// Sample alert context used when testing an action, so templates render with realistic values.
+// Sample alert context used when testing an action, so templates render with realistic
+// values. Covers EVERY variable in ALERT_TEMPLATE_VARIABLES (asserted by test) — a test
+// run must resolve the same variables a real run would, or a template that works in Test
+// ships with literal {{...}} left in it.
 export const buildSampleContext = (): Record<string, string> => ({
 	'alert.name': 'Test alert from OpsiMate',
-	'alert.service': 'demo-service',
-	'alert.severity': 'critical',
+	'alert.id': 'test-alert-1',
 	'alert.status': 'firing',
+	'alert.type': 'custom',
 	'alert.summary': 'This is a test action triggered from OpsiMate.',
+	'alert.severity': 'critical',
+	'alert.service': 'demo-service',
 	'alert.startsAt': new Date().toISOString(),
+	'alert.updatedAt': new Date().toISOString(),
+	'alert.createdAt': new Date().toISOString(),
+	'alert.url': 'https://example.com/alerts/test-alert-1',
+	'alert.runbookUrl': 'https://example.com/runbooks/demo-service',
+	'alert.tags.env': 'prod',
+	'alert.tags.team': 'platform',
 });
 
 // Context built from a real alert, used when running an action against an alert.

--- a/apps/server/src/bl/actions/actionExecutor.ts
+++ b/apps/server/src/bl/actions/actionExecutor.ts
@@ -21,20 +21,22 @@ export interface ExecutableAction {
 	config: ActionConfig;
 }
 
-// Minimal alert shape needed to render action templates. Mirrors the shared Alert fields we use.
+// Minimal alert shape needed to render action templates. Mirrors the shared Alert
+// fields we use; every field tolerates null — real alerts carry nulls (custom alerts
+// have type: null), and the context builder maps them to '' anyway.
 export interface AlertContextInput {
-	id?: string;
-	alertName?: string;
-	status?: string;
-	type?: string;
-	severity?: string;
+	id?: string | null;
+	alertName?: string | null;
+	status?: string | null;
+	type?: string | null;
+	severity?: string | null;
 	summary?: string | null;
-	startsAt?: string;
-	updatedAt?: string;
-	createdAt?: string;
-	alertUrl?: string;
+	startsAt?: string | null;
+	updatedAt?: string | null;
+	createdAt?: string | null;
+	alertUrl?: string | null;
 	runbookUrl?: string | null;
-	tags?: Record<string, string>;
+	tags?: Record<string, string> | null;
 }
 
 // Sample alert context used when testing an action, so templates render with realistic

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -12,6 +12,7 @@ import {
 	User,
 } from '@OpsiMate/shared';
 import { CreateEnrichmentInput, EnrichmentRepository, UpdateEnrichmentInput } from '../../dal/enrichmentRepository';
+import { buildAlertContext } from '../actions/actionExecutor';
 import { AuditBL } from '../audit/audit.bl';
 
 const logger = new Logger('bl/enrichment.bl');
@@ -139,11 +140,14 @@ export class EnrichmentBL {
 
 	// Templates may reference the alert's current values; enrichments chain in order, so a
 	// later rule's {{summary}} sees the previous rule's output.
-	// Templates can reference the alert's own values. Besides {{summary}}, {{name}} and
-	// {{status}}, any label/tag is available as {{label.<key>}} (alias {{tag.<key>}}), e.g.
-	// {{label.host}}. Unknown placeholders are left untouched.
+	// The canonical vocabulary is the alert.* namespace action templates use (alert.name,
+	// alert.tags.<key>, ... — see buildAlertContext, reused verbatim so the two systems
+	// cannot drift). The original un-namespaced variables — {{summary}}, {{name}},
+	// {{status}}, {{label.<key>}} (alias {{tag.<key>}}) — keep resolving so existing
+	// rules are untouched. Unknown placeholders are left as-is.
 	private static resolveTemplate(template: string, alert: Alert): string {
 		const ctx: Record<string, string> = {
+			...buildAlertContext(alert),
 			summary: alert.summary ?? '',
 			name: alert.alertName ?? '',
 			status: alert.status ?? '',

--- a/apps/server/src/bl/enrichments/enrichment.bl.ts
+++ b/apps/server/src/bl/enrichments/enrichment.bl.ts
@@ -139,23 +139,13 @@ export class EnrichmentBL {
 	}
 
 	// Templates may reference the alert's current values; enrichments chain in order, so a
-	// later rule's {{summary}} sees the previous rule's output.
-	// The canonical vocabulary is the alert.* namespace action templates use (alert.name,
-	// alert.tags.<key>, ... — see buildAlertContext, reused verbatim so the two systems
-	// cannot drift). The original un-namespaced variables — {{summary}}, {{name}},
-	// {{status}}, {{label.<key>}} (alias {{tag.<key>}}) — keep resolving so existing
-	// rules are untouched. Unknown placeholders are left as-is.
+	// later rule's {{summary}} sees the previous rule's output. The vocabulary is the
+	// same one action templates use — {{summary}}, {{name}}, {{status}}, {{severity}},
+	// {{label.<key>}}, ... — via buildAlertContext, reused verbatim so the two systems
+	// cannot drift (it also accepts the alert.*/tag.* aliases). Unknown placeholders are
+	// left as-is.
 	private static resolveTemplate(template: string, alert: Alert): string {
-		const ctx: Record<string, string> = {
-			...buildAlertContext(alert),
-			summary: alert.summary ?? '',
-			name: alert.alertName ?? '',
-			status: alert.status ?? '',
-		};
-		for (const [key, value] of Object.entries(alert.tags ?? {})) {
-			ctx[`label.${key}`] = String(value);
-			ctx[`tag.${key}`] = String(value);
-		}
+		const ctx = buildAlertContext(alert);
 		return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (match, key: string) => (key in ctx ? ctx[key] : match));
 	}
 

--- a/apps/server/tests/actionTemplating.test.ts
+++ b/apps/server/tests/actionTemplating.test.ts
@@ -1,0 +1,98 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { SuperTest, Test } from 'supertest';
+import Database from 'better-sqlite3';
+import { ALERT_TEMPLATE_VARIABLES } from '@OpsiMate/shared';
+import { buildAlertContext, buildSampleContext } from '../src/bl/actions/actionExecutor';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
+
+// Template-variable contract of actions: the advertised variable list resolves in every
+// context, and the HTTP action templates its URL and body (the client's picker is built
+// on ALERT_TEMPLATE_VARIABLES, so drift here means chips that insert dead variables).
+
+let app: SuperTest<Test>;
+let db: Database.Database;
+let jwtToken: string;
+
+const post = (url: string, body: object) => app.post(url).set('Authorization', `Bearer ${jwtToken}`).send(body);
+
+beforeAll(async () => {
+	db = await setupDB();
+	app = await setupExpressApp(db);
+	jwtToken = await setupUserWithToken(app);
+});
+
+describe('alert template variables', () => {
+	test('every advertised variable resolves in the real-alert context', () => {
+		const ctx = buildAlertContext({
+			id: 'a-1',
+			alertName: 'CPU high',
+			status: 'firing',
+			type: 'grafana',
+			severity: 'critical',
+			summary: 'CPU above 90%',
+			startsAt: '2026-01-01T00:00:00Z',
+			updatedAt: '2026-01-02T00:00:00Z',
+			createdAt: '2026-01-01T00:00:00Z',
+			alertUrl: 'https://grafana/alert/a-1',
+			runbookUrl: 'https://runbooks/cpu',
+			tags: { service: 'api', env: 'prod' },
+		});
+		for (const variable of ALERT_TEMPLATE_VARIABLES) {
+			expect(ctx, `missing ${variable}`).toHaveProperty([variable]);
+		}
+		expect(ctx['alert.tags.env']).toBe('prod');
+	});
+
+	test('every advertised variable resolves in the Test-button sample context', () => {
+		const ctx = buildSampleContext();
+		for (const variable of ALERT_TEMPLATE_VARIABLES) {
+			expect(ctx, `missing ${variable}`).toHaveProperty([variable]);
+		}
+	});
+});
+
+describe('HTTP action templating over the API', () => {
+	test('a templated URL is accepted by validation and resolves in preview', async () => {
+		const created = await post('/api/v1/actions', {
+			name: 'Ack in external system',
+			type: 'http',
+			config: {
+				url: 'https://api.example.com/alerts/{{alert.id}}/ack?sev={{alert.severity}}',
+				method: 'POST',
+				headers: { 'X-Alert': '{{alert.name}}' },
+				bodyTemplate: '{"alert":"{{alert.name}}","tag":"{{alert.tags.env}}"}',
+			},
+		});
+		expect(created.status).toBe(201);
+		const actionId = created.body.data.id;
+
+		const preview = await post(`/api/v1/actions/${actionId}/preview`, {
+			alert: {
+				id: 'abc-123',
+				alertName: 'Disk full',
+				status: 'firing',
+				severity: 'critical',
+				tags: { env: 'prod' },
+			},
+		});
+		expect(preview.status).toBe(200);
+		expect(preview.body.data.url).toBe('https://api.example.com/alerts/abc-123/ack?sev=critical');
+		expect(preview.body.data.body).toBe('{"alert":"Disk full","tag":"prod"}');
+	});
+
+	test('unknown variables stay literal instead of resolving to empty', async () => {
+		const created = await post('/api/v1/actions', {
+			name: 'Unknown var',
+			type: 'http',
+			config: {
+				url: 'https://api.example.com/x',
+				method: 'POST',
+				bodyTemplate: '{{alert.nope}}',
+			},
+		});
+		const preview = await post(`/api/v1/actions/${created.body.data.id}/preview`, {
+			alert: { alertName: 'x' },
+		});
+		expect(preview.body.data.body).toBe('{{alert.nope}}');
+	});
+});

--- a/apps/server/tests/actionTemplating.test.ts
+++ b/apps/server/tests/actionTemplating.test.ts
@@ -5,9 +5,11 @@ import { ALERT_TEMPLATE_VARIABLES } from '@OpsiMate/shared';
 import { buildAlertContext, buildSampleContext } from '../src/bl/actions/actionExecutor';
 import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
 
-// Template-variable contract of actions: the advertised variable list resolves in every
-// context, and the HTTP action templates its URL and body (the client's picker is built
-// on ALERT_TEMPLATE_VARIABLES, so drift here means chips that insert dead variables).
+// Template-variable contract of actions AND enrichments (both resolve through
+// buildAlertContext): the advertised short variables ({{name}}, {{label.env}}) resolve
+// in every context, the alert.*/tag.* aliases keep older templates working, and the
+// HTTP action templates its URL and body. The client's picker is built on
+// ALERT_TEMPLATE_VARIABLES, so drift here means chips that insert dead variables.
 
 let app: SuperTest<Test>;
 let db: Database.Database;
@@ -22,32 +24,48 @@ beforeAll(async () => {
 });
 
 describe('alert template variables', () => {
-	test('every advertised variable resolves in the real-alert context', () => {
-		const ctx = buildAlertContext({
-			id: 'a-1',
-			alertName: 'CPU high',
-			status: 'firing',
-			type: 'grafana',
-			severity: 'critical',
-			summary: 'CPU above 90%',
-			startsAt: '2026-01-01T00:00:00Z',
-			updatedAt: '2026-01-02T00:00:00Z',
-			createdAt: '2026-01-01T00:00:00Z',
-			alertUrl: 'https://grafana/alert/a-1',
-			runbookUrl: 'https://runbooks/cpu',
-			tags: { service: 'api', env: 'prod' },
-		});
+	const fullAlert = {
+		id: 'a-1',
+		alertName: 'CPU high',
+		status: 'firing',
+		type: 'grafana',
+		severity: 'critical',
+		summary: 'CPU above 90%',
+		startsAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-02T00:00:00Z',
+		createdAt: '2026-01-01T00:00:00Z',
+		alertUrl: 'https://grafana/alert/a-1',
+		runbookUrl: 'https://runbooks/cpu',
+		tags: { service: 'api', env: 'prod' },
+	};
+
+	test('every advertised variable resolves to the alert value in the real-alert context', () => {
+		const ctx = buildAlertContext(fullAlert);
 		for (const variable of ALERT_TEMPLATE_VARIABLES) {
 			expect(ctx, `missing ${variable}`).toHaveProperty([variable]);
+			expect(ctx[variable], `${variable} resolved empty`).not.toBe('');
 		}
-		expect(ctx['alert.tags.env']).toBe('prod');
+		expect(ctx['name']).toBe('CPU high');
+		expect(ctx['severity']).toBe('critical');
+		expect(ctx['url']).toBe('https://grafana/alert/a-1');
+		expect(ctx['label.env']).toBe('prod');
 	});
 
-	test('every advertised variable resolves in the Test-button sample context', () => {
+	test('alert.* and tag.* aliases keep older templates resolving', () => {
+		const ctx = buildAlertContext(fullAlert);
+		expect(ctx['alert.name']).toBe('CPU high');
+		expect(ctx['alert.tags.env']).toBe('prod');
+		expect(ctx['tag.env']).toBe('prod');
+	});
+
+	test('every advertised variable resolves in the Test-button sample context, timestamps chronological', () => {
 		const ctx = buildSampleContext();
 		for (const variable of ALERT_TEMPLATE_VARIABLES) {
 			expect(ctx, `missing ${variable}`).toHaveProperty([variable]);
+			expect(ctx[variable], `${variable} resolved empty`).not.toBe('');
 		}
+		expect(new Date(ctx['createdAt']).getTime()).toBeLessThan(new Date(ctx['updatedAt']).getTime());
+		expect(new Date(ctx['startsAt']).getTime()).toBeLessThanOrEqual(new Date(ctx['updatedAt']).getTime());
 	});
 });
 
@@ -57,10 +75,10 @@ describe('HTTP action templating over the API', () => {
 			name: 'Ack in external system',
 			type: 'http',
 			config: {
-				url: 'https://api.example.com/alerts/{{alert.id}}/ack?sev={{alert.severity}}',
+				url: 'https://api.example.com/alerts/{{id}}/ack?sev={{severity}}',
 				method: 'POST',
-				headers: { 'X-Alert': '{{alert.name}}' },
-				bodyTemplate: '{"alert":"{{alert.name}}","tag":"{{alert.tags.env}}"}',
+				headers: { 'X-Alert': '{{name}}' },
+				bodyTemplate: '{"alert":"{{name}}","tag":"{{label.env}}"}',
 			},
 		});
 		expect(created.status).toBe(201);
@@ -84,7 +102,7 @@ describe('HTTP action templating over the API', () => {
 		const created = await post('/api/v1/actions', {
 			name: 'Null-tolerant preview',
 			type: 'http',
-			config: { url: 'https://api.example.com/x/{{alert.id}}', method: 'POST', bodyTemplate: '{{alert.type}}' },
+			config: { url: 'https://api.example.com/x/{{id}}', method: 'POST', bodyTemplate: '{{type}}' },
 		});
 		// Custom alerts carry type: null (and often null URLs); the details panel sends
 		// the alert as-is, so the schema must tolerate every nullable field.
@@ -110,12 +128,12 @@ describe('HTTP action templating over the API', () => {
 			config: {
 				url: 'https://api.example.com/x',
 				method: 'POST',
-				bodyTemplate: '{{alert.nope}}',
+				bodyTemplate: '{{nope}}',
 			},
 		});
 		const preview = await post(`/api/v1/actions/${created.body.data.id}/preview`, {
 			alert: { alertName: 'x' },
 		});
-		expect(preview.body.data.body).toBe('{{alert.nope}}');
+		expect(preview.body.data.body).toBe('{{nope}}');
 	});
 });

--- a/apps/server/tests/actionTemplating.test.ts
+++ b/apps/server/tests/actionTemplating.test.ts
@@ -80,6 +80,29 @@ describe('HTTP action templating over the API', () => {
 		expect(preview.body.data.body).toBe('{"alert":"Disk full","tag":"prod"}');
 	});
 
+	test('an alert with null fields previews fine — nulls must not 400 the context schema', async () => {
+		const created = await post('/api/v1/actions', {
+			name: 'Null-tolerant preview',
+			type: 'http',
+			config: { url: 'https://api.example.com/x/{{alert.id}}', method: 'POST', bodyTemplate: '{{alert.type}}' },
+		});
+		// Custom alerts carry type: null (and often null URLs); the details panel sends
+		// the alert as-is, so the schema must tolerate every nullable field.
+		const preview = await post(`/api/v1/actions/${created.body.data.id}/preview`, {
+			alert: {
+				id: 'null-1',
+				alertName: 'Custom alert',
+				type: null,
+				summary: null,
+				alertUrl: null,
+				runbookUrl: null,
+			},
+		});
+		expect(preview.status).toBe(200);
+		expect(preview.body.data.url).toBe('https://api.example.com/x/null-1');
+		expect(preview.body.data.body).toBe('');
+	});
+
 	test('unknown variables stay literal instead of resolving to empty', async () => {
 		const created = await post('/api/v1/actions', {
 			name: 'Unknown var',

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -432,20 +432,24 @@ export const ActionIdSchema = z.object({
 	}),
 });
 
-// Body for running an action against a specific alert. Lenient: extra alert fields are allowed.
+// Body for running an action against a specific alert. Lenient on BOTH axes: extra
+// alert fields pass through, and every known field tolerates null — real alerts carry
+// nulls (custom alerts have type: null, many have no URL), and the executor already
+// maps null/undefined to '' when building the template context. A strict field here
+// turns "preview an ordinary alert" into a 400.
 const alertContextSchema = z
 	.object({
-		id: z.string().optional(),
-		alertName: z.string().optional(),
-		status: z.string().optional(),
-		type: z.string().optional(),
-		summary: z.string().optional().nullable(),
-		startsAt: z.string().optional(),
-		updatedAt: z.string().optional(),
-		createdAt: z.string().optional(),
-		alertUrl: z.string().optional(),
-		runbookUrl: z.string().optional().nullable(),
-		tags: z.record(z.string(), z.string()).optional(),
+		id: z.string().nullish(),
+		alertName: z.string().nullish(),
+		status: z.string().nullish(),
+		type: z.string().nullish(),
+		summary: z.string().nullish(),
+		startsAt: z.string().nullish(),
+		updatedAt: z.string().nullish(),
+		createdAt: z.string().nullish(),
+		alertUrl: z.string().nullish(),
+		runbookUrl: z.string().nullish(),
+		tags: z.record(z.string(), z.string()).nullish(),
 	})
 	.passthrough();
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -535,27 +535,29 @@ export interface AlertEnrichment {
 // This phase only covers configuring them; wiring them to alerts comes later.
 export type ActionType = 'slack' | 'teams' | 'jira' | 'http';
 
-// The alert fields available as {{...}} template variables in every action template —
-// message/title/summary/description/body, and the HTTP action's URL and header values.
-// One list shared by the client's variable picker and the server's resolver context
-// (buildAlertContext), which additionally exposes one `alert.tags.<key>` variable per
-// tag on the alert (see alertTagTemplateVariable).
+// The alert fields available as {{...}} template variables in every action and
+// enrichment template — kept short and obvious ({{name}}, {{severity}}) because the
+// person writing a template shouldn't need to learn a namespace. One list shared by
+// the client's variable picker and the server's resolver context (buildAlertContext),
+// which additionally exposes one `label.<key>` variable per tag on the alert (see
+// alertTagTemplateVariable) and accepts `alert.*`/`alert.tags.*`/`tag.*` as aliases
+// for older templates.
 export const ALERT_TEMPLATE_VARIABLES = [
-	'alert.name',
-	'alert.id',
-	'alert.status',
-	'alert.type',
-	'alert.summary',
-	'alert.severity',
-	'alert.service',
-	'alert.startsAt',
-	'alert.updatedAt',
-	'alert.createdAt',
-	'alert.url',
-	'alert.runbookUrl',
+	'name',
+	'id',
+	'status',
+	'type',
+	'summary',
+	'severity',
+	'service',
+	'startsAt',
+	'updatedAt',
+	'createdAt',
+	'url',
+	'runbookUrl',
 ] as const;
 
-export const alertTagTemplateVariable = (tagKey: string): string => `alert.tags.${tagKey}`;
+export const alertTagTemplateVariable = (tagKey: string): string => `label.${tagKey}`;
 
 export type HttpActionMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -535,6 +535,28 @@ export interface AlertEnrichment {
 // This phase only covers configuring them; wiring them to alerts comes later.
 export type ActionType = 'slack' | 'teams' | 'jira' | 'http';
 
+// The alert fields available as {{...}} template variables in every action template —
+// message/title/summary/description/body, and the HTTP action's URL and header values.
+// One list shared by the client's variable picker and the server's resolver context
+// (buildAlertContext), which additionally exposes one `alert.tags.<key>` variable per
+// tag on the alert (see alertTagTemplateVariable).
+export const ALERT_TEMPLATE_VARIABLES = [
+	'alert.name',
+	'alert.id',
+	'alert.status',
+	'alert.type',
+	'alert.summary',
+	'alert.severity',
+	'alert.service',
+	'alert.startsAt',
+	'alert.updatedAt',
+	'alert.createdAt',
+	'alert.url',
+	'alert.runbookUrl',
+] as const;
+
+export const alertTagTemplateVariable = (tagKey: string): string => `alert.tags.${tagKey}`;
+
 export type HttpActionMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 export interface SlackActionConfig {


### PR DESCRIPTION
## What

Users asked for templated params in the HTTP-request action — like the Teams/Jira actions have — including in the URL, plus an enrichments-style picker to insert them easily.

**Key discovery:** the server has *always* resolved `{{alert.*}}` variables in the HTTP action's URL, headers, and body (`actionExecutor.ts` → `sendHttp`). The feature existed; the UI just never said so and offered no help writing them. So this PR is UI + contract-hardening:

### Shared contract
- `ALERT_TEMPLATE_VARIABLES` declared once in `@OpsiMate/shared` — the canonical variable list behind both the client's picker and the server's resolver, with a drift test asserting every advertised variable resolves in both the real-alert context and the Test-button sample context. A chip can never insert a dead variable.

### Client
- New generic **`TemplateVariablePicker`** (`components/shared`) — the enrichments dialog's label-picker pattern generalized: clickable `{{variable}}` chips that insert at the caret of whichever registered field is focused (`onMouseDown` preventDefault keeps focus through the click), replacing any selection, falling back to the type's main template field. Works on `<input>` and `<textarea>`.
- Wired into **all four** action forms: Slack (message), Teams (title + message), Jira (summary + description), HTTP (**URL + body**). Chips offer the fixed alert fields plus one `alert.tags.<key>` per tag key present on current alerts.
- The HTTP URL field is now labeled "URL — variables resolve here too" with a templated placeholder (`…/alerts/{{alert.id}}/ack`), and the dialog description spells out that URL + header values template as well.

### Server
- `buildSampleContext` (the Test button) extended from 6 variables to the full set + sample tags — a template that "works in Test" can no longer ship with `{{...}}` left unresolved in real runs.
- New tests (`actionTemplating.test.ts`): templated URL passes create-validation and resolves in preview (`/alerts/{{alert.id}}/ack?sev={{alert.severity}}` → `/alerts/abc-123/ack?sev=critical`), body + tag variables resolve, unknown variables stay literal.

## Verified live
Opened the dialog on a running instance: chips render under each form; focused the URL field → clicked `{{alert.id}}` → inserted at the caret (`https://api.example.com/ack/{{alert.id}}`, focus retained); typed mid-JSON in the body → clicked `{{alert.name}}` → inserted at the caret there.

206 server tests (4 new) + 145 client tests green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added template-variable pickers to action and enrichment forms.
  - Insert alert fields and tag values into Slack, Teams, Jira, HTTP, and summary templates.
  - Added support for templating HTTP URLs and bodies, with header variables also resolved.
  - Standardized alert variables while maintaining compatibility with legacy aliases.

- **Bug Fixes**
  - Templates now handle nullable alert fields correctly.
  - Unknown template variables remain unchanged instead of causing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->