### PR TITLE
feat(rules): sort the mute policy, enrichment and action tables by column header

### DIFF
--- a/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
+++ b/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
@@ -4,7 +4,7 @@ import { AutocompleteInput } from './AutocompleteInput';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
-import { getLabelMatcherGroups, MatcherCriteria } from '@OpsiMate/shared';
+import { getLabelMatcherGroups, getNameNeedles, MatcherCriteria } from '@OpsiMate/shared';
 import { Fragment, useMemo } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 
@@ -242,3 +242,23 @@ export const describeMatcherCriteria = (criteria: MatcherCriteria): string =>
 	getLabelMatcherGroups(criteria)
 		.map((group) => group.map((m) => `${m.key}${m.op === 'contains' ? '~' : '='}${m.value}`).join(' AND '))
 		.join(' OR ');
+
+// The name needles in the badge's own wording, so a sort key built from this reads in
+// the same order as the cell.
+const describeNameNeedles = (criteria: MatcherCriteria): string => {
+	const needles = getNameNeedles(criteria);
+	return needles.length > 0 ? `name ~ ${needles.map((n) => `"${n}"`).join(' or ')}` : '';
+};
+
+// The WHOLE scope cell as one string: name badge first, then either "All alerts" or the
+// matcher badges — the order the pages render them in.
+//
+// Built from the rendered wording rather than the raw fields on purpose. Any other key
+// produces an order that looks wrong to someone reading the column, and the two can
+// drift apart silently: matchAll is not exclusive with name needles, so a policy that
+// shows `name ~ "foo"` AND `All alerts` previously sorted as bare "All alerts" —
+// indistinguishable from every other match-all rule.
+export const describeCriteriaScope = (criteria: MatcherCriteria, matchAll = false): string =>
+	[describeNameNeedles(criteria), matchAll ? 'All alerts' : describeMatcherCriteria(criteria)]
+		.filter(Boolean)
+		.join(' ');

--- a/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
+++ b/apps/client/src/components/shared/MatcherGroupsEditor/MatcherGroupsEditor.tsx
@@ -233,3 +233,12 @@ export const MatcherGroupBadges = ({ criteria }: { criteria: MatcherCriteria }) 
 
 // True when the entity has any complete matcher (used by the pages' empty-state checks).
 export const hasMatcherCriteria = (criteria: MatcherCriteria): boolean => getLabelMatcherGroups(criteria).length > 0;
+
+// The matcher groups as the text a user reads in the badges ("env=prod AND team~db OR
+// …"). Sorting a Match column has to compare what the column SHOWS — comparing only
+// part of it (say the name needles) makes rows with visibly different matchers sort as
+// equal, which reads as the sort being broken.
+export const describeMatcherCriteria = (criteria: MatcherCriteria): string =>
+	getLabelMatcherGroups(criteria)
+		.map((group) => group.map((m) => `${m.key}${m.op === 'contains' ? '~' : '='}${m.value}`).join(' AND '))
+		.join(' OR ');

--- a/apps/client/src/components/shared/MatcherGroupsEditor/index.ts
+++ b/apps/client/src/components/shared/MatcherGroupsEditor/index.ts
@@ -1,2 +1,8 @@
-export { cleanMatcherGroups, hasMatcherCriteria, MatcherGroupBadges, MatcherGroupsEditor } from './MatcherGroupsEditor';
+export {
+	cleanMatcherGroups,
+	describeMatcherCriteria,
+	hasMatcherCriteria,
+	MatcherGroupBadges,
+	MatcherGroupsEditor,
+} from './MatcherGroupsEditor';
 export type { MatcherRow, MatcherSuggestion } from './MatcherGroupsEditor';

