### PR TITLE
feat(grafana): professional example dashboard — rows, variables and links

### DIFF
--- a/infrastructure/grafana/opsimate-dashboard.json
+++ b/infrastructure/grafana/opsimate-dashboard.json
@@ -1,63 +1,209 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "title": "OpsiMate",
   "uid": "opsimate-self",
-  "tags": ["opsimate"],
+  "description": "Self-monitoring for OpsiMate: alert inventory and triage backlog, ingestion and lifecycle throughput, API latency, and server runtime health.",
+  "tags": ["opsimate", "alerting", "self-monitoring"],
   "timezone": "browser",
   "schemaVersion": 39,
-  "refresh": "30s",
-  "time": {
-    "from": "now-3h",
-    "to": "now"
-  },
-  "templating": {
-    "list": []
-  },
-  "annotations": {
-    "list": []
-  },
+  "version": 1,
   "editable": true,
   "graphTooltip": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "1h"]
+  },
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "opsimate.dev",
+      "tooltip": "OpsiMate website",
+      "type": "link",
+      "url": "https://opsimate.dev"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "GitHub",
+      "tooltip": "Source, issues and docs",
+      "type": "link",
+      "url": "https://github.com/OpsiMate/OpsiMate"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Open OpsiMate",
+      "tooltip": "This OpsiMate instance",
+      "type": "link",
+      "url": "${opsimate_url}/alerts"
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "type": "datasource",
+        "name": "datasource",
+        "label": "Data source",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
+        "type": "query",
+        "name": "instance",
+        "label": "Instance",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(opsimate_alerts, instance)",
+        "query": {
+          "query": "label_values(opsimate_alerts, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "current": {},
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1
+      },
+      {
+        "type": "query",
+        "name": "severity",
+        "label": "Severity",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(opsimate_alerts_by_severity, severity)",
+        "query": {
+          "query": "label_values(opsimate_alerts_by_severity, severity)",
+          "refId": "StandardVariableQuery"
+        },
+        "current": {},
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1
+      },
+      {
+        "type": "textbox",
+        "name": "opsimate_url",
+        "label": "OpsiMate URL",
+        "query": "http://localhost:8080",
+        "current": {
+          "text": "http://localhost:8080",
+          "value": "http://localhost:8080"
+        },
+        "hide": 0,
+        "options": [],
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "panels": [
     {
-      "type": "stat",
-      "title": "Firing",
+      "type": "row",
+      "title": "Overview",
+      "collapsed": false,
       "gridPos": {
-        "h": 4,
-        "w": 3,
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 0
       },
+      "panels": [],
+      "id": 1
+    },
+    {
+      "type": "stat",
+      "title": "Firing",
+      "description": "Alerts currently firing (not silenced). The headline number the on-call sees.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "opsimate_alerts{state=\"firing\"}",
+          "expr": "sum(opsimate_alerts{state=\"firing\", instance=~\"$instance\"})",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": false,
+          "editorMode": "code",
           "instant": true
         }
       ],
       "options": {
         "graphMode": "area",
-        "colorMode": "value"
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
       },
       "fieldConfig": {
         "defaults": {
+          "mappings": [],
           "color": {
             "mode": "thresholds"
           },
@@ -65,10 +211,11 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
-                "color": "yellow",
+                "color": "#EAB839",
                 "value": 1
               },
               {
@@ -76,47 +223,14 @@
                 "value": 100
               }
             ]
-          }
-        },
-        "overrides": []
-      },
-      "id": 1
-    },
-    {
-      "type": "stat",
-      "title": "Silenced",
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 3,
-        "y": 0
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "opsimate_alerts{state=\"silenced\"}",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
           },
-          "range": false,
-          "instant": true
-        }
-      ],
-      "options": {
-        "graphMode": "area",
-        "colorMode": "value"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "yellow"
-          }
+          "links": [
+            {
+              "title": "Open OpsiMate alerts",
+              "url": "${opsimate_url}/alerts",
+              "targetBlank": true
+            }
+          ]
         },
         "overrides": []
       },
