### PR TITLE
feat(server): Prometheus /metrics endpoint

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -39,6 +39,7 @@
 		"multer": "^2.2.0",
 		"node-ssh": "^13.2.1",
 		"nodemailer": "^7.0.13",
+		"prom-client": "^15.1.3",
 		"sshpk": "^1.18.0",
 		"vite": "^8.2.0",
 		"vite-plugin-node": "^8.0.0",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -52,6 +52,7 @@ import { RetentionJob } from './jobs/retention-job';
 import { RetentionBL } from './bl/retention/retention.bl';
 import { PlaygroundRepository } from './dal/playgroundRepository.ts';
 import { PlaygroundBL } from './bl/playground/playground.bl.ts';
+import { initMetrics, metricsHandler, metricsMiddleware } from './metrics';
 
 export enum AppMode {
 	SERVER = 'SERVER',
@@ -100,6 +101,12 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 
 	// SERVER mode: Create Express app and API routes
 	const app = express();
+
+	// Prometheus (issue #658): request timing on everything below, gauges resolved at
+	// scrape time from cheap SQL counts — never through the alerts snapshot.
+	initMetrics(db);
+	app.use(metricsMiddleware);
+	app.get('/metrics', metricsHandler);
 
 	// The alerts payload is large, repetitive JSON polled every few seconds by every
 	// open client — the highest-volume traffic this server produces, and it compresses

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -103,8 +103,8 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	const app = express();
 
 	// Prometheus (issue #658): request timing on everything below, gauges resolved at
-	// scrape time from cheap SQL counts — never through the alerts snapshot.
-	initMetrics(db);
+	// scrape time from cheap SQL counts — never through the alerts snapshot. The gauge
+	// statements are prepared further down, after every table they read exists.
 	app.use(metricsMiddleware);
 	app.get('/metrics', metricsHandler);
 
@@ -169,6 +169,9 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 		enrichmentRepo.initEnrichmentsTable(),
 		actionRepo.initActionsTable(),
 	]);
+
+	// Every table the metric gauges count now exists.
+	initMetrics(db);
 
 	// BL
 	const userBL = new UserBL(userRepo, mailClient, passwordResetsRepo, auditBL);

--- a/apps/server/src/bl/actions/action.bl.ts
+++ b/apps/server/src/bl/actions/action.bl.ts
@@ -10,6 +10,7 @@ import {
 	User,
 } from '@OpsiMate/shared';
 import { ActionRepository, CreateActionInput, UpdateActionInput } from '../../dal/actionRepository';