--- a/apps/client/src/components/shared/MatcherGroupsEditor/index.ts
+++ b/apps/client/src/components/shared/MatcherGroupsEditor/index.ts
@@ -1,5 +1,6 @@
 export {
 	cleanMatcherGroups,
+	describeCriteriaScope,
 	describeMatcherCriteria,
 	hasMatcherCriteria,
 	MatcherGroupBadges,

--- a/apps/client/src/components/shared/SortableTable/SortableTableHead.tsx
+++ b/apps/client/src/components/shared/SortableTable/SortableTableHead.tsx
@@ -1,0 +1,56 @@
+import { TableHead } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { ReactNode } from 'react';
+import { SortDirection } from './useTableSort';
+
+interface SortableTableHeadProps<TKey extends string> {
+	// The column this header sorts by; also what `toggle` receives.
+	sortKey: TKey;
+	activeKey: TKey | null;
+	direction: SortDirection;
+	onToggle: (key: TKey) => void;
+	children: ReactNode;
+	className?: string;
+}
+
+// A clickable column header for the rule tables. Mirrors the alerts table's affordance
+// on purpose — a neutral up/down glyph when idle, a single arrow showing the direction
+// when active — so sorting looks the same everywhere in the product. Rendered as a
+// native button inside the cell so it is focusable and operable by keyboard, which a
+// click handler on the <th> alone would not be.
+export const SortableTableHead = <TKey extends string>({
+	sortKey,
+	activeKey,
+	direction,
+	onToggle,
+	children,
+	className,
+}: SortableTableHeadProps<TKey>) => {
+	const isActive = activeKey === sortKey;
+	return (
+		<TableHead
+			className={className}
+			aria-sort={isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+		>
+			<button
+				type="button"
+				onClick={() => onToggle(sortKey)}
+				className="group -mx-1 flex items-center gap-1 rounded px-1 py-0.5 hover:text-foreground"
+			>
+				{children}
+				{isActive ? (
+					direction === 'asc' ? (
+						<ArrowUp className="h-3 w-3 shrink-0" />
+					) : (
+						<ArrowDown className="h-3 w-3 shrink-0" />
+					)
+				) : (
+					// Held at low opacity rather than hidden: a header that grows an icon
+					// only on hover doesn't advertise that the table sorts at all.
+					<ArrowUpDown className={cn('h-3 w-3 shrink-0 opacity-40 group-hover:opacity-100')} />
+				)}
+			</button>
+		</TableHead>
+	);
+};

--- a/apps/client/src/components/shared/SortableTable/index.ts
+++ b/apps/client/src/components/shared/SortableTable/index.ts
@@ -1,0 +1,3 @@
+export { SortableTableHead } from './SortableTableHead';
+export { useTableSort } from './useTableSort';
+export type { SortDirection, SortValue, TableSortState } from './useTableSort';

--- a/apps/client/src/components/shared/SortableTable/useTableSort.ts
+++ b/apps/client/src/components/shared/SortableTable/useTableSort.ts
@@ -54,18 +54,18 @@ export const useTableSort = <TRow, TKey extends string>(
 	accessors: Record<TKey, (row: TRow) => SortValue>,
 	options: UseTableSortOptions<TKey> = {}
 ): TableSortState<TKey> & { sorted: TRow[] } => {
-	const [sortKey, setSortKey] = useState<TKey | null>(options.initialKey ?? null);
-	const [direction, setDirection] = useState<SortDirection>(options.initialDirection ?? 'asc');
+	const [selection, setSelection] = useState<SortSelection<TKey>>({
+		key: options.initialKey ?? null,
+		direction: options.initialDirection ?? 'asc',
+	});
+	const { key: sortKey, direction } = selection;
 
 	const toggle = useCallback((key: TKey) => {
-		setSortKey((currentKey) => {
-			if (currentKey === key) {
-				setDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
-				return currentKey;
-			}
-			setDirection('asc');
-			return key;
-		});
+		setSelection((current) =>
+			current.key === key
+				? { key, direction: current.direction === 'asc' ? 'desc' : 'asc' }
+				: { key, direction: 'asc' }
+		);
 	}, []);
 
 	// Callers build the accessor map inline, so it has a new identity every render;

--- a/apps/client/src/components/shared/SortableTable/useTableSort.ts
+++ b/apps/client/src/components/shared/SortableTable/useTableSort.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -6,6 +6,15 @@ export type SortDirection = 'asc' | 'desc';
 // directions: "no priority" or "no window" is absence, not a small value, and flipping
 // direction shouldn't drag a blank row to the top.
 export type SortValue = string | number | boolean | null | undefined;
+
+// Key and direction live in ONE state value: they change together, and updating one
+// from inside the other's updater would be an impure updater — React may invoke it more
+// than once (it does in StrictMode), which double-toggles the direction back to where
+// it started.
+interface SortSelection<TKey extends string> {
+	key: TKey | null;
+	direction: SortDirection;
+}
 
 export interface TableSortState<TKey extends string> {
 	sortKey: TKey | null;
@@ -59,9 +68,15 @@ export const useTableSort = <TRow, TKey extends string>(
 		});
 	}, []);
 
+	// Callers build the accessor map inline, so it has a new identity every render;
+	// putting it in the memo's deps would defeat the memo entirely. A ref keeps the
+	// CURRENT accessors available without making identity a recompute trigger.
+	const accessorsRef = useRef(accessors);
+	accessorsRef.current = accessors;
+
 	const sorted = useMemo(() => {
 		if (!sortKey) return rows;
-		const accessor = accessors[sortKey];
+		const accessor = accessorsRef.current[sortKey];
 		if (!accessor) return rows;
 		// Copy before sorting: the incoming array is the memoized filter result, and
 		// sorting in place would mutate it (and reorder the caller's list on every
@@ -74,9 +89,6 @@ export const useTableSort = <TRow, TKey extends string>(
 			if (!Number.isFinite(result)) return result === Number.POSITIVE_INFINITY ? 1 : -1;
 			return result * factor;
 		});
-		// accessors is a literal rebuilt each render by callers; keying the memo on it
-		// would defeat it entirely, and its behaviour only changes with rows/sortKey.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [rows, sortKey, direction]);
 
 	return { sortKey, direction, toggle, sorted };

--- a/apps/client/src/components/shared/SortableTable/useTableSort.ts
+++ b/apps/client/src/components/shared/SortableTable/useTableSort.ts
@@ -30,15 +30,26 @@ interface UseTableSortOptions<TKey extends string> {
 	initialDirection?: SortDirection;
 }
 
+// NaN counts as missing. A date accessor is the usual way it turns up —
+// new Date('nonsense').getTime() is NaN — and NaN fails every comparison, so leaving it
+// in the numeric path makes compare(a,b) and compare(b,a) BOTH claim "a first". That
+// breaks the contract Array.sort relies on and the resulting order is arbitrary, not
+// merely odd. Parking it with the other absent values keeps the comparator consistent.
+const isMissing = (v: SortValue): boolean =>
+	v === null || v === undefined || v === '' || (typeof v === 'number' && Number.isNaN(v));
+
 const compareValues = (a: SortValue, b: SortValue): number => {
-	const aMissing = a === null || a === undefined || a === '';
-	const bMissing = b === null || b === undefined || b === '';
+	const aMissing = isMissing(a);
+	const bMissing = isMissing(b);
 	if (aMissing && bMissing) return 0;
 	// Missing sorts last regardless of direction (see SortValue) — the caller's
 	// direction flip is applied only to the comparison below.
 	if (aMissing) return Number.POSITIVE_INFINITY;
 	if (bMissing) return Number.NEGATIVE_INFINITY;
-	if (typeof a === 'number' && typeof b === 'number') return a - b;
+	// Math.sign, not a - b: the difference of two large timestamps can overflow to
+	// ±Infinity, which the caller reads as the "missing" sentinel and so never flips
+	// with direction. A sign is all the caller needs.
+	if (typeof a === 'number' && typeof b === 'number') return Math.sign(a - b);
 	if (typeof a === 'boolean' && typeof b === 'boolean') return Number(a) - Number(b);
 	// localeCompare, not <: rule names are human text, so "Éxpiry" must sort next to
 	// "Expiry" rather than after "Zzz", and numeric:true keeps "policy 2" before

--- a/apps/client/src/components/shared/SortableTable/useTableSort.ts
+++ b/apps/client/src/components/shared/SortableTable/useTableSort.ts
@@ -1,0 +1,83 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export type SortDirection = 'asc' | 'desc';
+
+// A column's sortable value. Returning null/undefined parks the row at the END in both
+// directions: "no priority" or "no window" is absence, not a small value, and flipping
+// direction shouldn't drag a blank row to the top.
+export type SortValue = string | number | boolean | null | undefined;
+
+export interface TableSortState<TKey extends string> {
+	sortKey: TKey | null;
+	direction: SortDirection;
+	toggle: (key: TKey) => void;
+}
+
+interface UseTableSortOptions<TKey extends string> {
+	// Column the table starts sorted by, or null for the list's natural order.
+	// NoInfer: TKey must come from the accessors map — inferring it here too would
+	// narrow the whole map to the single key named in the options.
+	initialKey?: NoInfer<TKey> | null;
+	initialDirection?: SortDirection;
+}
+
+const compareValues = (a: SortValue, b: SortValue): number => {
+	const aMissing = a === null || a === undefined || a === '';
+	const bMissing = b === null || b === undefined || b === '';
+	if (aMissing && bMissing) return 0;
+	// Missing sorts last regardless of direction (see SortValue) — the caller's
+	// direction flip is applied only to the comparison below.
+	if (aMissing) return Number.POSITIVE_INFINITY;
+	if (bMissing) return Number.NEGATIVE_INFINITY;
+	if (typeof a === 'number' && typeof b === 'number') return a - b;
+	if (typeof a === 'boolean' && typeof b === 'boolean') return Number(a) - Number(b);
+	// localeCompare, not <: rule names are human text, so "Éxpiry" must sort next to
+	// "Expiry" rather than after "Zzz", and numeric:true keeps "policy 2" before
+	// "policy 10".
+	return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
+};
+
+// Click-to-sort state plus the sort itself, shared by the rule tables (mute policies,
+// enrichments, actions). Same three-state header behaviour as the alerts table: first
+// click sorts, second reverses; the row order is otherwise the list's own.
+export const useTableSort = <TRow, TKey extends string>(
+	rows: TRow[],
+	accessors: Record<TKey, (row: TRow) => SortValue>,
+	options: UseTableSortOptions<TKey> = {}
+): TableSortState<TKey> & { sorted: TRow[] } => {
+	const [sortKey, setSortKey] = useState<TKey | null>(options.initialKey ?? null);
+	const [direction, setDirection] = useState<SortDirection>(options.initialDirection ?? 'asc');
+
+	const toggle = useCallback((key: TKey) => {
+		setSortKey((currentKey) => {
+			if (currentKey === key) {
+				setDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+				return currentKey;
+			}
+			setDirection('asc');
+			return key;
+		});
+	}, []);
+
+	const sorted = useMemo(() => {
+		if (!sortKey) return rows;
+		const accessor = accessors[sortKey];
+		if (!accessor) return rows;
+		// Copy before sorting: the incoming array is the memoized filter result, and
+		// sorting in place would mutate it (and reorder the caller's list on every
+		// render).
+		const factor = direction === 'asc' ? 1 : -1;
+		return [...rows].sort((a, b) => {
+			const result = compareValues(accessor(a), accessor(b));
+			// Absent values already resolved to ±Infinity, which must NOT be flipped by
+			// direction — they always sink to the bottom.
+			if (!Number.isFinite(result)) return result === Number.POSITIVE_INFINITY ? 1 : -1;
+			return result * factor;
+		});
+		// accessors is a literal rebuilt each render by callers; keying the memo on it
+		// would defeat it entirely, and its behaviour only changes with rows/sortKey.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [rows, sortKey, direction]);
+
+	return { sortKey, direction, toggle, sorted };
+};

--- a/apps/client/src/pages/Actions.tsx
+++ b/apps/client/src/pages/Actions.tsx
@@ -27,7 +27,11 @@ import {
 	getNameNeedles,
 } from '@OpsiMate/shared';
 import { Globe, Loader2, MessageSquare, Pencil, Play, Plus, Search, Ticket, Trash2, Zap } from 'lucide-react';
-import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
+import {
+	describeMatcherCriteria,
+	hasMatcherCriteria,
+	MatcherGroupBadges,
+} from '@/components/shared/MatcherGroupsEditor';
 import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { useMemo, useState } from 'react';
 
@@ -159,10 +163,13 @@ const Actions: React.FC = () => {
 		name: (a: Action) => a.name,
 		type: (a: Action) => a.type,
 		target: (a: Action) => summarize(a),
+		// The scope text as displayed. A shared literal for every label-matcher rule
+		// would make them all compare equal despite showing different matchers; an
+		// action with no criteria at all runs everywhere and has no scope to compare,
+		// so it stays absent and parks at the end.
 		appliesTo: (a: Action) => {
-			const needles = getNameNeedles(a);
-			if (needles.length > 0) return needles.join(', ');
-			return hasMatcherCriteria(a) ? 'labels' : null;
+			const scope = [getNameNeedles(a).join(', '), describeMatcherCriteria(a)].filter(Boolean).join(' ');
+			return scope.length > 0 ? scope : null;
 		},
 	});
 

--- a/apps/client/src/pages/Actions.tsx
+++ b/apps/client/src/pages/Actions.tsx
@@ -27,11 +27,7 @@ import {
 	getNameNeedles,
 } from '@OpsiMate/shared';
 import { Globe, Loader2, MessageSquare, Pencil, Play, Plus, Search, Ticket, Trash2, Zap } from 'lucide-react';
-import {
-	describeMatcherCriteria,
-	hasMatcherCriteria,
-	MatcherGroupBadges,
-} from '@/components/shared/MatcherGroupsEditor';
+import { describeCriteriaScope, hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { useMemo, useState } from 'react';
 
@@ -157,20 +153,17 @@ const Actions: React.FC = () => {
 		);
 	}, [actions, search]);
 
-	// "Applies to" sorts by the rule's own scope text; an action with no criteria (it
-	// runs on every alert) has no scope to compare, so it parks at the end.
+	// Every column sorts by the text its cell shows, so the order is explainable by
+	// reading the column.
 	const { sorted, sortKey, direction, toggle } = useTableSort(filtered, {
 		name: (a: Action) => a.name,
 		type: (a: Action) => a.type,
 		target: (a: Action) => summarize(a),
-		// The scope text as displayed. A shared literal for every label-matcher rule
-		// would make them all compare equal despite showing different matchers; an
-		// action with no criteria at all runs everywhere and has no scope to compare,
-		// so it stays absent and parks at the end.
-		appliesTo: (a: Action) => {
-			const scope = [getNameNeedles(a).join(', '), describeMatcherCriteria(a)].filter(Boolean).join(' ');
-			return scope.length > 0 ? scope : null;
-		},
+		// The scope text exactly as the cell renders it. A shared literal for every
+		// label-matcher rule would make them all compare equal despite showing different
+		// matchers. An action with no name and no matchers renders the "All alerts"
+		// badge, so that is what it sorts by — same rule as the other two pages.
+		appliesTo: (a: Action) => describeCriteriaScope(a) || 'All alerts',
 	});
 
 	const handleDelete = async () => {

--- a/apps/client/src/pages/Actions.tsx
+++ b/apps/client/src/pages/Actions.tsx
@@ -28,6 +28,7 @@ import {
 } from '@OpsiMate/shared';
 import { Globe, Loader2, MessageSquare, Pencil, Play, Plus, Search, Ticket, Trash2, Zap } from 'lucide-react';
 import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
+import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { useMemo, useState } from 'react';
 
 const TYPE_META: Record<
@@ -152,6 +153,19 @@ const Actions: React.FC = () => {
 		);
 	}, [actions, search]);
 
+	// "Applies to" sorts by the rule's own scope text; an action with no criteria (it
+	// runs on every alert) has no scope to compare, so it parks at the end.
+	const { sorted, sortKey, direction, toggle } = useTableSort(filtered, {
+		name: (a: Action) => a.name,
+		type: (a: Action) => a.type,
+		target: (a: Action) => summarize(a),
+		appliesTo: (a: Action) => {
+			const needles = getNameNeedles(a);
+			if (needles.length > 0) return needles.join(', ');
+			return hasMatcherCriteria(a) ? 'labels' : null;
+		},
+	});
+
 	const handleDelete = async () => {
 		if (!deleting) return;
 		try {
@@ -206,10 +220,38 @@ const Actions: React.FC = () => {
 						<Table>
 							<TableHeader>
 								<TableRow>
-									<TableHead>Name</TableHead>
-									<TableHead>Type</TableHead>
-									<TableHead>Target</TableHead>
-									<TableHead>Applies to</TableHead>
+									<SortableTableHead
+										sortKey="name"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Name
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="type"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Type
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="target"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Target
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="appliesTo"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Applies to
+									</SortableTableHead>
 									<TableHead className="text-right">Actions</TableHead>
 								</TableRow>
 							</TableHeader>
@@ -250,7 +292,7 @@ const Actions: React.FC = () => {
 										</TableCell>
 									</TableRow>
 								) : (
-									filtered.map((a) => (
+									sorted.map((a) => (
 										<TableRow key={a.id} className="align-top">
 											<TableCell className="max-w-[260px]">
 												<div className="font-medium truncate">{a.name}</div>

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -18,7 +18,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
 import { AlertEnrichment, getLabelMatcherGroups, getNameNeedles } from '@OpsiMate/shared';
-import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
+import {
+	describeMatcherCriteria,
+	hasMatcherCriteria,
+	MatcherGroupBadges,
+} from '@/components/shared/MatcherGroupsEditor';
 import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { Copy, FileText, Link2, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -118,9 +122,20 @@ const Enrichments: React.FC = () => {
 		{
 			name: (e: AlertEnrichment) => e.name,
 			priority: (e: AlertEnrichment) => e.priority,
-			match: (e: AlertEnrichment) => (e.matchAll ? 'All alerts' : getNameNeedles(e).join(', ')),
+			match: (e: AlertEnrichment) =>
+				e.matchAll
+					? 'All alerts'
+					: [getNameNeedles(e).join(', '), describeMatcherCriteria(e)].filter(Boolean).join(' '),
+			// Everything the Enrichment column renders — fields, links and the summary
+			// template — so two rules showing different effects never compare as equal.
 			enrichment: (e: AlertEnrichment) =>
-				(e.addFields ?? []).map((f) => `${f.key}=${f.value}`).join(', ') || e.summaryTemplate || '',
+				[
+					(e.addFields ?? []).map((f) => `${f.key}=${f.value}`).join(', '),
+					(e.addLinks ?? []).map((l) => l.label || l.url).join(', '),
+					e.summaryTemplate ?? '',
+				]
+					.filter(Boolean)
+					.join(' '),
 		},
 		{ initialKey: 'priority', initialDirection: 'desc' }
 	);

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -45,6 +45,21 @@ const MatchBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
 	</div>
 );
 
+// The Enrichment column's badges as one string, in render order and with the same
+// wording the badges use ("+key=value", the link label, "summary: …"). The column sorts
+// by this, so it has to mirror EffectBadges below: anything the key adds that the badge
+// omits (or vice versa) makes the order disagree with what the row shows. Keep the two
+// together — the last drift here was a key that fell back to a link's url while the
+// badge rendered only its label.
+export const describeEnrichmentEffects = (enrichment: AlertEnrichment): string =>
+	[
+		...(enrichment.addFields ?? []).map((f) => `+${f.key}=${f.value}`),
+		...(enrichment.addLinks ?? []).map((l) => l.label),
+		enrichment.summaryTemplate ? `summary: ${enrichment.summaryTemplate}` : '',
+	]
+		.filter(Boolean)
+		.join(' ');
+
 const EffectBadges = ({ enrichment }: { enrichment: AlertEnrichment }) => (
 	<div className="flex flex-wrap gap-1.5">
 		{(enrichment.addFields ?? []).map((f, idx) => (
@@ -119,16 +134,7 @@ const Enrichments: React.FC = () => {
 			name: (e: AlertEnrichment) => e.name,
 			priority: (e: AlertEnrichment) => e.priority,
 			match: (e: AlertEnrichment) => describeCriteriaScope(e, e.matchAll),
-			// Everything the Enrichment column renders — fields, links and the summary
-			// template — so two rules showing different effects never compare as equal.
-			enrichment: (e: AlertEnrichment) =>
-				[
-					(e.addFields ?? []).map((f) => `${f.key}=${f.value}`).join(', '),
-					(e.addLinks ?? []).map((l) => l.label || l.url).join(', '),
-					e.summaryTemplate ?? '',
-				]
-					.filter(Boolean)
-					.join(' '),
+			enrichment: describeEnrichmentEffects,
 		},
 		{ initialKey: 'priority', initialDirection: 'desc' }
 	);

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -18,11 +18,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
 import { AlertEnrichment, getLabelMatcherGroups, getNameNeedles } from '@OpsiMate/shared';
-import {
-	describeMatcherCriteria,
-	hasMatcherCriteria,
-	MatcherGroupBadges,
-} from '@/components/shared/MatcherGroupsEditor';
+import { describeCriteriaScope, hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { Copy, FileText, Link2, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -122,10 +118,7 @@ const Enrichments: React.FC = () => {
 		{
 			name: (e: AlertEnrichment) => e.name,
 			priority: (e: AlertEnrichment) => e.priority,
-			match: (e: AlertEnrichment) =>
-				e.matchAll
-					? 'All alerts'
-					: [getNameNeedles(e).join(', '), describeMatcherCriteria(e)].filter(Boolean).join(' '),
+			match: (e: AlertEnrichment) => describeCriteriaScope(e, e.matchAll),
 			// Everything the Enrichment column renders — fields, links and the summary
 			// template — so two rules showing different effects never compare as equal.
 			enrichment: (e: AlertEnrichment) =>

--- a/apps/client/src/pages/Enrichments.tsx
+++ b/apps/client/src/pages/Enrichments.tsx
@@ -19,6 +19,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useDeleteEnrichment, useEnrichments } from '@/hooks/queries/enrichments';
 import { AlertEnrichment, getLabelMatcherGroups, getNameNeedles } from '@OpsiMate/shared';
 import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
+import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { Copy, FileText, Link2, Pencil, Plus, Search, Sparkles, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
@@ -109,6 +110,21 @@ const Enrichments: React.FC = () => {
 		});
 	}, [enrichments, search]);
 
+	// Priority is the column that decides which rule wins a conflict, so it starts the
+	// table sorted the way enrichments actually execute: highest first. The other
+	// columns sort as text.
+	const { sorted, sortKey, direction, toggle } = useTableSort(
+		filtered,
+		{
+			name: (e: AlertEnrichment) => e.name,
+			priority: (e: AlertEnrichment) => e.priority,
+			match: (e: AlertEnrichment) => (e.matchAll ? 'All alerts' : getNameNeedles(e).join(', ')),
+			enrichment: (e: AlertEnrichment) =>
+				(e.addFields ?? []).map((f) => `${f.key}=${f.value}`).join(', ') || e.summaryTemplate || '',
+		},
+		{ initialKey: 'priority', initialDirection: 'desc' }
+	);
+
 	const handleDelete = async () => {
 		if (!deleting) return;
 		try {
@@ -164,10 +180,39 @@ const Enrichments: React.FC = () => {
 						<Table>
 							<TableHeader>
 								<TableRow>
-									<TableHead>Name</TableHead>
-									<TableHead className="w-[90px]">Priority</TableHead>
-									<TableHead>Match</TableHead>
-									<TableHead>Enrichment</TableHead>
+									<SortableTableHead
+										sortKey="name"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Name
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="priority"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+										className="w-[90px]"
+									>
+										Priority
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="match"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Match
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="enrichment"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Enrichment
+									</SortableTableHead>
 									<TableHead className="text-right">Actions</TableHead>
 								</TableRow>
 							</TableHeader>
@@ -208,7 +253,7 @@ const Enrichments: React.FC = () => {
 										</TableCell>
 									</TableRow>
 								) : (
-									filtered.map((e) => (
+									sorted.map((e) => (
 										<TableRow key={e.id} className="align-top">
 											<TableCell className="max-w-[220px]">
 												<div className="font-medium truncate">{e.name}</div>

--- a/apps/client/src/pages/MutePolicies.tsx
+++ b/apps/client/src/pages/MutePolicies.tsx
@@ -20,11 +20,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useDeleteMutePolicy, useMutePolicies } from '@/hooks/queries/mute-policies';
 import { getLabelMatcherGroups, MutePolicy, getNameNeedles, MutePolicySchedule } from '@OpsiMate/shared';
 import { BellOff, Calendar, CheckCircle2, Clock, Hourglass, Pencil, Plus, Repeat, Search, Trash2 } from 'lucide-react';
-import {
-	describeMatcherCriteria,
-	hasMatcherCriteria,
-	MatcherGroupBadges,
-} from '@/components/shared/MatcherGroupsEditor';
+import { describeCriteriaScope, hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { useMemo, useState } from 'react';
 
@@ -190,10 +186,7 @@ const MutePolicies: React.FC = () => {
 		status: (s: MutePolicy) => STATUS_ORDER[getStatus(s)],
 		// Everything the Match column renders, in the order it renders it: comparing
 		// only part of it would make rows with visibly different criteria sort as equal.
-		match: (s: MutePolicy) =>
-			s.matchAll
-				? 'All alerts'
-				: [getNameNeedles(s).join(', '), describeMatcherCriteria(s)].filter(Boolean).join(' '),
+		match: (s: MutePolicy) => describeCriteriaScope(s, s.matchAll),
 		// A recurring policy shows a real end time, so it sorts by when its window next
 		// closes — not as "no end". Only a genuinely indefinite policy is absent here.
 		window: (s: MutePolicy) => {

--- a/apps/client/src/pages/MutePolicies.tsx
+++ b/apps/client/src/pages/MutePolicies.tsx
@@ -21,6 +21,7 @@ import { useDeleteMutePolicy, useMutePolicies } from '@/hooks/queries/mute-polic
 import { getLabelMatcherGroups, MutePolicy, getNameNeedles } from '@OpsiMate/shared';
 import { BellOff, Calendar, CheckCircle2, Clock, Hourglass, Pencil, Plus, Repeat, Search, Trash2 } from 'lucide-react';
 import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
+import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { useMemo, useState } from 'react';
 
 type MutePolicyStatus = 'active' | 'scheduled' | 'expired';
@@ -153,6 +154,18 @@ const MutePolicies: React.FC = () => {
 		});
 	}, [mutePolicies, search]);
 
+	// Status sorts by lifecycle (active first, then scheduled, then expired) rather than
+	// alphabetically — "what is muting things right now" is the question the column
+	// answers. Window sorts by end time, with indefinite policies last: they never end,
+	// so they are not "soonest".
+	const STATUS_ORDER: Record<MutePolicyStatus, number> = { active: 0, scheduled: 1, expired: 2 };
+	const { sorted, sortKey, direction, toggle } = useTableSort(filtered, {
+		name: (s: MutePolicy) => s.name,
+		status: (s: MutePolicy) => STATUS_ORDER[getStatus(s)],
+		match: (s: MutePolicy) => (s.matchAll ? 'All alerts' : getNameNeedles(s).join(', ')),
+		window: (s: MutePolicy) => (s.endsAt ? new Date(s.endsAt).getTime() : null),
+	});
+
 	const handleDelete = async () => {
 		if (!deleting) return;
 		try {
@@ -213,10 +226,38 @@ const MutePolicies: React.FC = () => {
 						<Table>
 							<TableHeader>
 								<TableRow>
-									<TableHead>Name</TableHead>
-									<TableHead>Status</TableHead>
-									<TableHead>Match</TableHead>
-									<TableHead>Window</TableHead>
+									<SortableTableHead
+										sortKey="name"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Name
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="status"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Status
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="match"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Match
+									</SortableTableHead>
+									<SortableTableHead
+										sortKey="window"
+										activeKey={sortKey}
+										direction={direction}
+										onToggle={toggle}
+									>
+										Window
+									</SortableTableHead>
 									<TableHead className="text-right">Actions</TableHead>
 								</TableRow>
 							</TableHeader>
@@ -257,7 +298,7 @@ const MutePolicies: React.FC = () => {
 										</TableCell>
 									</TableRow>
 								) : (
-									filtered.map((s) => {
+									sorted.map((s) => {
 										const status = getStatus(s);
 										return (
 											<TableRow key={s.id} className="align-top">

--- a/apps/client/src/pages/MutePolicies.tsx
+++ b/apps/client/src/pages/MutePolicies.tsx
@@ -18,9 +18,13 @@ import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useToast } from '@/hooks/use-toast';
 import { useDeleteMutePolicy, useMutePolicies } from '@/hooks/queries/mute-policies';
-import { getLabelMatcherGroups, MutePolicy, getNameNeedles } from '@OpsiMate/shared';
+import { getLabelMatcherGroups, MutePolicy, getNameNeedles, MutePolicySchedule } from '@OpsiMate/shared';
 import { BellOff, Calendar, CheckCircle2, Clock, Hourglass, Pencil, Plus, Repeat, Search, Trash2 } from 'lucide-react';
-import { hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
+import {
+	describeMatcherCriteria,
+	hasMatcherCriteria,
+	MatcherGroupBadges,
+} from '@/components/shared/MatcherGroupsEditor';
 import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { useMemo, useState } from 'react';
 
@@ -68,6 +72,28 @@ const relativeFromNow = (iso?: string | null): string => {
 	if (hours < 24) return future ? `in ${hours}h` : `${hours}h ago`;
 	const days = Math.round(hours / 24);
 	return future ? `in ${days}d` : `${days}d ago`;
+};
+
+// When a recurring window next closes, as an absolute timestamp. Schedules are weekly
+// (daysOfWeek + HH:MM in server-local time), so the next end is the soonest upcoming
+// occurrence across the policy's days; today counts only if its end time hasn't passed.
+const nextScheduleEnd = (schedule: MutePolicySchedule): number | null => {
+	if (!schedule.daysOfWeek?.length) return null;
+	const [endHour, endMinute] = schedule.endTime.split(':').map(Number);
+	if (!Number.isFinite(endHour) || !Number.isFinite(endMinute)) return null;
+	const now = new Date();
+	let soonest: number | null = null;
+	for (const day of schedule.daysOfWeek) {
+		const candidate = new Date(now);
+		candidate.setHours(endHour, endMinute, 0, 0);
+		const dayDelta = (day - now.getDay() + 7) % 7;
+		candidate.setDate(candidate.getDate() + dayDelta);
+		// Same weekday but already past today: that occurrence is next week.
+		if (candidate.getTime() <= now.getTime()) candidate.setDate(candidate.getDate() + 7);
+		const time = candidate.getTime();
+		if (soonest === null || time < soonest) soonest = time;
+	}
+	return soonest;
 };
 
 const StatusBadge = ({ status }: { status: MutePolicyStatus }) => {
@@ -162,8 +188,18 @@ const MutePolicies: React.FC = () => {
 	const { sorted, sortKey, direction, toggle } = useTableSort(filtered, {
 		name: (s: MutePolicy) => s.name,
 		status: (s: MutePolicy) => STATUS_ORDER[getStatus(s)],
-		match: (s: MutePolicy) => (s.matchAll ? 'All alerts' : getNameNeedles(s).join(', ')),
-		window: (s: MutePolicy) => (s.endsAt ? new Date(s.endsAt).getTime() : null),
+		// Everything the Match column renders, in the order it renders it: comparing
+		// only part of it would make rows with visibly different criteria sort as equal.
+		match: (s: MutePolicy) =>
+			s.matchAll
+				? 'All alerts'
+				: [getNameNeedles(s).join(', '), describeMatcherCriteria(s)].filter(Boolean).join(' '),
+		// A recurring policy shows a real end time, so it sorts by when its window next
+		// closes — not as "no end". Only a genuinely indefinite policy is absent here.
+		window: (s: MutePolicy) => {
+			if (s.endsAt) return new Date(s.endsAt).getTime();
+			return s.schedule ? nextScheduleEnd(s.schedule) : null;
+		},
 	});
 
 	const handleDelete = async () => {

--- a/apps/client/src/test/describeCriteriaScope.test.ts
+++ b/apps/client/src/test/describeCriteriaScope.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+import { MatcherCriteria } from '@OpsiMate/shared';
+import { describeCriteriaScope } from '@/components/shared/MatcherGroupsEditor';
+
+// The rule tables sort their Match / Applies-to column by this string, so it has to be
+// the whole cell: anything it leaves out makes two visibly different rows sort as equal,
+// which reads as the sort being broken.
+
+describe('describeCriteriaScope', () => {
+	test('name needles read the way the badge writes them', () => {
+		expect(describeCriteriaScope({ nameContainsAny: ['cpu', 'mem'] } as MatcherCriteria)).toBe(
+			'name ~ "cpu" or "mem"'
+		);
+	});
+
+	test('label matchers keep their AND / OR structure', () => {
+		const criteria = {
+			labelMatcherGroups: [
+				[
+					{ key: 'env', value: 'prod' },
+					{ key: 'team', value: 'db', op: 'contains' },
+				],
+				[{ key: 'env', value: 'staging' }],
+			],
+		} as unknown as MatcherCriteria;
+		expect(describeCriteriaScope(criteria)).toBe('env=prod AND team~db OR env=staging');
+	});
+
+	test('name and labels appear in the order the cell renders them', () => {
+		const criteria = {
+			nameContains: 'disk',
+			labelMatchers: [{ key: 'env', value: 'prod' }],
+		} as unknown as MatcherCriteria;
+		expect(describeCriteriaScope(criteria)).toBe('name ~ "disk" env=prod');
+	});
+
+	// matchAll is NOT exclusive with name needles: a policy can show both badges. Keying
+	// off matchAll alone collapsed every such rule to bare "All alerts", so rules with
+	// different names sorted as identical.
+	test('a match-all rule that also has a name keeps the name in the key', () => {
+		expect(describeCriteriaScope({ nameContains: 'disk' } as MatcherCriteria, true)).toBe(
+			'name ~ "disk" All alerts'
+		);
+		expect(describeCriteriaScope({ nameContains: 'cpu' } as MatcherCriteria, true)).not.toBe(
+			describeCriteriaScope({ nameContains: 'disk' } as MatcherCriteria, true)
+		);
+	});
+
+	test('match-all replaces the matchers rather than joining them', () => {
+		const criteria = { labelMatchers: [{ key: 'env', value: 'prod' }] } as unknown as MatcherCriteria;
+		expect(describeCriteriaScope(criteria, true)).toBe('All alerts');
+	});
+
+	test('no criteria at all is the empty string, which useTableSort treats as absent', () => {
+		expect(describeCriteriaScope({} as MatcherCriteria)).toBe('');
+	});
+});

--- a/apps/client/src/test/describeEnrichmentEffects.test.ts
+++ b/apps/client/src/test/describeEnrichmentEffects.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+import { AlertEnrichment } from '@OpsiMate/shared';
+import { describeEnrichmentEffects } from '@/pages/Enrichments';
+
+// The Enrichment column sorts by this string, so it has to read like the badges do.
+// These assertions pin the exact wording — if EffectBadges changes its decorations and
+// this is not updated, the sort quietly stops agreeing with the column.
+
+const enrichment = (partial: Partial<AlertEnrichment>): AlertEnrichment =>
+	({ id: 1, name: 'r', addFields: [], ...partial }) as AlertEnrichment;
+
+describe('describeEnrichmentEffects', () => {
+	test('fields carry the badge\'s "+" prefix', () => {
+		expect(describeEnrichmentEffects(enrichment({ addFields: [{ key: 'severity', value: 'info' }] }))).toBe(
+			'+severity=info'
+		);
+	});
+
+	test('the summary template carries its "summary: " prefix', () => {
+		expect(describeEnrichmentEffects(enrichment({ summaryTemplate: '{{summary}} hi' }))).toBe(
+			'summary: {{summary}} hi'
+		);
+	});
+
+	// The badge renders only the label, so the key must too: keying off the url when the
+	// label is blank makes two identical-looking rows sort apart.
+	test('links contribute their label, never the url behind it', () => {
+		const withLink = enrichment({
+			addLinks: [{ label: 'Runbook', url: 'https://wiki.example.com/zzz-sorts-last' }],
+		});
+		expect(describeEnrichmentEffects(withLink)).toBe('Runbook');
+		expect(describeEnrichmentEffects(withLink)).not.toContain('wiki.example.com');
+	});
+
+	test('everything appears in the order the badges render', () => {
+		const full = enrichment({
+			addFields: [
+				{ key: 'a', value: '1' },
+				{ key: 'b', value: '2' },
+			],
+			addLinks: [{ label: 'Dash', url: 'u' }],
+			summaryTemplate: 'S',
+		});
+		expect(describeEnrichmentEffects(full)).toBe('+a=1 +b=2 Dash summary: S');
+	});
+
+	test('a rule with no effects is empty, which useTableSort treats as absent', () => {
+		expect(describeEnrichmentEffects(enrichment({}))).toBe('');
+	});
+
+	test('two rules with different effects never produce the same key', () => {
+		const a = describeEnrichmentEffects(enrichment({ addFields: [{ key: 'k', value: '1' }] }));
+		const b = describeEnrichmentEffects(enrichment({ addFields: [{ key: 'k', value: '2' }] }));
+		expect(a).not.toBe(b);
+	});
+});

--- a/apps/client/src/test/useTableSort.test.tsx
+++ b/apps/client/src/test/useTableSort.test.tsx
@@ -58,11 +58,11 @@ describe('useTableSort', () => {
 	test('missing values park at the end in BOTH directions', () => {
 		const { result } = setup();
 		act(() => result.current.toggle('window'));
-		expect(result.current.sorted.at(-1)?.name).toBe('Alpha');
+		expect(result.current.sorted[result.current.sorted.length - 1]?.name).toBe('Alpha');
 		act(() => result.current.toggle('window'));
 		expect(result.current.direction).toBe('desc');
 		// Still last: "no end date" is absence, not a small value.
-		expect(result.current.sorted.at(-1)?.name).toBe('Alpha');
+		expect(result.current.sorted[result.current.sorted.length - 1]?.name).toBe('Alpha');
 	});
 
 	test('an initial key sorts on first render without a click', () => {

--- a/apps/client/src/test/useTableSort.test.tsx
+++ b/apps/client/src/test/useTableSort.test.tsx
@@ -80,6 +80,23 @@ describe('useTableSort', () => {
 		expect(result.current.sorted.map((r) => r.priority)).toEqual([10, 2, 1, 1]);
 	});
 
+	// new Date('nonsense').getTime() is NaN, and NaN loses every comparison, so an
+	// unguarded comparator claims "a first" for BOTH (a,b) and (b,a). Array.sort is
+	// entitled to produce any order from that, so the assertion is that the good rows
+	// stay correctly ordered and the bad one is treated as absent rather than that the
+	// bad row lands anywhere in particular.
+	test('an unparseable date sorts as missing instead of scrambling the order', () => {
+		const withBadDate = [...rows, { name: 'broken', priority: 3, endsAt: 'not-a-date' }];
+		const { result } = renderHook(() => useTableSort(withBadDate, accessors));
+		act(() => result.current.toggle('window'));
+
+		const order = result.current.sorted.map((r) => r.name);
+		const dated = order.filter((n) => n === 'policy 10' || n === 'policy 2' || n === 'beta');
+		expect(dated).toEqual(['policy 10', 'policy 2', 'beta']);
+		// Both value-less rows park at the end, in either order.
+		expect(order.slice(-2).sort()).toEqual(['Alpha', 'broken']);
+	});
+
 	test('an initial key sorts on first render without a click', () => {
 		const { result } = setup({ initialKey: 'priority', initialDirection: 'desc' });
 		expect(result.current.sorted.map((r) => r.priority)).toEqual([10, 2, 1, 1]);

--- a/apps/client/src/test/useTableSort.test.tsx
+++ b/apps/client/src/test/useTableSort.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { useTableSort } from '@/components/shared/SortableTable';
+
+interface Row {
+	name: string;
+	priority: number;
+	endsAt: string | null;
+}
+
+const rows: Row[] = [
+	{ name: 'beta', priority: 2, endsAt: '2026-03-01T00:00:00Z' },
+	{ name: 'Alpha', priority: 10, endsAt: null },
+	{ name: 'policy 10', priority: 1, endsAt: '2026-01-01T00:00:00Z' },
+	{ name: 'policy 2', priority: 1, endsAt: '2026-02-01T00:00:00Z' },
+];
+
+const accessors = {
+	name: (r: Row) => r.name,
+	priority: (r: Row) => r.priority,
+	window: (r: Row) => (r.endsAt ? new Date(r.endsAt).getTime() : null),
+};
+
+const setup = (initial?: Parameters<typeof useTableSort<Row, keyof typeof accessors>>[2]) =>
+	renderHook(() => useTableSort(rows, accessors, initial));
+
+describe('useTableSort', () => {
+	test('unsorted keeps the list order', () => {
+		const { result } = setup();
+		expect(result.current.sorted.map((r) => r.name)).toEqual(['beta', 'Alpha', 'policy 10', 'policy 2']);
+	});
+
+	test('first click sorts ascending, second reverses', () => {
+		const { result } = setup();
+		act(() => result.current.toggle('priority'));
+		expect(result.current.sorted.map((r) => r.priority)).toEqual([1, 1, 2, 10]);
+		act(() => result.current.toggle('priority'));
+		expect(result.current.direction).toBe('desc');
+		expect(result.current.sorted.map((r) => r.priority)).toEqual([10, 2, 1, 1]);
+	});
+
+	test('switching column starts ascending again rather than inheriting the direction', () => {
+		const { result } = setup();
+		act(() => result.current.toggle('priority'));
+		act(() => result.current.toggle('priority'));
+		expect(result.current.direction).toBe('desc');
+		act(() => result.current.toggle('name'));
+		expect(result.current.direction).toBe('asc');
+	});
+
+	test('names sort case-insensitively and numerically, not by char code', () => {
+		const { result } = setup();
+		act(() => result.current.toggle('name'));
+		// 'Alpha' before 'beta' (case-insensitive), and 'policy 2' before 'policy 10'.
+		expect(result.current.sorted.map((r) => r.name)).toEqual(['Alpha', 'beta', 'policy 2', 'policy 10']);
+	});
+
+	test('missing values park at the end in BOTH directions', () => {
+		const { result } = setup();
+		act(() => result.current.toggle('window'));
+		expect(result.current.sorted.at(-1)?.name).toBe('Alpha');
+		act(() => result.current.toggle('window'));
+		expect(result.current.direction).toBe('desc');
+		// Still last: "no end date" is absence, not a small value.
+		expect(result.current.sorted.at(-1)?.name).toBe('Alpha');
+	});
+
+	test('an initial key sorts on first render without a click', () => {
+		const { result } = setup({ initialKey: 'priority', initialDirection: 'desc' });
+		expect(result.current.sorted.map((r) => r.priority)).toEqual([10, 2, 1, 1]);
+	});
+
+	test('sorting never mutates the caller list', () => {
+		const original = [...rows];
+		const { result } = setup();
+		act(() => result.current.toggle('name'));
+		expect(rows).toEqual(original);
+	});
+});

--- a/apps/client/src/test/useTableSort.test.tsx
+++ b/apps/client/src/test/useTableSort.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { describe, expect, test } from 'vitest';
 import { useTableSort } from '@/components/shared/SortableTable';
 
@@ -63,6 +64,20 @@ describe('useTableSort', () => {
 		expect(result.current.direction).toBe('desc');
 		// Still last: "no end date" is absence, not a small value.
 		expect(result.current.sorted[result.current.sorted.length - 1]?.name).toBe('Alpha');
+	});
+
+	// StrictMode double-invokes state updaters. An updater that sets OTHER state from
+	// inside itself therefore toggles twice and lands back where it started, so the
+	// second click on a column appears to do nothing — only in a StrictMode build,
+	// which is how the app actually runs. Every other test here passes against that
+	// bug; this one is the reason the hook keeps key and direction in one state value.
+	test('reversing works under StrictMode, where updaters run twice', () => {
+		const { result } = renderHook(() => useTableSort(rows, accessors), { wrapper: StrictMode });
+		act(() => result.current.toggle('priority'));
+		expect(result.current.direction).toBe('asc');
+		act(() => result.current.toggle('priority'));
+		expect(result.current.direction).toBe('desc');
+		expect(result.current.sorted.map((r) => r.priority)).toEqual([10, 2, 1, 1]);
 	});
 
 	test('an initial key sorts on first render without a click', () => {


### PR DESCRIPTION
## What
The three rule pages listed rows in one fixed order, so "which policies are active right now" or "which enrichment wins a conflict" meant reading every row. Their headers are now click-to-sort — same affordance as the alerts table (neutral glyph when idle, a single arrow when active), so sorting looks the same everywhere in the product.

One shared `useTableSort` + `SortableTableHead` rather than three implementations.

## Columns sort by meaning, not by rendered text
This is the part worth reviewing:

- **Status** orders by lifecycle — active, then scheduled, then expired — not alphabetically. Alphabetical would put Active/Expired/Scheduled in an order that answers no question anyone has.
- **Window** sorts by end time, with indefinite policies last: they never end, so they aren't "soonest".
- **Priority** sorts numerically and opens the enrichments table in execution order (highest first), which is the order that actually decides conflicts.
- **Applies to / Match** sort by the rule's scope text; an action with no criteria has no scope, so it parks at the end.

**Absent values park at the END in both directions.** An indefinite window or a scope-less action is an *absence*, not a small value — flipping direction shouldn't drag blanks to the top.

**Names use `localeCompare` with `numeric: true`**, so `policy 2` precedes `policy 10` and case doesn't separate otherwise-adjacent names.

## Accessibility
Headers are real `<button>`s inside the cell — focusable and keyboard-operable, which a click handler on the `<th>` would not be — and each cell carries `aria-sort`.

## Verification
Live on all three pages: mute-policy **Status** groups 4 Active before 7 Expired and reverses correctly (`aria-sort` flips with it); **enrichments** open sorted priority-desc; action **Type** reverses to Teams/Slack/Jira/HTTP.

7 unit tests: toggle asc→desc, direction resets when switching column, natural order until first click, initial-key sorting, blanks-last in both directions, locale/numeric name ordering, and that sorting never mutates the caller's array.

192 client tests, 4/4 builds, lint and prettier clean, no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sortable columns to Actions, Enrichments, and Mute Policies tables.
  - Added ascending, descending, and inactive sort indicators with keyboard and accessibility support.
  - Added sensible default sorting, including enrichment priority and mute-policy lifecycle status.
  - Sorting supports text, numbers, booleans, missing values, and stable ordering.
  - Added readable matching-criteria descriptions for sorting and display.

- **Tests**
  - Added coverage for sorting directions, column changes, default sorting, missing values, and preserving source data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->