@@ -124,39 +238,65 @@
     },
     {
       "type": "stat",
-      "title": "Resolved",
+      "title": "Silenced",
+      "description": "Alerts still active but suppressed from notifying. A number that only grows is a smell.",
       "gridPos": {
         "h": 4,
-        "w": 3,
+        "w": 6,
         "x": 6,
-        "y": 0
+        "y": 1
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "opsimate_alerts{state=\"resolved\"}",
+          "expr": "sum(opsimate_alerts{state=\"silenced\", instance=~\"$instance\"})",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": false,
+          "editorMode": "code",
           "instant": true
         }
       ],
       "options": {
         "graphMode": "area",
-        "colorMode": "value"
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
       },
       "fieldConfig": {
         "defaults": {
+          "mappings": [],
           "color": {
             "mode": "fixed",
-            "fixedColor": "green"
-          }
+            "fixedColor": "#EAB839"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#EAB839",
+                "value": null
+              }
+            ]
+          },
+          "links": [
+            {
+              "title": "Open OpsiMate alerts",
+              "url": "${opsimate_url}/alerts",
+              "targetBlank": true
+            }
+          ]
         },
         "overrides": []
       },
@@ -164,54 +304,65 @@
     },
     {
       "type": "stat",
-      "title": "Unassigned firing",
+      "title": "Resolved",
+      "description": "Alerts in the resolved archive. Grows over time and is trimmed by the retention job.",
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 9,
-        "y": 0
+        "w": 6,
+        "x": 12,
+        "y": 1
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "opsimate_firing_alerts_unassigned",
+          "expr": "sum(opsimate_alerts{state=\"resolved\", instance=~\"$instance\"})",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": false,
+          "editorMode": "code",
           "instant": true
         }
       ],
       "options": {
         "graphMode": "area",
-        "colorMode": "value"
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
       },
       "fieldConfig": {
         "defaults": {
+          "mappings": [],
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed",
+            "fixedColor": "green"
           },
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 50
+                "color": "green",
+                "value": null
               }
             ]
-          }
+          },
+          "links": [
+            {
+              "title": "Open OpsiMate alerts",
+              "url": "${opsimate_url}/alerts",
+              "targetBlank": true
+            }
+          ]
         },
         "overrides": []
       },
@@ -219,35 +370,45 @@
     },
     {
       "type": "stat",
-      "title": "Unread firing",
+      "title": "Unassigned",
+      "description": "Firing alerts with no owner \u2014 the untriaged backlog.",
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 12,
-        "y": 0
+        "w": 6,
+        "x": 0,
+        "y": 5
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "opsimate_firing_alerts_unread",
+          "expr": "sum(opsimate_firing_alerts_unassigned{instance=~\"$instance\"})",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": false,
+          "editorMode": "code",
           "instant": true
         }
       ],
       "options": {
         "graphMode": "area",
-        "colorMode": "value"
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
       },
       "fieldConfig": {
         "defaults": {
+          "mappings": [],
           "color": {
             "mode": "thresholds"
           },
@@ -255,10 +416,11 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
-                "color": "yellow",
+                "color": "#EAB839",
                 "value": 1
               },
               {
@@ -266,7 +428,14 @@
                 "value": 50
               }
             ]
-          }
+          },
+          "links": [
+            {
+              "title": "Open OpsiMate alerts",
+              "url": "${opsimate_url}/alerts",
+              "targetBlank": true
+            }
+          ]
         },
         "overrides": []
       },