+import { actionsRunTotal } from '../../metrics';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
 import { AuditBL } from '../audit/audit.bl';
 import {
@@ -52,6 +53,7 @@ export class ActionBL {
 			buildAlertContext(alert),
 			overrides
 		);
+		actionsRunTotal.inc({ type: action.type, outcome: result.success ? 'success' : 'error' });
 
 		// Record the run on the alert's history timeline (best-effort; never block the action).
 		if (alert.id && this.alertHistoryRepo) {

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -15,6 +15,7 @@ import {
 } from '@OpsiMate/shared';
 import { AlertCommentsRepository } from '../../dal/alertCommentsRepository.ts';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
+import { alertsIngestedTotal } from '../../metrics';
 import { UserRepository } from '../../dal/userRepository';
 import { toIsoUtc } from '../../utils/time';
 import { EnrichmentBL } from '../enrichments/enrichment.bl';
@@ -269,6 +270,9 @@ export class AlertBL {
 			// alert must never show as both firing and resolved.
 			const result = await this.alertRepo.insertOrUpdateAlert({ ...alert, tags, severity, team });
 			this.invalidateSnapshots();
+			// In-memory increment; this is the single funnel every webhook source flows
+			// through, so one counter covers all of them.
+			alertsIngestedTotal.inc({ type: alert.type ?? 'unknown', severity });
 			return result;
 		} catch (error) {
 			logger.error('Error inserting alert', error);

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -15,7 +15,15 @@ import {
 } from '@OpsiMate/shared';
 import { AlertCommentsRepository } from '../../dal/alertCommentsRepository.ts';
 import { AlertHistoryRepository } from '../../dal/alertHistoryRepository';
-import { alertsIngestedTotal } from '../../metrics';
+import {
+	alertsIngestedTotal,
+	alertsResolvedTotal,
+	alertsSilencedTotal,
+	alertsUnsilencedTotal,
+	bulkActionsTotal,
+	bulkAlertsAffectedTotal,
+	snapshotComputeDuration,
+} from '../../metrics';
 import { UserRepository } from '../../dal/userRepository';
 import { toIsoUtc } from '../../utils/time';
 import { EnrichmentBL } from '../enrichments/enrichment.bl';
@@ -211,6 +219,8 @@ export class AlertBL {
 			}
 		}
 		logger.info(`Bulk ${input.action}: ${succeeded}/${targetIds.length} succeeded`);
+		bulkActionsTotal.inc({ action: input.action });
+		if (succeeded > 0) bulkAlertsAffectedTotal.inc({ action: input.action }, succeeded);
 		return { matched: targetIds.length, succeeded, failed };
 	}
 
@@ -285,6 +295,7 @@ export class AlertBL {
 	private async expireSilences(): Promise<void> {
 		const expiredIds = await this.alertRepo.clearExpiredSilences(new Date().toISOString());
 		if (expiredIds.length > 0) this.invalidateSnapshots();
+		if (expiredIds.length > 0) alertsUnsilencedTotal.inc(expiredIds.length);
 		await Promise.all(
 			expiredIds.map((id) =>
 				this.recordHistoryEvent(id, AlertHistoryEventType.UNSILENCED, 'Silence expired', null)
@@ -320,6 +331,7 @@ export class AlertBL {
 		await this.alertRepo.markSilenceResetCleared(occurrence.toISOString());
 		const clearedIds = await this.alertRepo.clearSilencesEstablishedBy(occurrence.toISOString());
 		if (clearedIds.length > 0) this.invalidateSnapshots();
+		if (clearedIds.length > 0) alertsUnsilencedTotal.inc(clearedIds.length);
 		if (clearedIds.length > 0) {
 			logger.info(`Daily silence reset cleared ${clearedIds.length} silence(s)`);
 		}
@@ -383,6 +395,7 @@ export class AlertBL {
 	}
 
 	private async computeAllAlerts(): Promise<Alert[]> {
+		const endTimer = snapshotComputeDuration.startTimer({ list: 'active' });
 		try {
 			logger.info('Fetching all alerts');
 			await this.expireSilences();
@@ -398,6 +411,8 @@ export class AlertBL {
 		} catch (error) {
 			logger.error('Error fetching alerts', error);
 			throw error;
+		} finally {
+			endTimer();
 		}
 	}
 
@@ -418,6 +433,7 @@ export class AlertBL {
 			let alert = await this.alertRepo.silenceAlert(id, normalizedSilencedUntil);
 			this.invalidateSnapshots();
 			if (alert) {
+				alertsSilencedTotal.inc();
 				const description = normalizedSilencedUntil
 					? `Alert silenced until ${normalizedSilencedUntil}`
 					: 'Alert silenced';
@@ -455,6 +471,7 @@ export class AlertBL {
 			const alert = await this.alertRepo.unsilenceAlert(id);
 			this.invalidateSnapshots();
 			if (alert) {
+				alertsUnsilencedTotal.inc();
 				await this.recordHistoryEvent(id, AlertHistoryEventType.UNSILENCED, 'Alert unsilenced', actorName);
 			}
 			return alert;
@@ -471,6 +488,7 @@ export class AlertBL {
 	}
 
 	private async computeAllResolvedAlerts(): Promise<Alert[]> {
+		const endTimer = snapshotComputeDuration.startTimer({ list: 'resolved' });
 		try {
 			logger.info('Fetching all resolved alerts');
 			let alerts = await this.resolvedAlertRepo.getAllResolvedAlerts();
@@ -489,6 +507,8 @@ export class AlertBL {
 		} catch (error) {
 			logger.error('Error fetching resolved alerts', error);
 			throw error;
+		} finally {
+			endTimer();
 		}
 	}
 
@@ -518,6 +538,7 @@ export class AlertBL {
 			// Remove from active table
 			await this.alertRepo.deleteAlert(activeAlertId);
 			this.invalidateSnapshots();
+			alertsResolvedTotal.inc({ mode: manualActor !== undefined ? 'manual' : 'auto' });
 
 			if (manualActor !== undefined) {
 				await this.recordHistoryEvent(
@@ -563,6 +584,7 @@ export class AlertBL {
 			// Delete alerts from active table
 			await this.alertRepo.deleteAlertsNotInIds(activeAlertIds, alertType);
 			this.invalidateSnapshots();
+			if (alertsToResolve.length > 0) alertsResolvedTotal.inc({ mode: 'auto' }, alertsToResolve.length);
 
 			logger.info(`Resolved ${alertsToResolve.length} alerts`);
 		} catch (error) {

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -30,6 +30,58 @@ export const httpRequestDuration = new Histogram({
 	registers: [metricsRegistry],
 });
 
+// ---- applicative counters, incremented at the single BL funnel of each operation ----
+
+export const alertsResolvedTotal = new Counter({
+	name: 'opsimate_alerts_resolved_total',
+	help: 'Alerts resolved, split by mode: manual (a user clicked resolve) vs auto (the source reported recovery)',
+	labelNames: ['mode'] as const,
+	registers: [metricsRegistry],
+});
+
+export const alertsSilencedTotal = new Counter({
+	name: 'opsimate_alerts_silenced_total',
+	help: 'Silence operations applied to alerts',
+	registers: [metricsRegistry],
+});
+
+export const alertsUnsilencedTotal = new Counter({
+	name: 'opsimate_alerts_unsilenced_total',
+	help: 'Unsilence operations applied to alerts (manual, timer expiry, and daily reset)',
+	registers: [metricsRegistry],
+});
+
+export const actionsRunTotal = new Counter({
+	name: 'opsimate_actions_run_total',
+	help: 'Actions executed against alerts, by action type and outcome',
+	labelNames: ['type', 'outcome'] as const,
+	registers: [metricsRegistry],
+});
+
+export const bulkActionsTotal = new Counter({
+	name: 'opsimate_bulk_actions_total',
+	help: 'Bulk operations executed (one increment per request, whatever its size)',
+	labelNames: ['action'] as const,
+	registers: [metricsRegistry],
+});
+
+export const bulkAlertsAffectedTotal = new Counter({
+	name: 'opsimate_bulk_alerts_affected_total',
+	help: 'Alerts actually mutated by bulk operations (the succeeded count)',
+	labelNames: ['action'] as const,
+	registers: [metricsRegistry],
+});
+
+// Visibility into the snapshot cache the whole read path sits on: how often the full
+// alert list is recomputed (enrichments + mute policies + comments + firing times) and
+// how long it takes. Wraps a computation that runs anyway — zero added cost.
+export const snapshotComputeDuration = new Histogram({
+	name: 'opsimate_snapshot_compute_duration_seconds',
+	help: 'Duration of full alert-snapshot recomputes, by list',
+	labelNames: ['list'] as const,
+	registers: [metricsRegistry],
+});
+
 // Alert state gauges, resolved lazily per scrape. States mirror what the product
 // shows: firing and silenced live in the alerts table (is_dismissed is the silence
 // flag), resolved in alerts_resolved. "Muted" is a read-time mute-policy computation
@@ -41,10 +93,13 @@ interface StateCountRow {
 	count: number;
 }
 
-// Bound by initMetrics; the gauges below read through it so initMetrics stays
+// Bound by initMetrics; the gauges below read through them so initMetrics stays
 // idempotent (tests build several apps in one process — a second Gauge with the same
 // name would throw on registration).
 let countByStateAndSeverity: Database.Statement | null = null;
+let firingTriageCounts: Database.Statement | null = null;
+let oldestFiringStartsAt: Database.Statement | null = null;
+let resourceCounts: Database.Statement | null = null;
 
 export const initMetrics = (db: Database.Database): void => {
 	countByStateAndSeverity = db.prepare(`
@@ -56,6 +111,21 @@ export const initMetrics = (db: Database.Database): void => {
 		SELECT 'resolved' AS state, severity, COUNT(*) AS count
 		FROM alerts_resolved
 		GROUP BY severity
+	`);
+	firingTriageCounts = db.prepare(`
+		SELECT SUM(CASE WHEN owner_id IS NULL THEN 1 ELSE 0 END) AS unassigned,
+		       SUM(CASE WHEN is_read = 0 OR is_read IS NULL THEN 1 ELSE 0 END) AS unread
+		FROM alerts WHERE is_dismissed = 0
+	`);
+	oldestFiringStartsAt = db.prepare(`SELECT MIN(starts_at) AS oldest FROM alerts WHERE is_dismissed = 0`);
+	resourceCounts = db.prepare(`
+		SELECT 'users' AS kind, COUNT(*) AS count FROM users
+		UNION ALL SELECT 'integrations', COUNT(*) FROM integrations
+		UNION ALL SELECT 'dashboards', COUNT(*) FROM dashboards
+		UNION ALL SELECT 'enrichment_rules', COUNT(*) FROM alert_enrichments
+		UNION ALL SELECT 'mute_policies', COUNT(*) FROM alert_mute_policies
+		UNION ALL SELECT 'actions', COUNT(*) FROM actions
+		UNION ALL SELECT 'oncall_teams', COUNT(*) FROM oncall_teams
 	`);
 };
 
@@ -87,6 +157,58 @@ new Gauge({
 		this.reset();
 		for (const row of countByStateAndSeverity.all() as StateCountRow[]) {
 			this.set({ state: row.state, severity: row.severity ?? 'unknown' }, row.count);
+		}
+	},
+});
+
+// Triage backlog: firing alerts nobody owns and nobody has looked at.
+new Gauge({
+	name: 'opsimate_firing_alerts_unassigned',
+	help: 'Firing alerts with no owner',
+	registers: [metricsRegistry],
+	collect() {
+		if (!firingTriageCounts) return;
+		const row = firingTriageCounts.get() as { unassigned: number | null; unread: number | null };
+		this.set(row.unassigned ?? 0);
+	},
+});
+
+new Gauge({
+	name: 'opsimate_firing_alerts_unread',
+	help: 'Firing alerts no one has opened yet',
+	registers: [metricsRegistry],
+	collect() {
+		if (!firingTriageCounts) return;
+		const row = firingTriageCounts.get() as { unassigned: number | null; unread: number | null };
+		this.set(row.unread ?? 0);
+	},
+});
+
+// Age of the longest-firing alert — the "is something rotting unhandled" signal.
+// 0 when nothing is firing.
+new Gauge({
+	name: 'opsimate_oldest_firing_alert_age_seconds',
+	help: 'Age in seconds of the oldest currently-firing alert (0 when none)',
+	registers: [metricsRegistry],
+	collect() {
+		if (!oldestFiringStartsAt) return;
+		const row = oldestFiringStartsAt.get() as { oldest: string | null };
+		const started = row.oldest ? Date.parse(row.oldest) : NaN;
+		this.set(Number.isFinite(started) ? Math.max(0, (Date.now() - started) / 1000) : 0);
+	},
+});
+
+// Inventory of configured objects — trend lines answer "who added 40 mute policies".
+new Gauge({
+	name: 'opsimate_resources',
+	help: 'Count of configured resources by kind (users, integrations, dashboards, rules, ...)',
+	labelNames: ['kind'] as const,
+	registers: [metricsRegistry],
+	collect() {
+		if (!resourceCounts) return;
+		this.reset();
+		for (const row of resourceCounts.all() as { kind: string; count: number }[]) {
+			this.set({ kind: row.kind }, row.count);
 		}
 	},
 });

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -93,6 +93,20 @@ interface StateCountRow {
 	count: number;
 }
 
+interface TriageCountRow {
+	unassigned: number | null;
+	unread: number | null;
+}
+
+interface OldestFiringRow {
+	oldest: string | null;
+}
+
+interface ResourceCountRow {
+	kind: string;
+	count: number;
+}
+
 // Bound by initMetrics; the gauges below read through them so initMetrics stays
 // idempotent (tests build several apps in one process — a second Gauge with the same
 // name would throw on registration).
@@ -168,7 +182,7 @@ new Gauge({
 	registers: [metricsRegistry],
 	collect() {
 		if (!firingTriageCounts) return;
-		const row = firingTriageCounts.get() as { unassigned: number | null; unread: number | null };
+		const row = firingTriageCounts.get() as TriageCountRow;
 		this.set(row.unassigned ?? 0);
 	},
 });
@@ -179,7 +193,7 @@ new Gauge({
 	registers: [metricsRegistry],
 	collect() {
 		if (!firingTriageCounts) return;
-		const row = firingTriageCounts.get() as { unassigned: number | null; unread: number | null };
+		const row = firingTriageCounts.get() as TriageCountRow;
 		this.set(row.unread ?? 0);
 	},
 });
@@ -192,7 +206,7 @@ new Gauge({
 	registers: [metricsRegistry],
 	collect() {
 		if (!oldestFiringStartsAt) return;
-		const row = oldestFiringStartsAt.get() as { oldest: string | null };
+		const row = oldestFiringStartsAt.get() as OldestFiringRow;
 		const started = row.oldest ? Date.parse(row.oldest) : NaN;
 		this.set(Number.isFinite(started) ? Math.max(0, (Date.now() - started) / 1000) : 0);
 	},
@@ -207,7 +221,7 @@ new Gauge({
 	collect() {
 		if (!resourceCounts) return;
 		this.reset();
-		for (const row of resourceCounts.all() as { kind: string; count: number }[]) {
+		for (const row of resourceCounts.all() as ResourceCountRow[]) {
 			this.set({ kind: row.kind }, row.count);
 		}
 	},

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -1,0 +1,117 @@
+import type Database from 'better-sqlite3';
+import { NextFunction, Request, Response } from 'express';
+import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from 'prom-client';
+
+// Prometheus metrics (issue #658). Everything here is deliberately OUTSIDE the hot
+// path: the alert gauges run plain COUNT/GROUP BY prepared statements at SCRAPE time
+// (sub-millisecond at 10k rows) instead of reading the alerts snapshot — so a scrape
+// can never trigger the expensive enrichment/mute-policy compute — and the request
+// histogram and ingestion counter are in-memory increments.
+
+export const metricsRegistry = new Registry();
+
+// Process/runtime metrics: memory, CPU, event loop lag, GC, open handles.
+collectDefaultMetrics({ register: metricsRegistry });
+
+// Incremented in the single ingestion funnel (AlertBL.insertOrUpdateAlert), so every
+// webhook source counts the same way. Label cardinality is bounded: a handful of
+// integration types x three severities.
+export const alertsIngestedTotal = new Counter({
+	name: 'opsimate_alerts_ingested_total',
+	help: 'Alerts received through the ingestion funnel (inserts and updates)',
+	labelNames: ['type', 'severity'] as const,
+	registers: [metricsRegistry],
+});
+
+export const httpRequestDuration = new Histogram({
+	name: 'opsimate_http_request_duration_seconds',
+	help: 'HTTP request duration by method, matched route and status code',
+	labelNames: ['method', 'route', 'status_code'] as const,
+	registers: [metricsRegistry],
+});
+
+// Alert state gauges, resolved lazily per scrape. States mirror what the product
+// shows: firing and silenced live in the alerts table (is_dismissed is the silence
+// flag), resolved in alerts_resolved. "Muted" is a read-time mute-policy computation
+// over the snapshot, not a stored state — surfacing it would drag rule evaluation
+// into every scrape, so it is deliberately absent.
+interface StateCountRow {
+	state: string;
+	severity: string | null;
+	count: number;
+}
+
+// Bound by initMetrics; the gauges below read through it so initMetrics stays
+// idempotent (tests build several apps in one process — a second Gauge with the same
+// name would throw on registration).
+let countByStateAndSeverity: Database.Statement | null = null;
+
+export const initMetrics = (db: Database.Database): void => {
+	countByStateAndSeverity = db.prepare(`
+		SELECT CASE WHEN is_dismissed = 1 THEN 'silenced' ELSE 'firing' END AS state,
+		       severity, COUNT(*) AS count
+		FROM alerts
+		GROUP BY state, severity
+		UNION ALL
+		SELECT 'resolved' AS state, severity, COUNT(*) AS count
+		FROM alerts_resolved
+		GROUP BY severity
+	`);
+};
+
+new Gauge({
+	name: 'opsimate_alerts',
+	help: 'Current number of alerts by state (firing, silenced, resolved)',
+	labelNames: ['state'] as const,
+	registers: [metricsRegistry],
+	collect() {
+		if (!countByStateAndSeverity) return;
+		const totals: Record<string, number> = { firing: 0, silenced: 0, resolved: 0 };
+		for (const row of countByStateAndSeverity.all() as StateCountRow[]) {
+			totals[row.state] = (totals[row.state] ?? 0) + row.count;
+		}
+		this.reset();
+		for (const [state, count] of Object.entries(totals)) {
+			this.set({ state }, count);
+		}
+	},
+});
+
+new Gauge({
+	name: 'opsimate_alerts_by_severity',
+	help: 'Current number of alerts by state and severity',
+	labelNames: ['state', 'severity'] as const,
+	registers: [metricsRegistry],
+	collect() {
+		if (!countByStateAndSeverity) return;
+		this.reset();
+		for (const row of countByStateAndSeverity.all() as StateCountRow[]) {
+			this.set({ state: row.state, severity: row.severity ?? 'unknown' }, row.count);
+		}
+	},
+});
+
+// Times every request against the MATCHED route pattern (e.g. /api/v1/alerts/:id/silence),
+// never the raw URL — raw paths would explode label cardinality with every alert id and
+// every scanner probe. Unmatched requests all share one 'unmatched' series.
+export const metricsMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+	const end = httpRequestDuration.startTimer();
+	res.on('finish', () => {
+		const route = req.route ? `${req.baseUrl}${(req.route as { path: string }).path}` : 'unmatched';
+		end({ method: req.method, route, status_code: String(res.statusCode) });
+	});
+	next();
+};
+
+// Scrape endpoint. Open by default (Prometheus-friendly, exposes only counts and
+// timings); setting METRICS_TOKEN requires `Authorization: Bearer <token>`. Read per
+// request so tests — and operators — can change it without a rebuild.
+export const metricsHandler = async (req: Request, res: Response): Promise<void> => {
+	const token = process.env.METRICS_TOKEN;
+	if (token && req.headers.authorization !== `Bearer ${token}`) {
+		res.status(401).send('unauthorized');
+		return;
+	}
+	res.set('Content-Type', metricsRegistry.contentType);
+	res.send(await metricsRegistry.metrics());
+};

--- a/apps/server/tests/metrics.test.ts
+++ b/apps/server/tests/metrics.test.ts
@@ -83,6 +83,39 @@ describe('GET /metrics', () => {
 		expect(res.text).toContain('nodejs_eventloop_lag_seconds');
 	});
 
+	test('triage, age and resource gauges are exposed', async () => {
+		const res = await app.get('/metrics');
+		expect(res.text).toMatch(/opsimate_firing_alerts_unassigned \d+/);
+		expect(res.text).toMatch(/opsimate_firing_alerts_unread \d+/);
+		// Alerts inserted with starts_at=now: age is tiny but present and non-negative.
+		expect(res.text).toMatch(/opsimate_oldest_firing_alert_age_seconds \d+/);
+		expect(res.text).toMatch(/opsimate_resources\{kind="users"\} [1-9]/);
+		expect(res.text).toMatch(/opsimate_resources\{kind="dashboards"\} \d+/);
+	});
+
+	test('resolve and bulk operations increment their counters', async () => {
+		insertAlert('m-res', 'critical', 0);
+		await app.delete('/api/v1/alerts/m-res').set('Authorization', `Bearer ${jwtToken}`);
+
+		insertAlert('m-bulk', 'info', 0);
+		await app
+			.post('/api/v1/alerts/bulk')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ action: 'silence', ids: ['m-bulk'], silencedUntil: null });
+
+		const metrics = await app.get('/metrics');
+		expect(metrics.text).toMatch(/opsimate_alerts_resolved_total\{mode="manual"\} [1-9]/);
+		expect(metrics.text).toMatch(/opsimate_bulk_actions_total\{action="silence"\} [1-9]/);
+		expect(metrics.text).toMatch(/opsimate_bulk_alerts_affected_total\{action="silence"\} [1-9]/);
+		expect(metrics.text).toMatch(/opsimate_alerts_silenced_total [1-9]/);
+	});
+
+	test('snapshot compute duration is observed once the list is read', async () => {
+		await app.get('/api/v1/alerts?limit=1').set('Authorization', `Bearer ${jwtToken}`);
+		const metrics = await app.get('/metrics');
+		expect(metrics.text).toMatch(/opsimate_snapshot_compute_duration_seconds_count\{list="active"\} [1-9]/);
+	});
+
 	test('METRICS_TOKEN gates the endpoint when set', async () => {
 		process.env.METRICS_TOKEN = 'scrape-secret';
 		const denied = await app.get('/metrics');

--- a/apps/server/tests/metrics.test.ts
+++ b/apps/server/tests/metrics.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { SuperTest, Test } from 'supertest';
+import Database from 'better-sqlite3';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
+
+// The /metrics endpoint (issue #658): Prometheus text format, alert-state gauges
+// computed from cheap SQL counts at scrape time, ingestion counter, request-duration
+// histogram with matched-route labels, and optional bearer-token gating.
+
+let app: SuperTest<Test>;
+let db: Database.Database;
+let jwtToken: string;
+
+const insertAlert = (id: string, severity: string, dismissed: number) => {
+	db.prepare(
+		`INSERT INTO alerts (id, status, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed)
+		 VALUES (?, 'firing', ?, '{}', ?, ?, 'https://example.com', ?, 'Summary', NULL, ?)`
+	).run(id, severity, new Date().toISOString(), new Date().toISOString(), `Metric Alert ${id}`, dismissed);
+};
+
+const insertResolved = (id: string, severity: string) => {
+	db.prepare(
+		`INSERT INTO alerts_resolved (id, status, severity, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed)
+		 VALUES (?, 'resolved', ?, '{}', ?, ?, 'https://example.com', ?, 'Summary', NULL, 0)`
+	).run(id, severity, new Date().toISOString(), new Date().toISOString(), `Resolved Alert ${id}`);
+};
+
+beforeAll(async () => {
+	db = await setupDB();
+	app = await setupExpressApp(db);
+	jwtToken = await setupUserWithToken(app);
+	insertAlert('m-1', 'critical', 0);
+	insertAlert('m-2', 'critical', 0);
+	insertAlert('m-3', 'warning', 1);
+	insertResolved('m-r1', 'info');
+});
+
+afterEach(() => {
+	delete process.env.METRICS_TOKEN;
+});
+
+describe('GET /metrics', () => {
+	test('exposes alert-state gauges with firing/silenced/resolved naming', async () => {
+		const res = await app.get('/metrics');
+		expect(res.status).toBe(200);
+		expect(res.headers['content-type']).toContain('text/plain');
+		expect(res.text).toContain('opsimate_alerts{state="firing"} 2');
+		expect(res.text).toContain('opsimate_alerts{state="silenced"} 1');
+		expect(res.text).toContain('opsimate_alerts{state="resolved"} 1');
+		expect(res.text).toContain('opsimate_alerts_by_severity{state="firing",severity="critical"} 2');
+		expect(res.text).toContain('opsimate_alerts_by_severity{state="resolved",severity="info"} 1');
+	});
+
+	test('gauges track changes on the next scrape', async () => {
+		insertAlert('m-4', 'info', 0);
+		const res = await app.get('/metrics');
+		expect(res.text).toContain('opsimate_alerts{state="firing"} 3');
+		db.prepare(`DELETE FROM alerts WHERE id = 'm-4'`).run();
+	});
+
+	test('ingestion through the funnel increments the counter with type and severity', async () => {
+		const res = await app
+			.post('/api/v1/alerts/custom')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ id: 'ingest-1', alertName: 'Ingested', tags: { severity: 'critical' } });
+		expect(res.status).toBeLessThan(300);
+
+		const metrics = await app.get('/metrics');
+		expect(metrics.text).toMatch(/opsimate_alerts_ingested_total\{[^}]*severity="critical"[^}]*\} [1-9]/);
+	});
+
+	test('request durations are recorded against the matched route pattern, not the raw URL', async () => {
+		await app.get('/api/v1/alerts?limit=1').set('Authorization', `Bearer ${jwtToken}`);
+		const metrics = await app.get('/metrics');
+		expect(metrics.text).toContain('route="/api/v1/alerts/"');
+		// No raw-query or per-id label values may appear.
+		expect(metrics.text).not.toContain('limit=1');
+	});
+
+	test('includes default process metrics', async () => {
+		const res = await app.get('/metrics');
+		expect(res.text).toContain('process_cpu_user_seconds_total');
+		expect(res.text).toContain('nodejs_eventloop_lag_seconds');
+	});
+
+	test('METRICS_TOKEN gates the endpoint when set', async () => {
+		process.env.METRICS_TOKEN = 'scrape-secret';
+		const denied = await app.get('/metrics');
+		expect(denied.status).toBe(401);
+		const allowed = await app.get('/metrics').set('Authorization', 'Bearer scrape-secret');
+		expect(allowed.status).toBe(200);
+	});
+});

--- a/apps/server/tests/metrics.test.ts
+++ b/apps/server/tests/metrics.test.ts
@@ -35,8 +35,11 @@ beforeAll(async () => {
 	insertResolved('m-r1', 'info');
 });
 
+// Restore rather than delete: a developer's own METRICS_TOKEN must survive the run.
+const originalMetricsToken = process.env.METRICS_TOKEN;
 afterEach(() => {
-	delete process.env.METRICS_TOKEN;
+	if (originalMetricsToken === undefined) delete process.env.METRICS_TOKEN;
+	else process.env.METRICS_TOKEN = originalMetricsToken;
 });
 
 describe('GET /metrics', () => {
@@ -66,7 +69,7 @@ describe('GET /metrics', () => {
 		expect(res.status).toBeLessThan(300);
 
 		const metrics = await app.get('/metrics');
-		expect(metrics.text).toMatch(/opsimate_alerts_ingested_total\{[^}]*severity="critical"[^}]*\} [1-9]/);
+		expect(metrics.text).toMatch(/opsimate_alerts_ingested_total\{type="Custom",severity="critical"\} [1-9]/);
 	});
 
 	test('request durations are recorded against the matched route pattern, not the raw URL', async () => {

--- a/infrastructure/grafana/opsimate-dashboard.json
+++ b/infrastructure/grafana/opsimate-dashboard.json
@@ -10,9 +10,7 @@
   ],
   "title": "OpsiMate",
   "uid": "opsimate-self",
-  "tags": [
-    "opsimate"
-  ],
+  "tags": ["opsimate"],
   "timezone": "browser",
   "schemaVersion": 39,
   "refresh": "30s",
@@ -20,13 +18,21 @@
     "from": "now-3h",
     "to": "now"
   },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
   "panels": [
     {
       "type": "stat",
       "title": "Firing",
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 3,
         "x": 0,
         "y": 0
       },
@@ -37,13 +43,13 @@
       "targets": [
         {
           "expr": "opsimate_alerts{state=\"firing\"}",
-          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": false
+          "range": false,
+          "instant": true
         }
       ],
       "options": {
@@ -62,7 +68,7 @@
                 "color": "green"
               },
               {
-                "color": "orange",
+                "color": "yellow",
                 "value": 1
               },
               {
@@ -78,11 +84,91 @@
     },
     {
       "type": "stat",
+      "title": "Silenced",
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "opsimate_alerts{state=\"silenced\"}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": false,
+          "instant": true
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          }
+        },
+        "overrides": []
+      },
+      "id": 2
+    },
+    {
+      "type": "stat",
+      "title": "Resolved",
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "opsimate_alerts{state=\"resolved\"}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": false,
+          "instant": true
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        },
+        "overrides": []
+      },
+      "id": 3
+    },
+    {
+      "type": "stat",
       "title": "Unassigned firing",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
+        "w": 3,
+        "x": 9,
         "y": 0
       },
       "datasource": {
@@ -92,13 +178,13 @@
       "targets": [
         {
           "expr": "opsimate_firing_alerts_unassigned",
-          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": false
+          "range": false,
+          "instant": true
         }
       ],
       "options": {
@@ -129,15 +215,70 @@
         },
         "overrides": []
       },
-      "id": 2
+      "id": 4
+    },
+    {
+      "type": "stat",
+      "title": "Unread firing",
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "opsimate_firing_alerts_unread",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": false,
+          "instant": true
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 5
     },
     {
       "type": "stat",
       "title": "Oldest firing",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 8,
+        "w": 3,
+        "x": 15,
         "y": 0
       },
       "datasource": {
@@ -147,13 +288,13 @@
       "targets": [
         {
           "expr": "opsimate_oldest_firing_alert_age_seconds",
-          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": false
+          "range": false,
+          "instant": true
         }
       ],
       "options": {
@@ -185,15 +326,15 @@
         },
         "overrides": []
       },
-      "id": 3
+      "id": 6
     },
     {
       "type": "stat",
       "title": "Ingestion (5m)",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 12,
+        "w": 3,
+        "x": 18,
         "y": 0
       },
       "datasource": {
@@ -225,15 +366,15 @@
         },
         "overrides": []
       },
-      "id": 4
+      "id": 7
     },
     {
       "type": "stat",
       "title": "API p95 (5m)",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 16,
+        "w": 3,
+        "x": 21,
         "y": 0
       },
       "datasource": {
@@ -280,63 +421,7 @@
         },
         "overrides": []
       },
-      "id": 5
-    },
-    {
-      "type": "stat",
-      "title": "Event loop p99",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "nodejs_eventloop_lag_p99_seconds",
-          "instant": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": false
-        }
-      ],
-      "options": {
-        "graphMode": "area",
-        "colorMode": "value"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "yellow",
-                "value": 0.05
-              },
-              {
-                "color": "red",
-                "value": 0.2
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "id": 6
+      "id": 8
     },
     {
       "type": "timeseries",
@@ -354,22 +439,20 @@
       "targets": [
         {
           "expr": "opsimate_alerts",
-          "legendFormat": "{{state}}",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": true
+          "range": true,
+          "legendFormat": "{{state}}"
         }
       ],
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
+          "calcs": ["lastNotNull"]
         }
       },
       "fieldConfig": {
@@ -382,7 +465,7 @@
         },
         "overrides": []
       },
-      "id": 7
+      "id": 9
     },
     {
       "type": "timeseries",
@@ -400,22 +483,20 @@
       "targets": [
         {
           "expr": "opsimate_alerts_by_severity{state=\"firing\"}",
-          "legendFormat": "{{severity}}",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": true
+          "range": true,
+          "legendFormat": "{{severity}}"
         }
       ],
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
+          "calcs": ["lastNotNull"]
         }
       },
       "fieldConfig": {
@@ -432,7 +513,7 @@
         },
         "overrides": []
       },
