### PR TITLE
[FIX]: add try-catch for error handling in testIntegration

### DIFF
--- a/apps/server/src/api/v1/integrations/controller.ts
+++ b/apps/server/src/api/v1/integrations/controller.ts
@@ -32,26 +32,35 @@ export class IntegrationController {
 	};
 
 	testIntegration = async (req: Request, res: Response) => {
-		const integrationToCreate = CreateIntegrationSchema.parse(req.body);
+		try {
+			const integrationToCreate = CreateIntegrationSchema.parse(req.body);
 
-		const integrationConnector = integrationConnectorFactory(integrationToCreate.type);
+			const integrationConnector = integrationConnectorFactory(integrationToCreate.type);
 
-		const integration: Integration = {
-			...integrationToCreate,
-			createdAt: '',
-			id: 0,
-		};
+			const integration: Integration = {
+				...integrationToCreate,
+				createdAt: '',
+				id: 0,
+			};
 
-		const testResult = await integrationConnector.testConnection(integration);
+			const testResult = await integrationConnector.testConnection(integration);
 
-		if (testResult.success) {
-			return res.status(200).json({ success: true, data: { isValidConnection: true } });
-		} else {
-			return res.status(200).json({
-				success: false,
-				error: testResult.error || 'Connection test failed',
-				data: { isValidConnection: false },
-			});
+			if (testResult.success) {
+				return res.status(200).json({ success: true, data: { isValidConnection: true } });
+			} else {
+				return res.status(200).json({
+					success: false,
+					error: testResult.error || 'Connection test failed',
+					data: { isValidConnection: false },
+				});
+			}
+		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			} else {
+				logger.error('Error testing integration:', error);
+				return res.status(500).json({ success: false, error: 'Internal server error' });
+			}
 		}
 	};
 


### PR DESCRIPTION
## Issue Reference

Closes #771 

---

## What Was Changed

Added try catch block to POST /integrations/test-connection ( testIntegration function ).

---

## Why Was It Changed

For better error handling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved integration connection testing error handling.
  - Invalid request data now returns a clear HTTP 400 response with validation details.
  - Unexpected errors now return a consistent HTTP 500 response.
  - Existing successful and failed connection test responses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->