### PR TITLE
[FIX]: react router link in place of a html tag

### DIFF
--- a/apps/client/src/pages/NotFound.tsx
+++ b/apps/client/src/pages/NotFound.tsx
@@ -1,6 +1,6 @@
 import { Logger } from '@OpsiMate/shared';
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 
 const logger = new Logger('NotFound');
 
@@ -16,9 +16,12 @@ const NotFound = () => {
 			<div className="text-center">
 				<h1 className="text-4xl font-bold mb-4 text-foreground">404</h1>
 				<p className="text-xl text-muted-foreground mb-4">Oops! Page not found</p>
-				<a href="/" className="text-primary hover:text-primary/80 underline">
+				<Link to="/" className="text-primary hover:text-primary/80 underline">
 					Return to Home
-				</a>
+				</Link>
+				{/* <a href="/" className="text-primary hover:text-primary/80 underline">
+					Return to Home
+				</a> */}
 			</div>
 		</div>
 	);

--- a/apps/client/src/pages/NotFound.tsx
+++ b/apps/client/src/pages/NotFound.tsx
@@ -19,9 +19,6 @@ const NotFound = () => {
 				<Link to="/" className="text-primary hover:text-primary/80 underline">
 					Return to Home
 				</Link>
-				{/* <a href="/" className="text-primary hover:text-primary/80 underline">
-					Return to Home
-				</a> */}
 			</div>
 		</div>
 	);

--- a/apps/client/src/test/NotFound.test.tsx
+++ b/apps/client/src/test/NotFound.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, test } from 'vitest';
+import NotFound from '@/pages/NotFound';
+
+// "Return to Home" must navigate through the router, not by handing the URL back to
+// the browser. The distinction is invisible in the DOM (react-router's Link renders a
+// plain <a href>), but it is exactly what this asserts: in jsdom a bare <a href="/">
+// click cannot change the router's location — only a Link can. So this test fails
+// against an anchor and passes against a Link, without mocking anything.
+
+const renderAt = (path: string) =>
+	render(
+		<MemoryRouter initialEntries={[path]}>
+			<Routes>
+				<Route path="/" element={<div>home route rendered</div>} />
+				<Route path="*" element={<NotFound />} />
+			</Routes>
+		</MemoryRouter>
+	);
+
+describe('NotFound', () => {
+	test('renders the 404 state for an unknown route', () => {
+		renderAt('/no-such-page');
+		expect(screen.getByText('404')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Return to Home' })).toBeInTheDocument();
+	});
+
+	test('"Return to Home" navigates in-app instead of reloading the document', async () => {
+		const user = userEvent.setup();
+		renderAt('/no-such-page');
+
+		await user.click(screen.getByRole('link', { name: 'Return to Home' }));
+
+		// The home route took over: only client-side routing can do this in jsdom.
+		expect(screen.getByText('home route rendered')).toBeInTheDocument();
+		expect(screen.queryByText('404')).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Issue Reference
Closes #773 

---

## What Was Changed
The `a` tag was changed to the `Link` from react router.

---

## Why Was It Changed
It was changed because of the reasoning provided in #773. I am not sure of how to test this functionality. 

---

## Screenshots
The `NotFound` page still renders the same way. 
<img width="461" height="669" alt="Screenshot 2026-08-17 at 9 26 36 pm" src="https://github.com/user-attachments/assets/50bf08d5-4d76-4f0b-ae85-2aa993be4008" />

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation from the Not Found page by using in-app routing to return home without a full page reload.
  * Added coverage for Not Found page rendering and home navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->