-      "id": 8
+      "id": 10
     },
     {
       "type": "timeseries",
@@ -450,156 +531,20 @@
       "targets": [
         {
           "expr": "sum(rate(opsimate_alerts_ingested_total[5m])) by (type)",
-          "legendFormat": "{{type}}",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": true
+          "range": true,
+          "legendFormat": "{{type}}"
         }
       ],
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 12,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "id": 9
-    },
-    {
-      "type": "timeseries",
-      "title": "Alert lifecycle (5m rates)",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 12
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"manual\"}[5m]))",
-          "legendFormat": "resolved (manual)",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        },
-        {
-          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"auto\"}[5m]))",
-          "legendFormat": "resolved (auto)",
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        },
-        {
-          "expr": "rate(opsimate_alerts_silenced_total[5m])",
-          "legendFormat": "silenced",
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        },
-        {
-          "expr": "rate(opsimate_alerts_unsilenced_total[5m])",
-          "legendFormat": "unsilenced",
-          "refId": "D",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 12,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "id": 10
-    },
-    {
-      "type": "timeseries",
-      "title": "Bulk operations & actions",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 12
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(opsimate_bulk_alerts_affected_total[5m])) by (action)",
-          "legendFormat": "bulk {{action}} (alerts/s)",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        },
-        {
-          "expr": "sum(rate(opsimate_actions_run_total[5m])) by (type, outcome)",
-          "legendFormat": "action {{type}} {{outcome}}",
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
+          "calcs": ["lastNotNull"]
         }
       },
       "fieldConfig": {
@@ -617,6 +562,136 @@
     },
     {
       "type": "timeseries",
+      "title": "Alert lifecycle (5m rates)",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"manual\"}[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "resolved (manual)"
+        },
+        {
+          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"auto\"}[5m]))",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "resolved (auto)"
+        },
+        {
+          "expr": "rate(opsimate_alerts_silenced_total[5m])",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "silenced"
+        },
+        {
+          "expr": "rate(opsimate_alerts_unsilenced_total[5m])",
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "unsilenced"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "id": 12
+    },
+    {
+      "type": "timeseries",
+      "title": "Bulk operations & actions",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_bulk_alerts_affected_total[5m])) by (action)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "bulk {{action}} (alerts/s)"
+        },
+        {
+          "expr": "sum(rate(opsimate_actions_run_total[5m])) by (type, outcome)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "action {{type}} {{outcome}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "id": 13
+    },
+    {
+      "type": "timeseries",
       "title": "API p95 latency by route",
       "gridPos": {
         "h": 8,
@@ -631,130 +706,20 @@
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le, route)) > 0",
-          "legendFormat": "{{route}}",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": true
+          "range": true,
+          "legendFormat": "{{route}}"
         }
       ],
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 12,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "id": 12
-    },
-    {
-      "type": "timeseries",
-      "title": "HTTP requests by status (5m rate)",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 20
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(opsimate_http_request_duration_seconds_count[5m])) by (status_code)",
-          "legendFormat": "{{status_code}}",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 35,
-            "lineWidth": 2,
-            "showPoints": "never",
-            "stacking": {
-              "mode": "normal",
-              "group": "A"
-            }
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "id": 13
-    },
-    {
-      "type": "timeseries",
-      "title": "Alert snapshot recomputes",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 28
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(opsimate_snapshot_compute_duration_seconds_bucket[5m])) by (le, list))",
-          "legendFormat": "p95 {{list}}",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        },
-        {
-          "expr": "sum(rate(opsimate_snapshot_compute_duration_seconds_count[5m])) by (list)",
-          "legendFormat": "recomputes/s {{list}}",
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
+          "calcs": ["lastNotNull"]
         }
       },
       "fieldConfig": {
@@ -772,7 +737,111 @@
     },
     {
       "type": "timeseries",
-      "title": "Process",
+      "title": "HTTP requests by status (5m rate)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_http_request_duration_seconds_count[5m])) by (status_code)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "{{status_code}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 35,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "id": 15
+    },
+    {
+      "type": "timeseries",
+      "title": "Alert snapshot recomputes",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_snapshot_compute_duration_seconds_bucket[5m])) by (le, list))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "p95 {{list}}"
+        },
+        {
+          "expr": "sum(rate(opsimate_snapshot_compute_duration_seconds_count[5m])) by (list)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "recomputes/s {{list}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "id": 16
+    },
+    {
+      "type": "bargauge",
+      "title": "Configured resources",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -785,33 +854,74 @@
       },
       "targets": [
         {
-          "expr": "process_resident_memory_bytes",
-          "legendFormat": "RSS",
+          "expr": "opsimate_resources",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": true
+          "range": false,
+          "instant": true,
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          }
+        },
+        "overrides": []
+      },
+      "id": 17
+    },
+    {
+      "type": "timeseries",
+      "title": "Process memory",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "RSS"
         },
         {
           "expr": "nodejs_heap_size_used_bytes",
-          "legendFormat": "heap used",
           "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "range": true
+          "range": true,
+          "legendFormat": "heap used"
         }
       ],
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull"
-          ]
+          "calcs": ["lastNotNull"]
         }
       },
       "fieldConfig": {
@@ -825,15 +935,62 @@
         },
         "overrides": []
       },