@@ -274,35 +443,118 @@
     },
     {
       "type": "stat",
-      "title": "Oldest firing",
+      "title": "Unread",
+      "description": "Firing alerts nobody has opened yet.",
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 15,
-        "y": 0
+        "w": 6,
+        "x": 6,
+        "y": 5
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "opsimate_oldest_firing_alert_age_seconds",
+          "expr": "sum(opsimate_firing_alerts_unread{instance=~\"$instance\"})",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": false,
+          "editorMode": "code",
           "instant": true
         }
       ],
       "options": {
         "graphMode": "area",
-        "colorMode": "value"
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
       },
       "fieldConfig": {
         "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "links": [
+            {
+              "title": "Open OpsiMate alerts",
+              "url": "${opsimate_url}/alerts",
+              "targetBlank": true
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "id": 6
+    },
+    {
+      "type": "stat",
+      "title": "Oldest firing",
+      "description": "Age of the longest-firing alert. A steadily climbing value means something is rotting unhandled.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "expr": "max(opsimate_oldest_firing_alert_age_seconds{instance=~\"$instance\"})",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": false,
+          "editorMode": "code",
+          "instant": true
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
           "unit": "s",
           "color": {
             "mode": "thresholds"
@@ -311,10 +563,11 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
-                "color": "yellow",
+                "color": "#EAB839",
                 "value": 3600
               },
               {
@@ -326,78 +579,107 @@
         },
         "overrides": []
       },
-      "id": 6
-    },
-    {
-      "type": "stat",
-      "title": "Ingestion (5m)",
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 18,
-        "y": 0
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(opsimate_alerts_ingested_total[5m]))",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true
-        }
-      ],
-      "options": {
-        "graphMode": "area",
-        "colorMode": "value"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "ops",
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "blue"
-          }
-        },
-        "overrides": []
-      },
       "id": 7
     },
     {
       "type": "stat",
-      "title": "API p95 (5m)",
+      "title": "Ingestion rate",
+      "description": "Alerts per second arriving through the ingestion funnel, across every integration.",
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 21,
-        "y": 0
+        "w": 6,
+        "x": 12,
+        "y": 5
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le))",
+          "expr": "sum(rate(opsimate_alerts_ingested_total{instance=~\"$instance\"}[$__rate_interval]))",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
-          "range": true
+          "range": true,
+          "editorMode": "code"
         }
       ],
       "options": {
         "graphMode": "area",
-        "colorMode": "value"
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
       },
       "fieldConfig": {
         "defaults": {
+          "mappings": [],
+          "unit": "ops",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3274D9"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3274D9",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 8
+    },
+    {
+      "type": "stat",
+      "title": "API p95",
+      "description": "95th-percentile API latency across all routes.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket{instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
           "unit": "s",
           "color": {
             "mode": "thresholds"
@@ -406,10 +688,11 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
-                "color": "yellow",
+                "color": "#EAB839",
                 "value": 0.5
               },
               {
@@ -421,30 +704,32 @@
         },
         "overrides": []
       },
-      "id": 8
+      "id": 9
     },
     {
       "type": "timeseries",
       "title": "Alerts by state",
+      "description": "Inventory over time. Firing and silenced are live alerts; resolved is the archive.",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 4
+        "y": 9
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "opsimate_alerts",
+          "expr": "sum(opsimate_alerts{instance=~\"$instance\"}) by (state)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": true,
+          "editorMode": "code",
           "legendFormat": "{{state}}"
         }
       ],
@@ -452,7 +737,12 @@
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["lastNotNull"]
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "fieldConfig": {
@@ -460,56 +750,22 @@
           "custom": {
             "fillOpacity": 12,
             "lineWidth": 2,
-            "showPoints": "never"
-          }
-        },
-        "overrides": []
-      },
-      "id": 9
-    },
-    {
-      "type": "timeseries",
-      "title": "Firing alerts by severity",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 4
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "opsimate_alerts_by_severity{state=\"firing\"}",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "{{severity}}"
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": ["lastNotNull"]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 35,
-            "lineWidth": 2,
             "showPoints": "never",
-            "stacking": {
-              "mode": "normal",
-              "group": "A"
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
             }
-          }
+          },
+          "mappings": [],
+          "min": 0,
+          "links": [
+            {
+              "title": "Open OpsiMate alerts",
+              "url": "${opsimate_url}/alerts",
+              "targetBlank": true
+            }
+          ]
         },
         "overrides": []
       },
