### PR TITLE
feat(alerts): keyboard row navigation + bolder filter headlines

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertsTable.tsx
@@ -25,6 +25,7 @@ import { ColumnSettingsDropdown } from './ColumnSettingsDropdown';
 import { GroupByControls } from './GroupByControls';
 import {
 	useAlertGrouping,
+	useAlertKeyboardNav,
 	useAlertSelection,
 	useAlertSorting,
 	useColumnResize,
@@ -230,6 +231,9 @@ export const AlertsTable = ({
 		virtualizer.measure();
 	}, [expandRows, virtualizer]);
 
+	// ArrowUp/ArrowDown move the details-sidebar selection through the rows.
+	useAlertKeyboardNav({ flatRows, activeAlertId, onAlertClick, virtualizer, scrollerRef });
+
 	const virtualItems = virtualizer.getVirtualItems();
 
 	// Infinite scroll. onEndReached is defined only while more pages exist (the parent
@@ -392,7 +396,10 @@ export const AlertsTable = ({
 							    an overflow-auto div, which turned the header into a second,
 							    independently scrollable region with its own scrollbar. Opaque
 							    background because rows now scroll underneath it. */}
-							<div className="sticky top-0 z-10">
+							{/* data-table-sticky-header: keyboard navigation measures this (and the
+							    hanging group copies below) to know how much of the scroller's top is
+							    occluded — the virtualizer's own scroll math can't see sticky overlays. */}
+							<div className="sticky top-0 z-10" data-table-sticky-header>
 								<div className="border-b bg-background">
 									<table className="table-fixed w-full text-sm">
 										<TableHeader>
@@ -552,7 +559,7 @@ export const AlertsTable = ({
 								    bg-muted/50, and at rest the pinned copy sits exactly on the real
 								    group row — without this backing the two translucent layers stack
 								    and the first group renders darker than every other one. */}
-									<div className="absolute left-0 right-0 top-0 bg-background">
+									<div className="absolute left-0 right-0 top-0 bg-background" data-table-sticky-hang>
 										{activeStickyHeaders.map((item) => (
 											<StickyGroupHeader
 												key={`sticky-${item.type === 'group' ? item.key : ''}`}

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/index.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useAlertGrouping';
+export * from './useAlertKeyboardNav';
 export * from './useAlertSorting';
 export * from './useAlertSelection';
 export * from './useDragAutoScroll';

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertKeyboardNav.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertKeyboardNav.ts
@@ -1,0 +1,230 @@
+import { Alert } from '@OpsiMate/shared';
+import { Virtualizer } from '@tanstack/react-virtual';
+import { RefObject, useEffect, useRef } from 'react';
+import { FlatGroupItem } from '../AlertsTable.types';
+
+interface UseAlertKeyboardNavOptions {
+	flatRows: FlatGroupItem[];
+	// Alert currently open in the details sidebar; arrows move relative to it.
+	activeAlertId: string | null;
+	onAlertClick?: (alert: Alert) => void;
+	virtualizer: Virtualizer<HTMLDivElement, Element>;
+	scrollerRef: RefObject<HTMLDivElement | null>;
+}
+
+// One registered entry per mounted AlertsTable (split-by-assignment renders several).
+interface NavInstance {
+	getScroller: () => HTMLDivElement | null;
+	containsActive: () => boolean;
+	navigate: (delta: 1 | -1) => void;
+}
+
+// Arrows must not fire while the user is typing or inside any overlay that has its own
+// arrow-key semantics (Radix menus/selects/dialogs render in portals with these roles;
+// the popper wrapper catches popovers like the date-range calendar).
+const OVERLAY_SELECTOR =
+	'[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"], [role="combobox"], [data-radix-popper-content-wrapper]';
+
+const isTextEntry = (el: EventTarget | null): boolean => {
+	if (!(el instanceof HTMLElement)) return false;
+	if (el.isContentEditable) return true;
+	return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT';
+};
+
+// ONE window listener shared by every mounted table, dispatching to a single owner —
+// per-instance listeners would each move their own rows on the same keypress in the
+// split-by-assignment view. Owner resolution: the pane whose rows contain the alert
+// that is open in the details sidebar; failing that, the pane the user last
+// clicked/focused into; failing that, the first pane on screen.
+const instances = new Set<NavInstance>();
+
+const resolveOwner = (): NavInstance | null => {
+	const mounted = [...instances].filter((i) => i.getScroller());
+	if (mounted.length === 0) return null;
+	const withActive = mounted.find((i) => i.containsActive());
+	if (withActive) return withActive;
+	const focused = mounted.find((i) => i.getScroller()!.contains(document.activeElement));
+	if (focused) return focused;
+	return mounted.sort((a, b) =>
+		a.getScroller()!.compareDocumentPosition(b.getScroller()!) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+	)[0];
+};
+
+const handleWindowKeyDown = (e: KeyboardEvent) => {
+	if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+	// Modified arrows are someone else's shortcut (e.g. Alt+arrows navigates history).
+	if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+	if (isTextEntry(e.target)) return;
+	if (e.target instanceof HTMLElement && e.target.closest(OVERLAY_SELECTOR)) return;
+	const owner = resolveOwner();
+	if (!owner) return;
+	// Also claims the boundary press (first/last row): the key is "spent" on row
+	// navigation either way, rather than falling through to a surprise page scroll.
+	e.preventDefault();
+	owner.navigate(e.key === 'ArrowDown' ? 1 : -1);
+};
+
+// ArrowUp/ArrowDown step the details-sidebar selection through the table's rows —
+// group headers are skipped, collapsed groups' alerts are simply absent from flatRows.
+// With nothing selected, Down starts at the first row and Up at the last. Selection
+// goes through onAlertClick, so keyboard and mouse share one code path (including
+// mark-as-read).
+export const useAlertKeyboardNav = ({
+	flatRows,
+	activeAlertId,
+	onAlertClick,
+	virtualizer,
+	scrollerRef,
+}: UseAlertKeyboardNavOptions) => {
+	// The window listener lives for the instance's lifetime; reading through a ref keeps
+	// it current without re-registering (and re-ordering the registry) every render.
+	const latest = useRef({ flatRows, activeAlertId, onAlertClick, virtualizer });
+	latest.current = { flatRows, activeAlertId, onAlertClick, virtualizer };
+
+	useEffect(() => {
+		// The row index the keyboard last navigated to, or null when nothing is pinned.
+		// Only the LATEST navigation may correct the scroll — under key-repeat, stale
+		// loops from earlier steps would tug the scroller back to old targets.
+		let pendingScrollIndex: number | null = null;
+		let pendingAlertId: string | null = null;
+
+		// scrollToIndex alone is not enough, for two reasons. (1) The scroller's top is
+		// occluded by the sticky column header (and, when grouping, the pinned group
+		// copies), which the virtualizer's scroll math knows nothing about — a row it
+		// considers visible can sit fully under the header or just below the fold.
+		// (2) The layout keeps moving after the keypress: the selection render, the
+		// virtualizer's re-measure, and the debounce-coalesced mark-read refetch each
+		// shift rows by a few px. So the target is held visible by a BOUNDED per-frame
+		// rect check. Bounded matters: an unconditional every-frame nudge oscillates on
+		// sub-pixel row fractions — each nudge fires a scroll event and a render, 60
+		// times a second, forever. Hence the three stop conditions: an epsilon below
+		// which the row counts as in place, a no-progress check for when scrollTop is
+		// clamped at its limit (the row cannot be brought closer), and a frame budget
+		// long enough (~700ms) to outlast the refetch-driven shifts. A newer keypress
+		// retargets the pin; wheel/touch/mousedown releases it (it must never fight a
+		// manual scroll).
+		const PIN_FRAME_BUDGET = 45;
+		const PIN_EPSILON_PX = 1.5;
+		const pinTargetVisible = (attempts: number) => {
+			const rowIndex = pendingScrollIndex;
+			if (rowIndex === null) return;
+			if (attempts >= PIN_FRAME_BUDGET) {
+				pendingScrollIndex = null;
+				return;
+			}
+			const next = () => requestAnimationFrame(() => pinTargetVisible(attempts + 1));
+			const scroller = scrollerRef.current;
+			if (!scroller) {
+				// Scroller unmounted (tab switch, empty-state flip). Release rather than
+				// bare-return: navigate() only starts a loop when none is pinned, so a
+				// silent exit that leaves the pin set would strand navigation loop-less.
+				pendingScrollIndex = null;
+				return;
+			}
+			// The refetch can reorder rows — if this index no longer holds the alert we
+			// navigated to, the pin is meaningless; let go rather than chase a stranger.
+			const target = latest.current.flatRows[rowIndex];
+			if (!target || target.type !== 'leaf' || target.alert.id !== pendingAlertId) {
+				pendingScrollIndex = null;
+				return;
+			}
+			const row = scroller.querySelector(`[data-index="${rowIndex}"]`);
+			if (!row) {
+				// Not rendered yet (long jump) — the scrollToIndex that accompanied this
+				// pin brings it into the window within a frame or two.
+				next();
+				return;
+			}
+			const scRect = scroller.getBoundingClientRect();
+			// Client box, not rect bottom: the rect includes the horizontal scrollbar
+			// (~15px), and a row "visible" against the rect can sit entirely under it.
+			const visibleBottom = scRect.top + scroller.clientTop + scroller.clientHeight;
+			let visibleTop = scRect.top;
+			const sticky = scroller.querySelector('[data-table-sticky-header]');
+			if (sticky) {
+				visibleTop = Math.max(visibleTop, sticky.getBoundingClientRect().bottom);
+				// Pinned group copies hang BELOW the header via absolute positioning,
+				// extending the occlusion without extending the header's own rect.
+				const hang = sticky.querySelector('[data-table-sticky-hang]');
+				if (hang) visibleTop = Math.max(visibleTop, hang.getBoundingClientRect().bottom);
+			}
+			const rowRect = row.getBoundingClientRect();
+			const delta =
+				rowRect.top < visibleTop - PIN_EPSILON_PX
+					? rowRect.top - visibleTop
+					: rowRect.bottom > visibleBottom + PIN_EPSILON_PX
+						? rowRect.bottom - visibleBottom
+						: 0;
+			if (delta !== 0) {
+				const before = scroller.scrollTop;
+				scroller.scrollTop = before + delta;
+				// Clamped at the scroll limit: the row cannot be brought closer, and
+				// retrying every frame would nudge-and-render forever.
+				if (Math.abs(scroller.scrollTop - before) < 0.5) {
+					pendingScrollIndex = null;
+					return;
+				}
+			}
+			// In place (or just adjusted): keep watching until the budget runs out —
+			// the selection render and refetch shift rows AFTER first convergence.
+			next();
+		};
+
+		const releasePin = () => {
+			pendingScrollIndex = null;
+		};
+
+		const instance: NavInstance = {
+			getScroller: () => scrollerRef.current,
+			containsActive: () => {
+				const { flatRows: rows, activeAlertId: id } = latest.current;
+				return id !== null && rows.some((r) => r.type === 'leaf' && r.alert.id === id);
+			},
+			navigate: (delta) => {
+				const { flatRows: rows, activeAlertId: id, onAlertClick: open, virtualizer: v } = latest.current;
+				if (!open) return;
+				const alertRowIndices = rows.flatMap((r, i) => (r.type === 'leaf' ? [i] : []));
+				if (alertRowIndices.length === 0) return;
+				const currentPos =
+					id === null ? -1 : alertRowIndices.findIndex((i) => (rows[i] as { alert: Alert }).alert.id === id);
+				const nextPos =
+					currentPos === -1
+						? delta === 1
+							? 0
+							: alertRowIndices.length - 1
+						: Math.min(Math.max(currentPos + delta, 0), alertRowIndices.length - 1);
+				const rowIndex = alertRowIndices[nextPos];
+				const alert = (rows[rowIndex] as { alert: Alert }).alert;
+				v.scrollToIndex(rowIndex, { align: 'auto' });
+				const wasPinned = pendingScrollIndex !== null;
+				pendingScrollIndex = rowIndex;
+				pendingAlertId = alert.id;
+				// One pin loop at a time: retargeting an already-running loop must not
+				// stack a second rAF chain on top of it. (The running loop keeps its own
+				// attempt count — retargeting mid-flight is fine, the budget just isn't
+				// reset, and the next keypress starts fresh anyway.)
+				if (!wasPinned) requestAnimationFrame(() => pinTargetVisible(0));
+				// Guarded: onAlertClick TOGGLES on a repeated id, so calling it at a list
+				// boundary (where the step clamps in place) would close the sidebar.
+				if (alert.id !== id) open(alert);
+			},
+		};
+		instances.add(instance);
+		if (instances.size === 1) window.addEventListener('keydown', handleWindowKeyDown);
+		// Any manual scroll gesture releases the pin — it must never fight the user.
+		// Window-level (not scroller-level): the scroller node is remounted on tab
+		// switches and empty-state flips, and a listener bound to a dead node is gone.
+		window.addEventListener('wheel', releasePin, { passive: true });
+		window.addEventListener('touchstart', releasePin, { passive: true });
+		window.addEventListener('mousedown', releasePin);
+		return () => {
+			// Ends the pin loop: its next frame sees null and exits.
+			pendingScrollIndex = null;
+			window.removeEventListener('wheel', releasePin);
+			window.removeEventListener('touchstart', releasePin);
+			window.removeEventListener('mousedown', releasePin);
+			instances.delete(instance);
+			if (instances.size === 0) window.removeEventListener('keydown', handleWindowKeyDown);
+		};
+	}, [scrollerRef]);
+};

--- a/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertKeyboardNav.ts
+++ b/apps/client/src/components/Alerts/AlertsTable/hooks/useAlertKeyboardNav.ts
@@ -12,9 +12,19 @@ interface UseAlertKeyboardNavOptions {
 	scrollerRef: RefObject<HTMLDivElement | null>;
 }
 
+// A leaf row paired with its index in flatRows: stepping walks alerts only, but the
+// virtualizer is addressed by flatRows position (group headers included).
+interface IndexedAlertRow {
+	rowIndex: number;
+	alert: Alert;
+}
+
 // One registered entry per mounted AlertsTable (split-by-assignment renders several).
 interface NavInstance {
 	getScroller: () => HTMLDivElement | null;
+	// False when the table has no alert rows or no click handler — the keypress is then
+	// left to its default (scrolling) instead of being swallowed by preventDefault.
+	canNavigate: () => boolean;
 	containsActive: () => boolean;
 	navigate: (delta: 1 | -1) => void;
 }
@@ -57,7 +67,7 @@ const handleWindowKeyDown = (e: KeyboardEvent) => {
 	if (isTextEntry(e.target)) return;
 	if (e.target instanceof HTMLElement && e.target.closest(OVERLAY_SELECTOR)) return;
 	const owner = resolveOwner();
-	if (!owner) return;
+	if (!owner || !owner.canNavigate()) return;
 	// Also claims the boundary press (first/last row): the key is "spent" on row
 	// navigation either way, rather than falling through to a surprise page scroll.
 	e.preventDefault();
@@ -176,6 +186,10 @@ export const useAlertKeyboardNav = ({
 
 		const instance: NavInstance = {
 			getScroller: () => scrollerRef.current,
+			canNavigate: () => {
+				const { flatRows: rows, onAlertClick: open } = latest.current;
+				return open !== undefined && rows.some((r) => r.type === 'leaf');
+			},
 			containsActive: () => {
 				const { flatRows: rows, activeAlertId: id } = latest.current;
 				return id !== null && rows.some((r) => r.type === 'leaf' && r.alert.id === id);
@@ -183,18 +197,20 @@ export const useAlertKeyboardNav = ({
 			navigate: (delta) => {
 				const { flatRows: rows, activeAlertId: id, onAlertClick: open, virtualizer: v } = latest.current;
 				if (!open) return;
-				const alertRowIndices = rows.flatMap((r, i) => (r.type === 'leaf' ? [i] : []));
-				if (alertRowIndices.length === 0) return;
-				const currentPos =
-					id === null ? -1 : alertRowIndices.findIndex((i) => (rows[i] as { alert: Alert }).alert.id === id);
+				// Leaf rows with their flatRows index, so scrollToIndex can address the
+				// virtualizer while stepping skips the group headers.
+				const alertRows: IndexedAlertRow[] = rows.flatMap((r, i) =>
+					r.type === 'leaf' ? [{ rowIndex: i, alert: r.alert }] : []
+				);
+				if (alertRows.length === 0) return;
+				const currentPos = id === null ? -1 : alertRows.findIndex((r) => r.alert.id === id);
 				const nextPos =
 					currentPos === -1
 						? delta === 1
 							? 0
-							: alertRowIndices.length - 1
-						: Math.min(Math.max(currentPos + delta, 0), alertRowIndices.length - 1);
-				const rowIndex = alertRowIndices[nextPos];
-				const alert = (rows[rowIndex] as { alert: Alert }).alert;
+							: alertRows.length - 1
+						: Math.min(Math.max(currentPos + delta, 0), alertRows.length - 1);
+				const { rowIndex, alert } = alertRows[nextPos];
 				v.scrollToIndex(rowIndex, { align: 'auto' });
 				const wasPinned = pendingScrollIndex !== null;
 				pendingScrollIndex = rowIndex;

--- a/apps/client/src/components/shared/FilterPanel.tsx
+++ b/apps/client/src/components/shared/FilterPanel.tsx
@@ -320,7 +320,7 @@ export const FilterPanel = ({
 								    so the chevron and the counts form one aligned column. */}
 									<AccordionTrigger className="pl-2 pr-3 py-1.5 hover:no-underline hover:bg-muted/50 text-foreground">
 										<div className="flex items-center justify-between w-full pr-2">
-											<span className="text-xs font-medium text-foreground">
+											<span className="text-xs font-semibold text-foreground">
 												{config.fieldLabels[field] || field}
 											</span>
 											{activeValues.length + excludedValues.length > 0 && (

--- a/apps/client/src/components/shared/FilterPanel.tsx
+++ b/apps/client/src/components/shared/FilterPanel.tsx
@@ -320,7 +320,7 @@ export const FilterPanel = ({
 								    so the chevron and the counts form one aligned column. */}
 									<AccordionTrigger className="pl-2 pr-3 py-1.5 hover:no-underline hover:bg-muted/50 text-foreground">
 										<div className="flex items-center justify-between w-full pr-2">
-											<span className="text-xs font-semibold text-foreground">
+											<span className="text-[13px] font-bold text-foreground">
 												{config.fieldLabels[field] || field}
 											</span>
 											{activeValues.length + excludedValues.length > 0 && (

--- a/apps/client/src/hooks/queries/alerts/useMarkAlertRead.ts
+++ b/apps/client/src/hooks/queries/alerts/useMarkAlertRead.ts
@@ -1,7 +1,23 @@
 import { alertsApi } from '@/lib/api';
 import { Alert } from '@OpsiMate/shared';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { QueryClient, useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../queryKeys';
+
+// Mark-read arrives in BURSTS: keyboard row navigation marks every unread row it steps
+// onto, several per second under key-repeat. Invalidating per settle refetches the whole
+// alerts prefix (list, facets, counts) once per step — a burst of redundant server
+// round-trips and list re-renders. The refetch only reconciles state the optimistic
+// update already applied, so one trailing invalidation after the burst carries the same
+// guarantee at a fraction of the cost. Module-level: every component's mutations share
+// one timer, which is exactly the coalescing we want.
+let invalidateTimer: number | null = null;
+const scheduleAlertsInvalidate = (queryClient: QueryClient) => {
+	if (invalidateTimer !== null) window.clearTimeout(invalidateTimer);
+	invalidateTimer = window.setTimeout(() => {
+		invalidateTimer = null;
+		void queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+	}, 400);
+};
 
 // Marks an alert as read (unread alerts render bold). Optimistic so the row un-bolds
 // immediately on click. Note: useAlerts keys its query as [...queryKeys.alerts, mode],
@@ -32,7 +48,7 @@ export const useMarkAlertRead = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: queryKeys.alerts });
+			scheduleAlertsInvalidate(queryClient);
 		},
 	});
 };

--- a/apps/client/src/hooks/queries/alerts/useMarkAlertRead.ts
+++ b/apps/client/src/hooks/queries/alerts/useMarkAlertRead.ts
@@ -19,6 +19,41 @@ const scheduleAlertsInvalidate = (queryClient: QueryClient) => {
 	}, 400);
 };
 
+// A page of the useAlerts infinite query, as far as this updater needs to know it.
+interface AlertsPageLike {
+	alerts?: Alert[];
+}
+interface InfiniteAlertsLike {
+	pages: AlertsPageLike[];
+}
+
+const hasPages = (value: object): value is InfiniteAlertsLike => Array.isArray((value as InfiniteAlertsLike).pages);
+
+// Applies isRead to one alert wherever it lives in a cached query, WITHOUT assuming the
+// cache's shape. The ['alerts'] prefix matches queries of several shapes — the infinite
+// list ({pages: [{alerts}]}), facets objects, match counts — and an updater that calls
+// .map on all of them throws on the first non-array. That throw is worse than a broken
+// un-bold: an exception in onMutate makes react-query SKIP mutationFn entirely, so the
+// server was never told either and the row stayed bold forever (broken since the list
+// became paginated; the immediate refetch used to mask the optimistic path before that).
+const markAlertReadInCache =
+	(alertId: string) =>
+	(old: unknown): unknown => {
+		if (!old || typeof old !== 'object') return old;
+		const markRead = (alert: Alert): Alert => (alert.id === alertId ? { ...alert, isRead: true } : alert);
+		if (Array.isArray(old)) return (old as Alert[]).map(markRead);
+		if (hasPages(old)) {
+			return {
+				...old,
+				pages: old.pages.map((page) =>
+					page && Array.isArray(page.alerts) ? { ...page, alerts: page.alerts.map(markRead) } : page
+				),
+			};
+		}
+		// Facets, counts, summaries — nothing here carries isRead; leave untouched.
+		return old;
+	};
+
 // Marks an alert as read (unread alerts render bold). Optimistic so the row un-bolds
 // immediately on click. Note: useAlerts keys its query as [...queryKeys.alerts, mode],
 // so we use prefix-matching setQueriesData rather than a single setQueryData.
@@ -35,11 +70,8 @@ export const useMarkAlertRead = () => {
 		},
 		onMutate: async (alertId: string) => {
 			await queryClient.cancelQueries({ queryKey: queryKeys.alerts });
-			const previous = queryClient.getQueriesData<Alert[]>({ queryKey: queryKeys.alerts });
-			queryClient.setQueriesData<Alert[]>({ queryKey: queryKeys.alerts }, (old) => {
-				if (!old) return old;
-				return old.map((alert) => (alert.id === alertId ? { ...alert, isRead: true } : alert));
-			});
+			const previous = queryClient.getQueriesData({ queryKey: queryKeys.alerts });
+			queryClient.setQueriesData({ queryKey: queryKeys.alerts }, markAlertReadInCache(alertId));
 			return { previous };
 		},
 		onError: (_err, _alertId, context) => {

--- a/apps/client/src/test/useAlertKeyboardNav.test.tsx
+++ b/apps/client/src/test/useAlertKeyboardNav.test.tsx
@@ -1,0 +1,140 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { Alert } from '@OpsiMate/shared';
+import { Virtualizer } from '@tanstack/react-virtual';
+import { useAlertKeyboardNav } from '@/components/Alerts/AlertsTable/hooks/useAlertKeyboardNav';
+import { FlatGroupItem } from '@/components/Alerts/AlertsTable/AlertsTable.types';
+
+// Geometry (scroll pinning) is exercised in a real browser; what jsdom CAN pin down is
+// the decision logic: which row a keypress selects, which guards swallow the event, and
+// which table owns the keyboard when several are mounted (split-by-owner panes).
+
+const alert = (id: string): Alert => ({ id }) as Alert;
+const leaf = (id: string): FlatGroupItem => ({ type: 'leaf', alert: alert(id) });
+const group = (key: string): FlatGroupItem =>
+	({
+		type: 'group',
+		key,
+		field: 'f',
+		value: key,
+		count: 1,
+		level: 0,
+		isExpanded: true,
+		groupStatus: 'firing',
+	}) as FlatGroupItem;
+
+interface HookSetup {
+	onAlertClick: ReturnType<typeof vi.fn>;
+	scrollToIndex: ReturnType<typeof vi.fn>;
+	unmount: () => void;
+	rerender: (next: { activeAlertId: string | null }) => void;
+}
+
+const setup = (rows: FlatGroupItem[], activeAlertId: string | null = null): HookSetup => {
+	const onAlertClick = vi.fn();
+	const scrollToIndex = vi.fn();
+	const virtualizer = { scrollToIndex } as unknown as Virtualizer<HTMLDivElement, Element>;
+	const scrollerRef = { current: document.createElement('div') };
+	const view = renderHook(
+		(props: { activeAlertId: string | null }) =>
+			useAlertKeyboardNav({
+				flatRows: rows,
+				activeAlertId: props.activeAlertId,
+				onAlertClick,
+				virtualizer,
+				scrollerRef,
+			}),
+		{ initialProps: { activeAlertId } }
+	);
+	return { onAlertClick, scrollToIndex, unmount: view.unmount, rerender: view.rerender };
+};
+
+const press = (key: string, init: KeyboardEventInit = {}) =>
+	act(() => {
+		window.dispatchEvent(new KeyboardEvent('keydown', { key, cancelable: true, ...init }));
+	});
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('useAlertKeyboardNav', () => {
+	test('ArrowDown with nothing active selects the first alert row, skipping a leading group header', () => {
+		const h = setup([group('g1'), leaf('a'), leaf('b')]);
+		press('ArrowDown');
+		expect(h.onAlertClick).toHaveBeenCalledTimes(1);
+		expect(h.onAlertClick.mock.calls[0][0].id).toBe('a');
+		// Scrolls to the flatRows index of the row, not its position among alerts only.
+		expect(h.scrollToIndex).toHaveBeenCalledWith(1, { align: 'auto' });
+		h.unmount();
+	});
+
+	test('ArrowUp with nothing active starts from the LAST row', () => {
+		const h = setup([leaf('a'), leaf('b'), leaf('c')]);
+		press('ArrowUp');
+		expect(h.onAlertClick.mock.calls[0][0].id).toBe('c');
+		h.unmount();
+	});
+
+	test('ArrowDown steps over group headers between alerts', () => {
+		const h = setup([leaf('a'), group('g'), leaf('b')], 'a');
+		press('ArrowDown');
+		expect(h.onAlertClick.mock.calls[0][0].id).toBe('b');
+		h.unmount();
+	});
+
+	test('a boundary press never re-clicks the active alert (onAlertClick toggles closed)', () => {
+		const h = setup([leaf('a'), leaf('b')], 'a');
+		press('ArrowUp');
+		expect(h.onAlertClick).not.toHaveBeenCalled();
+		h.unmount();
+	});
+
+	test('typing targets and modified arrows are left alone', () => {
+		const h = setup([leaf('a'), leaf('b')]);
+		const input = document.createElement('input');
+		document.body.appendChild(input);
+		act(() => {
+			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+		});
+		press('ArrowDown', { metaKey: true });
+		press('ArrowDown', { shiftKey: true });
+		expect(h.onAlertClick).not.toHaveBeenCalled();
+		h.unmount();
+	});
+
+	test('arrows inside an overlay (dialog/menu) are left alone', () => {
+		const h = setup([leaf('a'), leaf('b')]);
+		const dialog = document.createElement('div');
+		dialog.setAttribute('role', 'dialog');
+		const button = document.createElement('button');
+		dialog.appendChild(button);
+		document.body.appendChild(dialog);
+		act(() => {
+			button.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+		});
+		expect(h.onAlertClick).not.toHaveBeenCalled();
+		h.unmount();
+	});
+
+	test('with two mounted tables, the one holding the active alert owns the keyboard', () => {
+		// Split-by-owner: pane A does not contain the active alert, pane B does. A naive
+		// per-instance listener would move BOTH panes on one keypress.
+		const paneA = setup([leaf('a1'), leaf('a2')], 'b1');
+		const paneB = setup([leaf('b1'), leaf('b2')], 'b1');
+		press('ArrowDown');
+		expect(paneA.onAlertClick).not.toHaveBeenCalled();
+		expect(paneB.onAlertClick).toHaveBeenCalledTimes(1);
+		expect(paneB.onAlertClick.mock.calls[0][0].id).toBe('b2');
+		paneA.unmount();
+		paneB.unmount();
+	});
+
+	test('the window listener is gone after the last table unmounts', () => {
+		const h = setup([leaf('a')]);
+		h.unmount();
+		press('ArrowDown');
+		expect(h.onAlertClick).not.toHaveBeenCalled();
+	});
+});

--- a/apps/client/src/test/useAlertKeyboardNav.test.tsx
+++ b/apps/client/src/test/useAlertKeyboardNav.test.tsx
@@ -24,11 +24,15 @@ const group = (key: string): FlatGroupItem =>
 		groupStatus: 'firing',
 	}) as FlatGroupItem;
 
+interface HookProps {
+	activeAlertId: string | null;
+}
+
 interface HookSetup {
 	onAlertClick: ReturnType<typeof vi.fn>;
 	scrollToIndex: ReturnType<typeof vi.fn>;
 	unmount: () => void;
-	rerender: (next: { activeAlertId: string | null }) => void;
+	rerender: (next: HookProps) => void;
 }
 
 const setup = (rows: FlatGroupItem[], activeAlertId: string | null = null): HookSetup => {
@@ -37,7 +41,7 @@ const setup = (rows: FlatGroupItem[], activeAlertId: string | null = null): Hook
 	const virtualizer = { scrollToIndex } as unknown as Virtualizer<HTMLDivElement, Element>;
 	const scrollerRef = { current: document.createElement('div') };
 	const view = renderHook(
-		(props: { activeAlertId: string | null }) =>
+		(props: HookProps) =>
 			useAlertKeyboardNav({
 				flatRows: rows,
 				activeAlertId: props.activeAlertId,

--- a/apps/client/src/test/useMarkAlertRead.test.tsx
+++ b/apps/client/src/test/useMarkAlertRead.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act, ReactNode } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Alert } from '@OpsiMate/shared';
+import { useMarkAlertRead } from '@/hooks/queries/alerts/useMarkAlertRead';
+
+const markAlertRead = vi.fn();
+vi.mock('@/lib/api', () => ({
+	alertsApi: {
+		markAlertRead: (id: string) => markAlertRead(id),
+	},
+}));
+
+// The ['alerts'] prefix matches queries of SEVERAL shapes at once: the infinite list
+// ({pages}), facets objects, match counts. The regression pinned here: an optimistic
+// updater that assumed Alert[] threw on the first non-array cache, and an onMutate
+// throw makes react-query skip mutationFn — so the server was never told and the row
+// stayed bold forever. The un-bold has to work with all of these shapes coexisting.
+
+const alert = (id: string, isRead: boolean): Alert => ({ id, isRead }) as Alert;
+
+interface SeededCaches {
+	queryClient: QueryClient;
+	infiniteKey: readonly unknown[];
+	facetsKey: readonly unknown[];
+	countKey: readonly unknown[];
+}
+
+const seedCaches = (): SeededCaches => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	const infiniteKey = ['alerts', 'api', null] as const;
+	const facetsKey = ['alerts', 'facets', 'active', null] as const;
+	const countKey = ['alerts', 'match-count', null] as const;
+	queryClient.setQueryData(infiniteKey, {
+		pages: [{ alerts: [alert('a1', false), alert('a2', true)], total: 2 }],
+		pageParams: [''],
+	});
+	queryClient.setQueryData(facetsKey, { severity: { critical: 3 } });
+	queryClient.setQueryData(countKey, 42);
+	return { queryClient, infiniteKey, facetsKey, countKey };
+};
+
+describe('useMarkAlertRead', () => {
+	beforeEach(() => {
+		markAlertRead.mockReset();
+		markAlertRead.mockResolvedValue({ success: true, data: { alert: alert('a1', true) } });
+	});
+
+	test('optimistically flips isRead inside the infinite pages and still calls the server', async () => {
+		const { queryClient, infiniteKey } = seedCaches();
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useMarkAlertRead(), { wrapper });
+
+		// Server held pending so the flip below is provably the OPTIMISTIC one.
+		let releaseServer: (value: unknown) => void = () => {};
+		markAlertRead.mockImplementation(() => new Promise((resolve) => (releaseServer = resolve)));
+
+		act(() => result.current.mutate('a1'));
+
+		await waitFor(() => {
+			const data = queryClient.getQueryData<{ pages: { alerts: Alert[] }[] }>(infiniteKey);
+			expect(data?.pages[0].alerts.find((a) => a.id === 'a1')?.isRead).toBe(true);
+			expect(data?.pages[0].alerts.find((a) => a.id === 'a2')?.isRead).toBe(true);
+		});
+
+		// The server call MUST happen — the old updater threw in onMutate, and
+		// react-query then skips mutationFn entirely.
+		expect(markAlertRead).toHaveBeenCalledWith('a1');
+		act(() => releaseServer({ success: true, data: { alert: alert('a1', true) } }));
+		queryClient.clear();
+	});
+
+	test('non-list caches under the same prefix are left byte-identical', async () => {
+		const { queryClient, facetsKey, countKey } = seedCaches();
+		const facetsBefore = queryClient.getQueryData(facetsKey);
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useMarkAlertRead(), { wrapper });
+
+		act(() => result.current.mutate('a1'));
+		await waitFor(() => expect(markAlertRead).toHaveBeenCalled());
+
+		expect(queryClient.getQueryData(facetsKey)).toBe(facetsBefore);
+		expect(queryClient.getQueryData(countKey)).toBe(42);
+		queryClient.clear();
+	});
+
+	test('a plain Alert[] cache (pre-pagination shape) still updates', async () => {
+		const { queryClient } = seedCaches();
+		const flatKey = ['alerts', 'legacy'] as const;
+		queryClient.setQueryData(flatKey, [alert('a1', false)]);
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useMarkAlertRead(), { wrapper });
+
+		act(() => result.current.mutate('a1'));
+
+		await waitFor(() => expect(queryClient.getQueryData<Alert[]>(flatKey)?.[0].isRead).toBe(true));
+		await waitFor(() => expect(markAlertRead).toHaveBeenCalled());
+		queryClient.clear();
+	});
+});


### PR DESCRIPTION
Two UI improvements:

1. **Bolder filter-sidebar headlines** — the section rubrics (Status, Severity, Type, tag keys…) step up from `font-medium` to `font-semibold`.

2. **Keyboard row navigation** — ArrowUp/ArrowDown move the alert selection (and the details sidebar) through the table.
   - Shares the click code path (`onAlertClick`), so mark-as-read behaves identically.
   - Group headers are skipped; collapsed groups' rows are naturally absent.
   - Boundary presses clamp in place without re-clicking (which would toggle the sidebar closed).
   - Split-by-owner: one window listener with an instance registry — the pane holding the active alert owns the keyboard, so panes never move in lockstep.
   - Guards: inputs, modified arrows, and Radix overlays (dialogs/menus/selects/popovers) keep their own arrow behavior.
   - Visibility: `scrollToIndex` can't see the sticky column header, the hanging group copies, or the horizontal scrollbar; a bounded, epsilon-tolerant rAF pin holds the row inside the real visible box and releases on wheel/touch/mousedown.
   - Mark-read's per-settle `invalidateQueries` is now debounce-coalesced (400 ms) so key-repeat doesn't refetch the alerts prefix once per row; the optimistic update already applies the visible change.

Verified live with trusted key events in Chrome (screenshots in the session): navigation in both directions across scroll boundaries in split-by-owner mode, exact positioning below the sticky header, sidebar following, and all guards. 8 new jsdom tests cover the decision logic and teardown; 214 client tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ArrowUp/ArrowDown keyboard navigation for alert rows.
  - Navigation skips group headers, respects text-entry fields and overlays, and opens the selected alert.
  - Automatically scrolls selected rows into view while accounting for sticky headers.

- **Bug Fixes**
  - Alert list updates are now batched after marking alerts as read, reducing unnecessary refreshes and preserving different alert list views.

- **Style**
  - Updated filter panel labels with a semibold font.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->