-      "id": 15
+      "id": 18
+    },
+    {
+      "type": "timeseries",
+      "title": "Event loop lag",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "nodejs_eventloop_lag_p50_seconds",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "nodejs_eventloop_lag_p99_seconds",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true,
+          "legendFormat": "p99"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "id": 19
     }
-  ],
-  "templating": {
-    "list": []
-  },
-  "annotations": {
-    "list": []
-  },
-  "editable": true,
-  "graphTooltip": 1
+  ]
 }

--- a/infrastructure/grafana/opsimate-dashboard.json
+++ b/infrastructure/grafana/opsimate-dashboard.json
@@ -1,0 +1,164 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "title": "OpsiMate",
+  "uid": "opsimate-self",
+  "tags": ["opsimate"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Firing alerts",
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "opsimate_alerts{state=\"firing\"}", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }, { "color": "red", "value": 1 }]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Silenced alerts",
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "opsimate_alerts{state=\"silenced\"}", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "yellow" } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Resolved alerts",
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "opsimate_alerts{state=\"resolved\"}", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "green" } },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Ingestion rate (5m)",
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "sum(rate(opsimate_alerts_ingested_total[5m]))" }],
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "type": "stat",
+      "title": "API p95 latency (5m)",
+      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le))"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "type": "stat",
+      "title": "Event loop lag (p99)",
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "nodejs_eventloop_lag_p99_seconds", "instant": true }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Alerts by state",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "opsimate_alerts", "legendFormat": "{{state}}" }]
+    },
+    {
+      "type": "timeseries",
+      "title": "Firing alerts by severity",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "opsimate_alerts_by_severity{state=\"firing\"}",
+          "legendFormat": "{{severity}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingestion by integration type",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_alerts_ingested_total[5m])) by (type)",
+          "legendFormat": "{{type}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "API p95 latency by route",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "{{route}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Process memory",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "process_resident_memory_bytes", "legendFormat": "RSS" },
+        { "expr": "nodejs_heap_size_used_bytes", "legendFormat": "heap used" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP requests by status (5m rate)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_http_request_duration_seconds_count[5m])) by (status_code)",
+          "legendFormat": "{{status_code}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] }
+    }
+  ]
+}