@@ -517,254 +773,41 @@
     },
     {
       "type": "timeseries",
-      "title": "Ingestion by integration type",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 12
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(opsimate_alerts_ingested_total[5m])) by (type)",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "{{type}}"
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": ["lastNotNull"]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 12,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "id": 11
-    },
-    {
-      "type": "timeseries",
-      "title": "Alert lifecycle (5m rates)",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 12
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"manual\"}[5m]))",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "resolved (manual)"
-        },
-        {
-          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"auto\"}[5m]))",
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "resolved (auto)"
-        },
-        {
-          "expr": "rate(opsimate_alerts_silenced_total[5m])",
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "silenced"
-        },
-        {
-          "expr": "rate(opsimate_alerts_unsilenced_total[5m])",
-          "refId": "D",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "unsilenced"
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": ["lastNotNull"]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 12,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "id": 12
-    },
-    {
-      "type": "timeseries",
-      "title": "Bulk operations & actions",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 12
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(opsimate_bulk_alerts_affected_total[5m])) by (action)",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "bulk {{action}} (alerts/s)"
-        },
-        {
-          "expr": "sum(rate(opsimate_actions_run_total[5m])) by (type, outcome)",
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "action {{type}} {{outcome}}"
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": ["lastNotNull"]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 12,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "id": 13
-    },
-    {
-      "type": "timeseries",
-      "title": "API p95 latency by route",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 20
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket[5m])) by (le, route)) > 0",
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "{{route}}"
-        }
-      ],
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": ["lastNotNull"]
-        }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 12,
-            "lineWidth": 2,
-            "showPoints": "never"
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "id": 14
-    },
-    {
-      "type": "timeseries",
-      "title": "HTTP requests by status (5m rate)",
+      "title": "Firing alerts by severity",
+      "description": "Firing alerts split by severity \u2014 filterable with the Severity variable above.",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 9
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "sum(rate(opsimate_http_request_duration_seconds_count[5m])) by (status_code)",
+          "expr": "sum(opsimate_alerts_by_severity{state=\"firing\", severity=~\"$severity\", instance=~\"$instance\"}) by (severity)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": true,
-          "legendFormat": "{{status_code}}"
+          "editorMode": "code",
+          "legendFormat": "{{severity}}"
         }
       ],
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["lastNotNull"]
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "fieldConfig": {
@@ -773,57 +816,80 @@
             "fillOpacity": 35,
             "lineWidth": 2,
             "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "stacking": {
               "mode": "normal",
               "group": "A"
             }
           },
-          "unit": "reqps"
+          "mappings": [],
+          "min": 0,
+          "links": [
+            {
+              "title": "Open OpsiMate alerts",
+              "url": "${opsimate_url}/alerts",
+              "targetBlank": true
+            }
+          ]
         },
         "overrides": []
       },
-      "id": 15
+      "id": 11
+    },
+    {
+      "type": "row",
+      "title": "Alert activity",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": [],
+      "id": 12
     },
     {
       "type": "timeseries",
-      "title": "Alert snapshot recomputes",
+      "title": "Ingestion by integration",
+      "description": "Which sources are sending alerts, and how fast. A source dropping to zero usually means a broken webhook.",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 28
+        "y": 18
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(opsimate_snapshot_compute_duration_seconds_bucket[5m])) by (le, list))",
+          "expr": "sum(rate(opsimate_alerts_ingested_total{instance=~\"$instance\"}[$__rate_interval])) by (type)",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": true,
-          "legendFormat": "p95 {{list}}"
-        },
-        {
-          "expr": "sum(rate(opsimate_snapshot_compute_duration_seconds_count[5m])) by (list)",
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "range": true,
-          "legendFormat": "recomputes/s {{list}}"
+          "editorMode": "code",
+          "legendFormat": "{{type}}"
         }
       ],
       "options": {
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["lastNotNull"]
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "fieldConfig": {
@@ -831,52 +897,250 @@
           "custom": {
             "fillOpacity": 12,
             "lineWidth": 2,
-            "showPoints": "never"
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            }
           },
-          "unit": "s"
+          "mappings": [],
+          "unit": "ops",
+          "min": 0
         },
         "overrides": []
       },
