### PR TITLE
fix(alerts): status sort groups Resolved alerts instead of mixing them into Firing

### DIFF
--- a/apps/server/tests/alertQueryEngine.test.ts
+++ b/apps/server/tests/alertQueryEngine.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'vitest';
-import { Alert, AlertStatus, applyAlertListQuery, computeAlertFacets, getTagKeyColumnId } from '@OpsiMate/shared';
+import {
+	Alert,
+	AlertStatus,
+	applyAlertListQuery,
+	computeAlertFacets,
+	getTagKeyColumnId,
+	sortAlertsBy,
+} from '@OpsiMate/shared';
 
 // The engine's own behaviors: paging, cursors, facet semantics. Filter/sort/search
 // semantics themselves are pinned by the client's test suite over the same functions.
@@ -125,5 +132,26 @@ describe('computeAlertFacets', () => {
 		const result = computeAlertFacets(alerts, {}, ['status'], []);
 		expect(result.total).toBe(5);
 		expect(result.silencedTotal).toBe(1);
+	});
+});
+
+describe('sortAlertsBy status', () => {
+	// Regression: the status sort value used to hardcode 'firing' for anything not
+	// silenced/muted, so Resolved alerts (the All view mixes them in) interleaved
+	// with Firing instead of forming their own group — sort looked broken.
+	test('every status forms its own contiguous group, resolved included', () => {
+		const mixed = [
+			mkAlert('f1'),
+			mkAlert('r1', { status: AlertStatus.RESOLVED }),
+			mkAlert('s1', { isSilenced: true }),
+			mkAlert('f2'),
+			mkAlert('m1', { isMuted: true }),
+			mkAlert('r2', { status: AlertStatus.RESOLVED }),
+		];
+		const asc = sortAlertsBy(mixed, 'status', 'asc').map((a) => a.id);
+		// Canonical values sort alphabetically: firing < muted < resolved < silenced.
+		expect(asc).toEqual(['f1', 'f2', 'm1', 'r1', 'r2', 's1']);
+		const desc = sortAlertsBy(mixed, 'status', 'desc').map((a) => a.id);
+		expect(desc).toEqual(['s1', 'r1', 'r2', 'm1', 'f1', 'f2']);
 	});
 });

--- a/packages/shared/src/alerts/alertQuery.ts
+++ b/packages/shared/src/alerts/alertQuery.ts
@@ -141,7 +141,12 @@ export const getAlertSortValue = (alert: Alert, sortField: string, users: AlertO
 		case 'alertName':
 			return (alert.alertName ?? '').toLowerCase();
 		case 'status':
-			return alert.isSilenced ? 'silenced' : alert.isMuted ? 'muted' : 'firing';
+			// The same canonical value the filter/facet path presents (Silenced/Muted
+			// win over the raw status), lowercased for ordering. The raw status must
+			// flow through: views that mix active and resolved alerts (the All view)
+			// sort Resolved rows as their own group — a hardcoded 'firing' fallback
+			// used to interleave them with live alerts, which read as sort-not-working.
+			return (getAlertFilterFieldValue(alert, 'status', users) ?? '').toLowerCase();
 		case 'severity':
 			// Rank-based so desc = critical first, info last.
 			return SEVERITY_RANK[getAlertSeverity(alert)];


### PR DESCRIPTION
## Problem
Sorting by the status column looked broken: in the **All** view (active + resolved merged), Resolved rows scattered among Firing rows instead of forming their own group.

Root cause in the shared query engine (`getAlertSortValue`): the status case returned `isSilenced ? 'silenced' : isMuted ? 'muted' : 'firing'` — **hardcoding `'firing'` for everything else**, including alerts whose `status` is `resolved`. The display/filter path (`getAlertFilterFieldValue`) already used the real status; the sort path didn't, so what you saw (Resolved) and what it sorted by (firing) disagreed.

## Fix
The sort value now flows through `getAlertFilterFieldValue` — the same canonical status the filters, facets and the column itself present — lowercased for ordering. Silenced/Muted still take precedence over the raw status, exactly as displayed. Result: `firing < muted < resolved < silenced`, contiguous groups in both directions.

One-line semantic change in `packages/shared`, so the server-pushed page order and the client's re-sort of the merged All list stay byte-identical.

## Verification
- Regression test in `alertQueryEngine.test.ts` pins the grouping (fails on the old code: resolved alerts interleave into the firing group by id).
- Live-verified in the UI: All view + status desc now renders Silenced (2) → Resolved (2) → Firing, previously Resolved was scattered mid-list.
- Full suites green: 218 server, 146 client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected alert sorting by status so firing, muted, resolved, and silenced alerts are grouped distinctly.
  * Ensured ascending and descending status sorting use the displayed alert status consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->