--- a/infrastructure/grafana/opsimate-dashboard.json
+++ b/infrastructure/grafana/opsimate-dashboard.json
@@ -10,155 +10,830 @@
   ],
   "title": "OpsiMate",
   "uid": "opsimate-self",
-  "tags": ["opsimate"],
+  "tags": [
+    "opsimate"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "refresh": "30s",
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
   "panels": [
     {
       "type": "stat",
-      "title": "Firing alerts",
-      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Firing",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
-        { "expr": "opsimate_alerts{state=\"firing\"}", "instant": true }
+        {
+          "expr": "opsimate_alerts{state=\"firing\"}",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": false
+        }
       ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green" }, { "color": "red", "value": 1 }]
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
           }
         },
         "overrides": []
-      }
+      },
+      "id": 1
     },
     {
       "type": "stat",
-      "title": "Silenced alerts",
-      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "targets": [
-        { "expr": "opsimate_alerts{state=\"silenced\"}", "instant": true }
-      ],
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "fixed", "fixedColor": "yellow" } },
-        "overrides": []
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Resolved alerts",
-      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "targets": [
-        { "expr": "opsimate_alerts{state=\"resolved\"}", "instant": true }
-      ],
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "fixed", "fixedColor": "green" } },
-        "overrides": []
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Ingestion rate (5m)",
-      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "targets": [{ "expr": "sum(rate(opsimate_alerts_ingested_total[5m]))" }],
-      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
-    },
-    {
-      "type": "stat",
-      "title": "API p95 latency (5m)",
-      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Unassigned firing",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le))"
+          "expr": "opsimate_firing_alerts_unassigned",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": false
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 2
     },
     {
       "type": "stat",
-      "title": "Event loop lag (p99)",
-      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Oldest firing",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
-        { "expr": "nodejs_eventloop_lag_p99_seconds", "instant": true }
+        {
+          "expr": "opsimate_oldest_firing_alert_age_seconds",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": false
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 3600
+              },
+              {
+                "color": "red",
+                "value": 86400
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 3
+    },
+    {
+      "type": "stat",
+      "title": "Ingestion (5m)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_alerts_ingested_total[5m]))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        },
+        "overrides": []
+      },
+      "id": 4
+    },
+    {
+      "type": "stat",
+      "title": "API p95 (5m)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 5
+    },
+    {
+      "type": "stat",
+      "title": "Event loop p99",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "nodejs_eventloop_lag_p99_seconds",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": false
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 6
     },
     {
       "type": "timeseries",
       "title": "Alerts by state",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "targets": [{ "expr": "opsimate_alerts", "legendFormat": "{{state}}" }]
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "opsimate_alerts",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "id": 7
     },
     {
       "type": "timeseries",
       "title": "Firing alerts by severity",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "opsimate_alerts_by_severity{state=\"firing\"}",
-          "legendFormat": "{{severity}}"
+          "legendFormat": "{{severity}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
         }