-      "id": 16
+      "id": 13
     },
     {
-      "type": "bargauge",
-      "title": "Configured resources",
+      "type": "timeseries",
+      "title": "Alert lifecycle",
+      "description": "How alerts leave the firing state: manual resolves are people, auto resolves are sources reporting recovery. Silence/unsilence includes timer expiry and the daily reset.",
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 28
+        "w": 8,
+        "x": 8,
+        "y": 18
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "opsimate_resources",
+          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"manual\", instance=~\"$instance\"}[$__rate_interval]))",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
-          "range": false,
-          "instant": true,
-          "legendFormat": "{{kind}}"
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "resolved (manual)"
+        },
+        {
+          "expr": "sum(rate(opsimate_alerts_resolved_total{mode=\"auto\", instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "resolved (auto)"
+        },
+        {
+          "expr": "sum(rate(opsimate_alerts_silenced_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "silenced"
+        },
+        {
+          "expr": "sum(rate(opsimate_alerts_unsilenced_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "unsilenced"
         }
       ],
       "options": {
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"]
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          }
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 14
+    },
+    {
+      "type": "timeseries",
+      "title": "Bulk operations & actions",
+      "description": "Alerts mutated per second by bulk operations, plus action executions (Slack/Teams/Jira/HTTP) with their outcome. A rising error series means an integration is failing.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_bulk_alerts_affected_total{instance=~\"$instance\"}[$__rate_interval])) by (action)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "bulk {{action}}"
+        },
+        {
+          "expr": "sum(rate(opsimate_actions_run_total{instance=~\"$instance\"}[$__rate_interval])) by (type, outcome)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "action {{type}} \u00b7 {{outcome}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 15
+    },
+    {
+      "type": "row",
+      "title": "API & performance",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [],
+      "id": 16
+    },
+    {
+      "type": "timeseries",
+      "title": "API p95 latency by route",
+      "description": "Per-route 95th percentile. Routes are matched patterns, never raw URLs, so alert ids can't fragment the series.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_http_request_duration_seconds_bucket{instance=~\"$instance\"}[$__rate_interval])) by (le, route)) > 0",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "{{route}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "unit": "s",
+          "min": 0
         },
         "overrides": []
       },
@@ -884,36 +1148,185 @@
     },
     {
       "type": "timeseries",
-      "title": "Process memory",
+      "title": "Requests by status",
+      "description": "Request rate by HTTP status. 304s are the client's efficient revalidation path; a rise in 4xx/5xx is the thing to watch.",
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(opsimate_http_request_duration_seconds_count{instance=~\"$instance\"}[$__rate_interval])) by (status_code)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "{{status_code}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 35,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 18
+    },
+    {
+      "type": "row",
+      "title": "Runtime & internals",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 19,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Alert snapshot recomputes",
+      "description": "The snapshot cache the whole read path sits on: how long a full recompute takes (enrichments, mute policies, comments, firing times) and how often it happens. Rising p95 is the earliest warning that the dataset is outgrowing the cache.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
         "x": 0,
         "y": 36
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "process_resident_memory_bytes",
+          "expr": "histogram_quantile(0.95, sum(rate(opsimate_snapshot_compute_duration_seconds_bucket{instance=~\"$instance\"}[$__rate_interval])) by (le, list))",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": true,
-          "legendFormat": "RSS"
+          "editorMode": "code",
+          "legendFormat": "p95 {{list}}"
         },
         {
-          "expr": "nodejs_heap_size_used_bytes",
+          "expr": "sum(rate(opsimate_snapshot_compute_duration_seconds_count{instance=~\"$instance\"}[$__rate_interval])) by (list)",
           "refId": "B",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": true,
+          "editorMode": "code",
+          "legendFormat": "recomputes/s {{list}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 1901
+    },
+    {
+      "type": "timeseries",
+      "title": "Process memory",
+      "description": "Resident set size and V8 heap usage of the OpsiMate server process.",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
+          "legendFormat": "RSS"
+        },
+        {
+          "expr": "nodejs_heap_size_used_bytes{instance=~\"$instance\"}",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": true,
+          "editorMode": "code",
           "legendFormat": "heap used"
         }
       ],
@@ -921,7 +1334,12 @@
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["lastNotNull"]
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "fieldConfig": {
@@ -929,46 +1347,56 @@
           "custom": {
             "fillOpacity": 12,
             "lineWidth": 2,
-            "showPoints": "never"
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            }
           },
-          "unit": "bytes"
+          "mappings": [],
+          "unit": "bytes",
+          "min": 0
         },
         "overrides": []
       },
-      "id": 18
+      "id": 1902
     },
     {
       "type": "timeseries",
       "title": "Event loop lag",
+      "description": "How long callbacks wait to run. Sustained p99 above ~100ms means the process is CPU-saturated.",
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 36
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "targets": [
         {
-          "expr": "nodejs_eventloop_lag_p50_seconds",
+          "expr": "nodejs_eventloop_lag_p50_seconds{instance=~\"$instance\"}",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": true,
+          "editorMode": "code",
           "legendFormat": "p50"
         },
         {
-          "expr": "nodejs_eventloop_lag_p99_seconds",
+          "expr": "nodejs_eventloop_lag_p99_seconds{instance=~\"$instance\"}",
           "refId": "B",
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "range": true,
+          "editorMode": "code",
           "legendFormat": "p99"
         }
       ],
@@ -976,7 +1404,12 @@
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["lastNotNull"]
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "fieldConfig": {
@@ -984,13 +1417,106 @@
           "custom": {
             "fillOpacity": 12,
             "lineWidth": 2,
-            "showPoints": "never"
+            "showPoints": "never",
+            "lineInterpolation": "smooth",
+            "gradientMode": "opacity",
+            "scaleDistribution": {
+              "type": "linear"
+            }
           },
-          "unit": "s"
+          "mappings": [],
+          "unit": "s",
+          "min": 0
         },
         "overrides": []
       },
