### PR TITLE
fix(alerts): Active tab and split-pane counts can no longer disagree

### DIFF
--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useDashboard } from '@/context/DashboardContext';
 import { deserializeTimeRange, readLegacySeverityColors, serializeTimeRange } from '@/context/DashboardContext.utils';
+import { splitOwnerPaneCounts } from './Alerts.utils';
 import {
 	useAlertFacets,
 	useAlertGroupSummaries,
@@ -199,6 +200,20 @@ const Alerts = () => {
 	const lastActiveTotal = useRef(Number.POSITIVE_INFINITY);
 	const lastResolvedTotal = useRef(Number.POSITIVE_INFINITY);
 
+	// The ONE clock for rolling windows. toCoarseWindow rounds to the minute so cache
+	// keys stay stable for a minute at a time — but nothing ever re-ran this memo, so
+	// the resolved window was actually frozen at the last filter/sort interaction and
+	// every server total slowly aged. Ticking once a minute delivers what the rounding
+	// promised. Every count that must agree with the list (split panes, status-aware
+	// tab count) derives its window from THIS query, never resolves its own.
+	const isRollingWindow = dashboardState.timeRange?.preset != null && dashboardState.timeRange.preset !== 'custom';
+	const [windowTick, setWindowTick] = useState(0);
+	useEffect(() => {
+		if (!isRollingWindow) return;
+		const timer = setInterval(() => setWindowTick((t) => t + 1), 60 * 1000);
+		return () => clearInterval(timer);
+	}, [isRollingWindow]);
+
 	const baseQuery = useMemo(() => {
 		const window = toCoarseWindow(dashboardState.timeRange);
 		return {
@@ -209,7 +224,9 @@ const Alerts = () => {
 			sort: alertSort.field,
 			dir: alertSort.dir,
 		};
-	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort]);
+		// windowTick re-anchors rolling presets to the current minute.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [statusSuspendedFilters, dashboardState.timeRange, dashboardState.query, alertSort, windowTick]);
 
 	// Load-all is gated on the last-known total staying under GROUP_LOAD_ALL_MAX: page
 	// one's response carries the total (regardless of limit), and when it's small enough
@@ -499,16 +516,18 @@ const Alerts = () => {
 	};
 	// The count query needs a STABLE object for its key, so it memoizes — with a slow
 	// tick re-resolving the rolling window, keeping the displayed N within a minute of
-	// what the action would do. The tick only runs while something consumes a count:
-	// an open selection, or the split-by-owner panes.
+	// what the action would do. The tick only runs while an open selection consumes the
+	// count. (The split-by-owner panes no longer ride this clock — they derive their
+	// window from baseQuery, so they can never disagree with the list total about
+	// which "now" they describe.)
 	const bulkCountEnabled = activeTab === AlertTab.Active && selectedAlerts.length > 0;
 	const splitCountsEnabled = splitByAssignment === true && activeTab === AlertTab.Active;
 	const [bulkWindowTick, setBulkWindowTick] = useState(0);
 	useEffect(() => {
-		if (!bulkCountEnabled && !splitCountsEnabled) return;
+		if (!bulkCountEnabled) return;
 		const timer = setInterval(() => setBulkWindowTick((t) => t + 1), 30 * 1000);
 		return () => clearInterval(timer);
-	}, [bulkCountEnabled, splitCountsEnabled]);
+	}, [bulkCountEnabled]);
 	const bulkCountQuery = useMemo(
 		() => buildBulkScopeQuery(),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -528,20 +547,32 @@ const Alerts = () => {
 	const hasExplicitOwnerFilter =
 		(dashboardState.filters.owner?.length ?? 0) > 0 || (dashboardState.filters['!owner']?.length ?? 0) > 0;
 	const paneCountsEnabled = splitCountsEnabled && !hasExplicitOwnerFilter;
-	const unassignedCountQuery = useMemo(
-		() => ({ ...bulkCountQuery, filters: { ...bulkCountQuery.filters, owner: ['Unassigned'] } }),
-		[bulkCountQuery]
+	// The FULL filter record over baseQuery's window: what the split panes actually
+	// render (they narrow by status client-side), anchored to the same resolved window
+	// as the list — a pane count must never freeze a different "now" than the total it
+	// sits next to.
+	const fullRecordCountQuery = useMemo(
+		() => ({
+			filters: dashboardState.filters,
+			from: baseQuery.from ?? undefined,
+			to: baseQuery.to ?? undefined,
+			search: dashboardState.query || undefined,
+		}),
+		[dashboardState.filters, baseQuery.from, baseQuery.to, dashboardState.query]
 	);
-	const assignedCountQuery = useMemo(
-		() => ({ ...bulkCountQuery, filters: { ...bulkCountQuery.filters, ['!owner']: ['Unassigned'] } }),
-		[bulkCountQuery]
-	);
+	// ONE request for BOTH panes (grouped by owner), polled at the list's own 5s
+	// cadence: the two headers can no longer disagree with each other, and against the
+	// list they are at most one poll apart instead of three independent queries
+	// describing three different moments.
+	const paneSummaries = useAlertGroupSummaries(['owner'], fullRecordCountQuery, {
+		enabled: paneCountsEnabled,
+		refetchIntervalMs: 5 * 1000,
+	});
 	// Read through the enabled gate: a disabled query can still surface stale placeholder
-	// data from before the owner filter was applied.
-	const unassignedMatchCount = useAlertMatchCount(unassignedCountQuery, paneCountsEnabled);
-	const assignedMatchCount = useAlertMatchCount(assignedCountQuery, paneCountsEnabled);
-	const unassignedTotal = paneCountsEnabled ? unassignedMatchCount : undefined;
-	const assignedTotal = paneCountsEnabled ? assignedMatchCount : undefined;
+	// data from before the split view was turned on.
+	const paneCounts = paneCountsEnabled ? splitOwnerPaneCounts(paneSummaries.groups) : undefined;
+	const unassignedTotal = paneCounts?.unassigned;
+	const assignedTotal = paneCounts?.assigned;
 
 	// Derived from the filters themselves rather than tracked separately, so the button and
 	// the sidebar's Status section always describe the same thing. The count comes from the
@@ -921,18 +952,25 @@ const Alerts = () => {
 	// search term is applied too — AlertsTable filters by it after the sidebar/time
 	// filters, and the counts must agree with the rows actually shown.
 	// Counts come from the SERVER totals, not the loaded page — so a search matching 1,800
-	// alerts reads "1,800", not "500". Each total already reflects that tab's filters,
-	// search and time window. Caveat: the active query suspends the status filter (it's the
-	// superset serving all three tabs), so with a status filter applied — e.g. silenced
-	// hidden — the Active count is the pre-status total. It signals "more than loaded"
-	// correctly; an exact status-aware count would need its own count query.
+	// alerts reads "1,800", not "500". The active query suspends the status filter (it's
+	// the superset serving all three tabs), so while a status filter is applied — e.g.
+	// silenced hidden — the suspended total counts statuses the table hides; a dedicated
+	// count over the FULL record supplies the exact number instead. It shares
+	// fullRecordCountQuery with the split panes, so "Active" and "Unassigned + Assigned"
+	// are the same question asked of the same window. The All tab keeps the suspended
+	// totals on purpose: that view really does show every status.
+	const hasStatusFilter =
+		(dashboardState.filters.status?.length ?? 0) > 0 || (dashboardState.filters['!status']?.length ?? 0) > 0;
+	const statusAwareActiveCount = useAlertMatchCount(fullRecordCountQuery, hasStatusFilter, {
+		refetchIntervalMs: 5 * 1000,
+	});
 	const tabCounts: Record<AlertTab, number> = useMemo(
 		() => ({
-			[AlertTab.Active]: activeTotal,
+			[AlertTab.Active]: hasStatusFilter ? (statusAwareActiveCount ?? activeTotal) : activeTotal,
 			[AlertTab.Resolved]: resolvedTotal,
 			[AlertTab.All]: activeTotal + resolvedTotal,
 		}),
-		[activeTotal, resolvedTotal]
+		[activeTotal, resolvedTotal, hasStatusFilter, statusAwareActiveCount]
 	);
 	return (
 		<DashboardLayout>

--- a/apps/client/src/components/Alerts/Alerts.tsx
+++ b/apps/client/src/components/Alerts/Alerts.tsx
@@ -210,8 +210,20 @@ const Alerts = () => {
 	const [windowTick, setWindowTick] = useState(0);
 	useEffect(() => {
 		if (!isRollingWindow) return;
-		const timer = setInterval(() => setWindowTick((t) => t + 1), 60 * 1000);
-		return () => clearInterval(timer);
+		// Aligned to the minute boundary, not to mount time: toCoarseWindow quantizes
+		// to the minute, so a free-running interval started at :59 would keep serving
+		// the old bucket for most of the next minute. First tick at the boundary, then
+		// every minute on the minute.
+		let interval: ReturnType<typeof setInterval> | undefined;
+		const untilNextMinute = 60000 - (Date.now() % 60000);
+		const align = setTimeout(() => {
+			setWindowTick((t) => t + 1);
+			interval = setInterval(() => setWindowTick((t) => t + 1), 60 * 1000);
+		}, untilNextMinute);
+		return () => {
+			clearTimeout(align);
+			if (interval) clearInterval(interval);
+		};
 	}, [isRollingWindow]);
 
 	const baseQuery = useMemo(() => {
@@ -246,6 +258,12 @@ const Alerts = () => {
 		[baseQuery, resolvedGroupLoadAll]
 	);
 
+	// The active list's ACTUAL poll cadence, shared with every count that must stay in
+	// step with it (split panes, status-aware tab count). Grouping slows the list to
+	// GROUPED_POLL_MS; counts polling faster than the list would race ahead of the rows
+	// they describe — the exact desync this file just removed.
+	const activeListPollMs = isGrouping && activeViewed ? GROUPED_POLL_MS : 5 * 1000;
+
 	const {
 		data: alerts = [],
 		total: activeTotal,
@@ -253,7 +271,7 @@ const Alerts = () => {
 		refetch,
 		fetchNextPage: fetchMoreActive,
 		hasNextPage: hasMoreActive,
-	} = useAlerts(activeQuery, { refetchIntervalMs: isGrouping && activeViewed ? GROUPED_POLL_MS : undefined });
+	} = useAlerts(activeQuery, { refetchIntervalMs: activeListPollMs });
 	const {
 		data: resolvedAlerts = [],
 		total: resolvedTotal,
@@ -566,7 +584,7 @@ const Alerts = () => {
 	// describing three different moments.
 	const paneSummaries = useAlertGroupSummaries(['owner'], fullRecordCountQuery, {
 		enabled: paneCountsEnabled,
-		refetchIntervalMs: 5 * 1000,
+		refetchIntervalMs: activeListPollMs,
 	});
 	// Read through the enabled gate: a disabled query can still surface stale placeholder
 	// data from before the split view was turned on.
@@ -962,7 +980,7 @@ const Alerts = () => {
 	const hasStatusFilter =
 		(dashboardState.filters.status?.length ?? 0) > 0 || (dashboardState.filters['!status']?.length ?? 0) > 0;
 	const statusAwareActiveCount = useAlertMatchCount(fullRecordCountQuery, hasStatusFilter, {
-		refetchIntervalMs: 5 * 1000,
+		refetchIntervalMs: activeListPollMs,
 	});
 	const tabCounts: Record<AlertTab, number> = useMemo(
 		() => ({

--- a/apps/client/src/components/Alerts/Alerts.utils.ts
+++ b/apps/client/src/components/Alerts/Alerts.utils.ts
@@ -1,0 +1,26 @@
+import { AlertGroupSummaryNode } from '@OpsiMate/shared';
+
+// The split-by-owner pane headers, derived from ONE group-summaries response. Both
+// numbers coming from a single server snapshot is the point: two independent count
+// queries answered at different moments could disagree with each other (and with the
+// list total), which read as "Unassigned 42 + Assigned 0 while Active says 41".
+export interface OwnerPaneCounts {
+	unassigned: number;
+	assigned: number;
+}
+
+// 'Unassigned' is the engine's display value for ownerless alerts (getOwnerDisplayName);
+// every other top-level owner bucket is a real assignee.
+export const splitOwnerPaneCounts = (nodes: AlertGroupSummaryNode[] | undefined): OwnerPaneCounts | undefined => {
+	if (!nodes) return undefined;
+	let unassigned = 0;
+	let assigned = 0;
+	for (const node of nodes) {
+		if (node.value === 'Unassigned') {
+			unassigned += node.count;
+		} else {
+			assigned += node.count;
+		}
+	}
+	return { unassigned, assigned };
+};

--- a/apps/client/src/hooks/queries/alerts/useAlertGroupSummaries.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertGroupSummaries.ts
@@ -7,10 +7,18 @@ import { queryKeys } from '../queryKeys';
 // Server-computed group counts + rollup status over the FULL matching set. Used when a
 // grouped view is too large to load whole: rows page in progressively, but the group
 // headers read these true totals — a header can never claim fewer alerts than exist.
+export interface AlertGroupSummariesOptions {
+	resolved?: boolean;
+	enabled?: boolean;
+	// Callers pairing these counts with a polled list pass that list's cadence, so the
+	// two describe the same moment (default 20s).
+	refetchIntervalMs?: number;
+}
+
 export const useAlertGroupSummaries = (
 	groupBy: string[],
 	params: Omit<AlertQueryParams, 'limit' | 'cursor' | 'sort' | 'dir'>,
-	options?: { resolved?: boolean; enabled?: boolean; refetchIntervalMs?: number }
+	options?: AlertGroupSummariesOptions
 ) => {
 	const { data } = useQuery({
 		queryKey: [

--- a/apps/client/src/hooks/queries/alerts/useAlertGroupSummaries.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertGroupSummaries.ts
@@ -10,7 +10,7 @@ import { queryKeys } from '../queryKeys';
 export const useAlertGroupSummaries = (
 	groupBy: string[],
 	params: Omit<AlertQueryParams, 'limit' | 'cursor' | 'sort' | 'dir'>,
-	options?: { resolved?: boolean; enabled?: boolean }
+	options?: { resolved?: boolean; enabled?: boolean; refetchIntervalMs?: number }
 ) => {
 	const { data } = useQuery({
 		queryKey: [
@@ -32,7 +32,9 @@ export const useAlertGroupSummaries = (
 			return response.data.groups;
 		},
 		staleTime: 10 * 1000,
-		refetchInterval: 20 * 1000,
+		// Callers that pair these counts with the 5s alert list (the split-by-owner
+		// panes) pass a matching cadence, so the two stop describing different moments.
+		refetchInterval: options?.refetchIntervalMs ?? 20 * 1000,
 		// Keep the previous header counts while a changed query refetches — group headers
 		// flashing to loaded-only counts and back reads as the data disappearing.
 		placeholderData: keepPreviousData,

--- a/apps/client/src/hooks/queries/alerts/useAlertMatchCount.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertMatchCount.ts
@@ -6,10 +6,15 @@ import { queryKeys } from '../queryKeys';
 // list request whose response carries the true total, so the count comes from the same
 // server engine that will resolve the bulk action; the one row in the payload is noise.
 // Only fetched while a selection is open (see `enabled`), so it costs nothing otherwise.
+export interface AlertMatchCountOptions {
+	// Match the cadence of whatever list this count sits next to (default 20s).
+	refetchIntervalMs?: number;
+}
+
 export const useAlertMatchCount = (
 	params: Pick<AlertQueryParams, 'filters' | 'from' | 'to' | 'search'>,
 	enabled: boolean,
-	options?: { refetchIntervalMs?: number }
+	options?: AlertMatchCountOptions
 ) => {
 	const { data } = useQuery({
 		queryKey: [

--- a/apps/client/src/hooks/queries/alerts/useAlertMatchCount.ts
+++ b/apps/client/src/hooks/queries/alerts/useAlertMatchCount.ts
@@ -8,7 +8,8 @@ import { queryKeys } from '../queryKeys';
 // Only fetched while a selection is open (see `enabled`), so it costs nothing otherwise.
 export const useAlertMatchCount = (
 	params: Pick<AlertQueryParams, 'filters' | 'from' | 'to' | 'search'>,
-	enabled: boolean
+	enabled: boolean,
+	options?: { refetchIntervalMs?: number }
 ) => {
 	const { data } = useQuery({
 		queryKey: [
@@ -28,7 +29,7 @@ export const useAlertMatchCount = (
 			return response.data.total ?? response.data.alerts.length;
 		},
 		staleTime: 10 * 1000,
-		refetchInterval: 20 * 1000,
+		refetchInterval: options?.refetchIntervalMs ?? 20 * 1000,
 		// The N in "Select all N matching" (and the split-pane totals) shouldn't blink to
 		// nothing whenever the query re-keys.
 		placeholderData: keepPreviousData,

--- a/apps/client/src/test/Alerts.utils.test.ts
+++ b/apps/client/src/test/Alerts.utils.test.ts
@@ -1,0 +1,34 @@
+import { AlertGroupSummaryNode } from '@OpsiMate/shared';
+import { describe, expect, test } from 'vitest';
+import { splitOwnerPaneCounts } from '@/components/Alerts/Alerts.utils';
+
+const node = (value: string, count: number): AlertGroupSummaryNode =>
+	({
+		key: `owner:${value}`,
+		field: 'owner',
+		value,
+		count,
+		status: 'firing',
+		level: 0,
+		children: [],
+	}) as unknown as AlertGroupSummaryNode;
+
+describe('splitOwnerPaneCounts', () => {
+	test('splits the Unassigned bucket from every named owner', () => {
+		const counts = splitOwnerPaneCounts([node('Unassigned', 42), node('John Doe', 3), node('Dana', 2)]);
+		expect(counts).toEqual({ unassigned: 42, assigned: 5 });
+	});
+
+	test('all unassigned: assigned is zero, and the two sum to the whole response', () => {
+		const counts = splitOwnerPaneCounts([node('Unassigned', 41)]);
+		expect(counts).toEqual({ unassigned: 41, assigned: 0 });
+	});
+
+	test('no summaries yet returns undefined so headers fall back to loaded counts', () => {
+		expect(splitOwnerPaneCounts(undefined)).toBeUndefined();
+	});
+
+	test('empty response is a real zero, not a fallback', () => {
+		expect(splitOwnerPaneCounts([])).toEqual({ unassigned: 0, assigned: 0 });
+	});
+});


### PR DESCRIPTION
## The bug
"On the Active button I can see 41 alerts, Unassigned says 42, Assigned 0."

Three numbers from three queries, asked at three different moments with two different filter records — they only ever agreed while nothing was changing:

| Number | Source | Window resolved | Poll |
|---|---|---|---|
| Active tab | list query, **status-suspended** filters | once per interaction (then frozen) | 5s |
| Unassigned | own limit-1 query | own 30s tick | 20s |
| Assigned | *another* limit-1 query | own 30s tick | 20s |

So: any resolve/assign desynced them for up to ~20s (the reported case); rolling-window presets drifted the frozen list window away from the panes' ticked one; and any status filter (silenced hidden) made the tab count a *pre-status* total permanently.

## The fix — one mechanism each
1. **One request for both panes**: group-summaries by owner over the full filter record, at the list's 5s cadence. `Unassigned + Assigned` now always describes a single server snapshot.
2. **One clock**: a minute tick re-runs `baseQuery`'s window resolution (delivering what `toCoarseWindow`'s minute-rounding always promised — previously nothing re-ran the memo, so the resolved window was frozen at the last interaction). Every dependent count derives `from`/`to` from `baseQuery` rather than resolving its own "now".
3. **Status-aware Active count**: while a status filter is active, the tab count comes from a dedicated full-record count that shares the exact query object with the panes — the tab and the pane sum are literally the same question. The All tab keeps suspended totals deliberately (it really shows every status).

The bulk-selection count keeps its action-time window semantics, unchanged.

## Verification
- Live, reproducing the report: 22 active with 2 silenced hidden — **old code: Active 22 vs panes 18+2**; new code: Active **20** = Unassigned **18** + Assigned **2**; the owner-summaries response (`Unassigned:18, idan lodzki:2`) is the byte source of both headers.
- New unit coverage for the pane split (`splitOwnerPaneCounts`): named-owner buckets sum into Assigned, all-unassigned, empty-response vs no-response semantics.
- 172 client tests green, lint 0 errors, no new type errors vs the main baseline (34 = 34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alert time-range views now refresh automatically as rolling time windows advance.
  * Owner-pane totals are calculated consistently from a shared summary.
  * Active-tab counts now reflect applied status filters.
  * Alert summary polling can be refreshed at customized intervals.

* **Bug Fixes**
  * Improved accuracy of assigned and unassigned alert totals, including empty and unavailable results.

* **Tests**
  * Added coverage for owner totals across assigned, unassigned, empty, and undefined results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->