-      ]
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 35,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "id": 8
     },
     {
       "type": "timeseries",
       "title": "Ingestion by integration type",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(rate(opsimate_alerts_ingested_total[5m])) by (type)",
-          "legendFormat": "{{type}}"
+          "legendFormat": "{{type}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] }
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "id": 9
+    },
+    {
+      "type": "timeseries",
+      "title": "Alert lifecycle (5m rates)",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"manual\"}[5m]))",
+          "legendFormat": "resolved (manual)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        },
+        {
+          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"auto\"}[5m]))",
+          "legendFormat": "resolved (auto)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        },
+        {
+          "expr": "rate(opsimate_alerts_silenced_total[5m])",
+          "legendFormat": "silenced",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        },
+        {
+          "expr": "rate(opsimate_alerts_unsilenced_total[5m])",
+          "legendFormat": "unsilenced",
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "id": 10
+    },
+    {
+      "type": "timeseries",
+      "title": "Bulk operations & actions",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_bulk_alerts_affected_total[5m])) by (action)",
+          "legendFormat": "bulk {{action}} (alerts/s)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        },
+        {
+          "expr": "sum(rate(opsimate_actions_run_total[5m])) by (type, outcome)",
+          "legendFormat": "action {{type}} {{outcome}}",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "id": 11
     },
     {
       "type": "timeseries",
       "title": "API p95 latency by route",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le, route))",