-      "id": 19
+      "id": 1903
+    },
+    {
+      "type": "row",
+      "title": "Configuration & help",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "panels": [],
+      "id": 20
+    },
+    {
+      "type": "bargauge",
+      "title": "Configured resources",
+      "description": "What is configured in this OpsiMate instance. Useful for spotting rule sprawl \u2014 40 mute policies usually means somebody is papering over a noisy source.",
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 45
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "expr": "opsimate_resources{instance=~\"$instance\"}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "range": false,
+          "editorMode": "code",
+          "instant": true,
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 21
+    },
+    {
+      "type": "text",
+      "title": "About this dashboard",
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 10,
+        "y": 45
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### OpsiMate self-monitoring\n\nEvery series here comes from the OpsiMate server's own `/metrics` endpoint (Prometheus text format). Gauges are computed from cheap SQL counts at scrape time, so scraping never touches the alert snapshot cache.\n\n**Prometheus scrape config**\n\n```yaml\nscrape_configs:\n  - job_name: opsimate\n    static_configs:\n      - targets: ['opsimate:3001']\n```\n\nIf the server sets `METRICS_TOKEN`, add an `authorization` block with the token as credentials.\n\n**Links** \u2014 [Open this OpsiMate instance](${opsimate_url}/alerts) \u00b7 [opsimate.dev](https://opsimate.dev) \u00b7 [GitHub](https://github.com/OpsiMate/OpsiMate) \u00b7 [Report an issue](https://github.com/OpsiMate/OpsiMate/issues)\n\n*Set the `OpsiMate URL` variable at the top so the panel links point at your own instance.*"
+      },
+      "id": 22
     }
   ]
 }


### PR DESCRIPTION
## What

Turns `infrastructure/grafana/opsimate-dashboard.json` from a flat grid of panels into a dashboard worth shipping as *the* reference example.

### Rows
Five titled sections instead of one long scroll: **Overview**, **Alert activity**, **API & performance**, **Runtime & internals**, **Configuration & help**. Each is collapsible.

### Template variables
| Variable | Purpose |
|---|---|
| **Data source** | A `datasource` picker — importing the dashboard needs no JSON editing |
| **Instance** | Multi-select, for orgs scraping several OpsiMate deployments |
| **Severity** | Multi-select, filters the severity breakdown |
| **OpsiMate URL** | Textbox that drives every deep link, so panels point at *your* instance |

### Links
Dashboard-level links to **[opsimate.dev](https://opsimate.dev)**, the **GitHub repo**, and **Open OpsiMate** (the user's own instance via the URL variable). The alert panels themselves link through to `/alerts`.

### Docs built in
- Every panel has a **description** (the hover ⓘ) saying what the metric means *and what a bad value looks like* — e.g. the snapshot-recompute panel explains that a rising p95 is the earliest warning the dataset is outgrowing the cache.
- An **"About this dashboard"** text panel with the Prometheus scrape config, the `METRICS_TOKEN` note, and the links.

### Polish
`$__rate_interval` instead of hardcoded `[5m]` (rates now adapt to scrape interval and zoom), smooth interpolation with gradient fills, `Last*`/`Max` legend tables, multi-series tooltips, unit-aware axes, threshold colouring on the stat row, and a 4+4 stat layout so no title truncates.

## Verified

Rendered end to end against a live Prometheus + Grafana stack scraping a 10k-alert instance — all five rows with real data: Firing 10,565 / Unassigned 7,342 / oldest firing 5.72 days, ingestion 0.218 ops/s by integration, lifecycle and bulk/action rates, p95 by route, snapshot recomputes (p95 675ms), memory, event loop lag, and the resources bar gauge.

Documentation-only change — no server or client code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)