-          "legendFormat": "{{route}}"
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le, route)) > 0",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
-    },
-    {
-      "type": "timeseries",
-      "title": "Process memory",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "targets": [
-        { "expr": "process_resident_memory_bytes", "legendFormat": "RSS" },
-        { "expr": "nodejs_heap_size_used_bytes", "legendFormat": "heap used" }
-      ],
-      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] }
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "id": 12
     },
     {
       "type": "timeseries",
       "title": "HTTP requests by status (5m rate)",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(rate(opsimate_http_request_duration_seconds_count[5m])) by (status_code)",
-          "legendFormat": "{{status_code}}"
+          "legendFormat": "{{status_code}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] }
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 35,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "id": 13
+    },
+    {
+      "type": "timeseries",
+      "title": "Alert snapshot recomputes",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_snapshot_compute_duration_seconds_bucket[5m])) by (le, list))",
+          "legendFormat": "p95 {{list}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        },
+        {
+          "expr": "sum(rate(opsimate_snapshot_compute_duration_seconds_count[5m])) by (list)",
+          "legendFormat": "recomputes/s {{list}}",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "id": 14
+    },
+    {
+      "type": "timeseries",
+      "title": "Process",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        },
+        {
+          "expr": "nodejs_heap_size_used_bytes",
+          "legendFormat": "heap used",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "range": true
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "id": 15
     }
-  ]
+  ],
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,7 +296,7 @@ importers:
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
 
   apps/server:
     dependencies:
@@ -345,6 +345,9 @@ importers:
       nodemailer:
         specifier: ^7.0.13
         version: 7.0.13
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       sshpk:
         specifier: ^1.18.0
         version: 1.18.0
@@ -405,7 +408,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
 
   packages/custom-actions:
     devDependencies:
@@ -1154,6 +1157,10 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
@@ -2836,6 +2843,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -4443,6 +4453,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -4913,6 +4927,9 @@ packages:
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -5896,6 +5913,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/types@0.143.0': {}
 
@@ -7257,7 +7276,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -7313,7 +7332,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -7563,6 +7582,8 @@ snapshots:
       require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
+
+  bintrees@1.0.2: {}
 
   body-parser@2.3.0:
     dependencies:
@@ -9336,6 +9357,11 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -9977,6 +10003,10 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
   teex@1.0.1:
     dependencies:
       streamx: 2.28.0
@@ -10295,7 +10325,7 @@ snapshots:
       tsx: 4.23.8
       yaml: 2.8.1
 
-  vitest@4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
@@ -10318,6 +10348,7 @@ snapshots:
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)
@@ -10325,7 +10356,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1))
@@ -10348,6 +10379,7 @@ snapshots:
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.8)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)


### PR DESCRIPTION
## What

Implements #658 — OpsiMate finally exposes metrics about itself.

`GET /metrics` (Prometheus text format, `prom-client`), mounted before auth:

| Metric | Type | Labels |
|---|---|---|
| `opsimate_alerts` | gauge | `state` = **firing / silenced / resolved** (per maintainer: not active/archived) |
| `opsimate_alerts_by_severity` | gauge | `state`, `severity` |
| `opsimate_alerts_ingested_total` | counter | `type`, `severity` — incremented in the single ingestion funnel every webhook flows through |
| `opsimate_http_request_duration_seconds` | histogram | `method`, `route`, `status_code` |
| `process_*`, `nodejs_*` | prom-client defaults | memory, event loop lag, GC, CPU |

## Performance — designed to cost nothing

- The gauges are computed **at scrape time** from plain `COUNT`/`GROUP BY` prepared statements — deliberately **not** through the alerts snapshot, so a scrape can never trigger the enrichment/mute-policy compute. Measured on a 10K-alert instance: **~9ms per scrape** end to end.
- The ingestion counter and request histogram are in-memory increments (nanoseconds). Nothing touches the ingestion hot path or the client's 5s poll.
- Histogram routes are labeled by the **matched route pattern** (`/api/v1/alerts/:id/silence`), never raw URLs — per-alert-id paths or scanner probes would explode label cardinality; all unmatched requests share one `unmatched` series.

## Auth

Open by default (Prometheus-friendly; it exposes only counts and timings). Setting the `METRICS_TOKEN` env var gates it behind `Authorization: Bearer <token>` — read per request, no rebuild needed.

## Bonus

Ready-made Grafana dashboard at `infrastructure/grafana/opsimate-dashboard.json`: state/severity stats and trends, ingestion rate by integration, p95 latency by route, memory, event loop lag.

## Verified

- 6 new tests: gauge naming and values, gauges tracking DB changes, counter incrementing through the real custom-alert endpoint, route-pattern (not raw-URL) labels, default metrics, token gating.
- 214 server tests green, lint clean.
- Live at 10K alerts: `opsimate_alerts{state="firing"} 9999`, severity split 3332/3333/3334, three scrapes timed 9–24ms.

Note: "muted" is intentionally absent from the gauges — it's a read-time mute-policy computation over the snapshot, not a stored state, and surfacing it would drag rule evaluation into every scrape.

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics covering server health, request latency, alert activity, triage backlog, resource usage, and configured resources.
  * Added a protected `/metrics` endpoint for monitoring integrations.
  * Added a Grafana dashboard with alert, API performance, lifecycle, and runtime panels.
  * Added tracking for alert actions, bulk operations, resolutions, silencing, ingestion, and snapshot computation.
  * Added optional bearer-token protection for metrics access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->