### PR TITLE
feat: warn on insecure ENCRYPTION_KEY + gate client typecheck in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,11 @@ jobs:
       - name: Lint apps/client
         run: pnpm --filter @OpsiMate/client lint
 
+      # vite build strips types, so tsc is the only thing that type-checks the client.
+      # Gates on NEW errors vs a committed baseline (the pre-existing backlog).
+      - name: Typecheck apps/client
+        run: pnpm --filter @OpsiMate/client typecheck
+
       - name: Format apps/server
         run: pnpm --filter @OpsiMate/server format
 

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -17,6 +17,8 @@
 		"test:coverage": "vitest run --coverage",
 		"lint": "eslint .",
 		"lint-fix": "eslint . --fix",
+		"typecheck": "node scripts/check-types.mjs",
+		"typecheck:update": "node scripts/check-types.mjs --update",
 		"format": "prettier --check .",
 		"check": "npm run format && npm run lint",
 		"fix": "npm run format-fix && npm run lint-fix"

--- a/apps/client/scripts/check-types.mjs
+++ b/apps/client/scripts/check-types.mjs
@@ -9,13 +9,20 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const clientDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const baselineFile = join(clientDir, 'type-errors-baseline.txt');
+// Some error messages embed absolute paths (e.g. a type printed as
+// import("<repo>/packages/shared/dist/types")). That prefix differs by machine
+// (/Users/... locally vs /home/runner/... on CI), so collapse it or the baseline
+// would never match across environments.
+const repoRoot = resolve(clientDir, '..', '..');
 
-// tsc exits non-zero when it finds errors; its report is on stdout either way.
+// tsc exits 1 (or 2) when it reports diagnostics — expected. Any OTHER failure means
+// tsc never actually ran (binary missing, bad config path), which must fail the gate
+// loudly instead of looking like "no errors".
 const runTsc = () => {
 	try {
 		execSync('pnpm exec tsc -p tsconfig.app.json --noEmit', {
@@ -25,17 +32,31 @@ const runTsc = () => {
 		});
 		return '';
 	} catch (error) {
-		return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+		const output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+		if (error.status !== 1 && error.status !== 2) {
+			console.error(`Could not run tsc — the client typecheck gate did not execute:\n${output}`);
+			process.exit(2);
+		}
+		return output;
 	}
 };
 
-// "path(line,col): error TSxxxx: message" -> "path: error TSxxxx: message". Dropping
-// line/column keeps the baseline stable when unrelated edits shift line numbers.
+// Normalize each diagnostic to a machine- and line-stable identity:
+//   "path(line,col): error TSxxxx: message" -> "path: error TSxxxx: message"
+//   "error TSxxxx: message" (global, no position) -> kept as-is
+// Global diagnostics (e.g. TS5058 "specified path does not exist") must be captured or
+// a broken invocation would normalize to nothing and pass green.
 const normalize = (output) => {
 	const ids = new Set();
-	for (const line of output.split('\n')) {
-		const match = line.match(/^(.*?)\(\d+,\d+\): (error TS\d+: .*)$/);
-		if (match) ids.add(`${match[1]}: ${match[2]}`.trim());
+	for (const rawLine of output.split('\n')) {
+		const line = rawLine.split(repoRoot).join('<repo>');
+		const positioned = line.match(/^(.*?)\(\d+,\d+\): (error TS\d+: .*)$/);
+		if (positioned) {
+			ids.add(`${positioned[1]}: ${positioned[2]}`.trim());
+			continue;
+		}
+		const global = line.match(/^(error TS\d+: .*)$/);
+		if (global) ids.add(global[1].trim());
 	}
 	return [...ids].sort();
 };

--- a/apps/client/scripts/check-types.mjs
+++ b/apps/client/scripts/check-types.mjs
@@ -1,0 +1,81 @@
+// Gate the client's `tsc` output against a committed baseline. `vite build` strips
+// types, so type errors otherwise reach main unnoticed (this exact gap once shipped a
+// hook calling a function with the wrong argument shape). The client carries a set of
+// pre-existing type errors we don't fix in one sweep; this script FAILS only on errors
+// NOT already in the baseline, so new code is gated while the backlog shrinks over time.
+//
+//   node scripts/check-types.mjs            check (used by CI); exits 1 on new errors
+//   node scripts/check-types.mjs --update   rewrite the baseline from current output
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const clientDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const baselineFile = join(clientDir, 'type-errors-baseline.txt');
+
+// tsc exits non-zero when it finds errors; its report is on stdout either way.
+const runTsc = () => {
+	try {
+		execSync('pnpm exec tsc -p tsconfig.app.json --noEmit', {
+			cwd: clientDir,
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		return '';
+	} catch (error) {
+		return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+	}
+};
+
+// "path(line,col): error TSxxxx: message" -> "path: error TSxxxx: message". Dropping
+// line/column keeps the baseline stable when unrelated edits shift line numbers.
+const normalize = (output) => {
+	const ids = new Set();
+	for (const line of output.split('\n')) {
+		const match = line.match(/^(.*?)\(\d+,\d+\): (error TS\d+: .*)$/);
+		if (match) ids.add(`${match[1]}: ${match[2]}`.trim());
+	}
+	return [...ids].sort();
+};
+
+const current = normalize(runTsc());
+
+if (process.argv.includes('--update')) {
+	writeFileSync(baselineFile, current.length ? `${current.join('\n')}\n` : '');
+	console.log(`Wrote ${current.length} baseline type-error(s) to ${baselineFile}`);
+	process.exit(0);
+}
+
+const baseline = existsSync(baselineFile)
+	? new Set(
+			readFileSync(baselineFile, 'utf8')
+				.split('\n')
+				.map((line) => line.trim())
+				.filter(Boolean)
+		)
+	: new Set();
+
+const introduced = current.filter((id) => !baseline.has(id));
+const currentSet = new Set(current);
+const cleared = [...baseline].filter((id) => !currentSet.has(id));
+
+if (cleared.length > 0) {
+	console.log(
+		`\n${cleared.length} baseline error(s) no longer occur — run ` +
+			'`pnpm --filter @OpsiMate/client typecheck:update` to shrink the baseline.'
+	);
+}
+
+if (introduced.length > 0) {
+	console.error(`\n✖ ${introduced.length} NEW client type error(s) not in the baseline:\n`);
+	for (const id of introduced) console.error(`  ${id}`);
+	console.error(
+		'\nFix them, or — if intentional — update the baseline with ' +
+			'`pnpm --filter @OpsiMate/client typecheck:update`.'
+	);
+	process.exit(1);
+}
+
+console.log(`✓ No new client type errors (${baseline.size} known baseline error(s)).`);

--- a/apps/client/type-errors-baseline.txt
+++ b/apps/client/type-errors-baseline.txt
@@ -1,0 +1,25 @@
+src/App.tsx: error TS2322: Type '{ children: Element; future: { v7_startTransition: boolean; v7_relativeSplatPath: boolean; }; }' is not assignable to type 'IntrinsicAttributes & BrowserRouterProps'.
+src/components/Alerts/AlertsTable/AlertRow/CopyCellButton.tsx: error TS2554: Expected 1 arguments, but got 0.
+src/components/Dashboards/Dashboards.tsx: error TS2345: Argument of type '{ id: string; name: string; type: "services" | "alerts"; description: string; visibleColumns: string[]; filters: Record<string, string[]>; columnOrder: string[]; groupBy: string[]; query: string; timeRange: TimeRange; }' is not assignable to parameter of type 'DashboardState'.
+src/components/shared/FormattedText.tsx: error TS2503: Cannot find namespace 'DOMPurify'.
+src/hooks/queries/integrations/useIntegrationUrls.ts: error TS2559: Type 'string' has no properties in common with type 'LogOptions'.
+src/hooks/useFormErrors.ts: error TS2559: Type '{ success: boolean; error?: string; errors?: Record<string, string>; }' has no properties in common with type 'LogOptions'.
+src/lib/errorMapper.ts: error TS2339: Property 'details' does not exist on type 'unknown'.
+src/lib/errorMapper.ts: error TS2339: Property 'error' does not exist on type 'unknown'.
+src/lib/errorMapper.ts: error TS2339: Property 'success' does not exist on type 'unknown'.
+src/lib/sslKeys.ts: error TS2322: Type '{ id: string; name: string; value: string; }[]' is not assignable to type 'SecretMetadata[]'.
+src/mocks/handlers.ts: error TS2352: Conversion of type 'ActionConfig' to type 'Record<string, string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+src/mocks/mockAlerts.ts: error TS2322: Type '{ alertTypes: { Grafana: number; GCP: number; UptimeKuma: number; Custom: number; }; statuses: { firing: number; resolved: number; pending: number; suppressed: number; inhibited: number; }; tags: { production: number; ... 8 more ...; warning: number; }; alertNames: {}; }' is not assignable to type '{ alertTypes?: Record<AlertType, number>; statuses?: Record<string, number>; tags?: Record<string, number>; alertNames?: Record<string, number>; }'.
+src/mocks/mockAlerts.ts: error TS2561: Object literal may only specify known properties, but 'tag' does not exist in type 'Alert'. Did you mean to write 'tags'?
+src/mocks/mockAlerts.ts: error TS2739: Type '{ GCP: number; Grafana: number; Custom: number; UptimeKuma: number; }' is missing the following properties from type 'Record<AlertType, number>': Datadog, Zabbix
+src/mocks/mockAlerts.ts: error TS2739: Type '{ UptimeKuma: number; Grafana: number; GCP: number; Custom: number; }' is missing the following properties from type 'Record<AlertType, number>': Datadog, Zabbix
+src/mocks/mockAlerts.utils.ts: error TS2739: Type '{ Grafana: number; GCP: number; UptimeKuma: number; Custom: number; }' is missing the following properties from type 'Record<AlertType, number>': Datadog, Zabbix
+src/pages/Integrations.tsx: error TS2339: Property 'toLowerCase' does not exist on type 'never'.
+src/pages/Integrations.tsx: error TS2345: Argument of type '{ name: string; type: IntegrationType; externalUrl: string; credentials: {}; }' is not assignable to parameter of type '{ name: string; type: IntegrationType; externalUrl: string; credentials: Record<string, string>; }'.
+src/pages/Integrations.tsx: error TS2367: This comparison appears to be unintentional because the types 'IntegrationType' and 'import("/Users/idanlodzki/OpsiMate/packages/shared/dist/types").IntegrationType' have no overlap.
+src/pages/Login.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
+src/pages/NotFound.tsx: error TS2559: Type 'string' has no properties in common with type 'LogOptions'.
+src/pages/Register.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
+src/pages/Settings.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'SetStateAction<number>'.
+src/test/severity.utils.test.ts: error TS2550: Property 'hasOwn' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
+src/test/useColumnManagement.test.tsx: error TS2741: Property 'values' is missing in type '{ key: string; label: string; }' but required in type 'TagKeyInfo'.

--- a/apps/client/type-errors-baseline.txt
+++ b/apps/client/type-errors-baseline.txt
@@ -16,7 +16,7 @@ src/mocks/mockAlerts.ts: error TS2739: Type '{ UptimeKuma: number; Grafana: numb
 src/mocks/mockAlerts.utils.ts: error TS2739: Type '{ Grafana: number; GCP: number; UptimeKuma: number; Custom: number; }' is missing the following properties from type 'Record<AlertType, number>': Datadog, Zabbix
 src/pages/Integrations.tsx: error TS2339: Property 'toLowerCase' does not exist on type 'never'.
 src/pages/Integrations.tsx: error TS2345: Argument of type '{ name: string; type: IntegrationType; externalUrl: string; credentials: {}; }' is not assignable to parameter of type '{ name: string; type: IntegrationType; externalUrl: string; credentials: Record<string, string>; }'.
-src/pages/Integrations.tsx: error TS2367: This comparison appears to be unintentional because the types 'IntegrationType' and 'import("/Users/idanlodzki/OpsiMate/packages/shared/dist/types").IntegrationType' have no overlap.
+src/pages/Integrations.tsx: error TS2367: This comparison appears to be unintentional because the types 'IntegrationType' and 'import("<repo>/packages/shared/dist/types").IntegrationType' have no overlap.
 src/pages/Login.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
 src/pages/NotFound.tsx: error TS2559: Type 'string' has no properties in common with type 'LogOptions'.
 src/pages/Register.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,11 +1,16 @@
 import { initializeDb } from './dal/db';
 import { createApp, AppMode } from './app';
 import { getServerConfig } from './config/config';
+import { assertEncryptionKeyConfigured } from './utils/encryption';
 import { Logger } from '@OpsiMate/shared';
 
 const logger = new Logger('server');
 
 await (async () => {
+	// Fail fast before touching the DB: a production boot with no ENCRYPTION_KEY would
+	// otherwise encrypt every credential under the public fallback key.
+	assertEncryptionKeyConfigured();
+
 	const serverConfig = getServerConfig();
 
 	// Allow environment variable to override config file

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,15 +1,15 @@
 import { initializeDb } from './dal/db';
 import { createApp, AppMode } from './app';
 import { getServerConfig } from './config/config';
-import { assertEncryptionKeyConfigured } from './utils/encryption';
+import { warnIfEncryptionKeyInsecure } from './utils/encryption';
 import { Logger } from '@OpsiMate/shared';
 
 const logger = new Logger('server');
 
 await (async () => {
-	// Fail fast before touching the DB: a production boot with no ENCRYPTION_KEY would
-	// otherwise encrypt every credential under the public fallback key.
-	assertEncryptionKeyConfigured();
+	// Nudge, don't block: a production boot with no ENCRYPTION_KEY encrypts credentials
+	// under the public fallback key — warn loudly but keep existing deployments running.
+	warnIfEncryptionKeyInsecure();
 
 	const serverConfig = getServerConfig();
 

--- a/apps/server/src/utils/encryption.ts
+++ b/apps/server/src/utils/encryption.ts
@@ -9,11 +9,48 @@ const KEY_LENGTH = 32;
 
 const logger = new Logger('encryption-');
 
+// The built-in key is a PUBLIC constant (it ships in this repo). It exists so local
+// dev and the test suite work with zero config — it must never protect real data.
+const DEV_FALLBACK_KEY = 'test-key-should-be-changed';
+
+// Raised when a value shaped exactly like our ciphertext cannot be decrypted — almost
+// always a changed ENCRYPTION_KEY or corrupted storage. Distinct type so callers can
+// tell "this secret is unreadable" apart from any other failure.
+export class DecryptionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'DecryptionError';
+	}
+}
+
 /**
  * Get encryption key from environment variable or use default
  */
 function getEncryptionKey(): string {
-	return process.env.ENCRYPTION_KEY || 'test-key-should-be-changed';
+	return process.env.ENCRYPTION_KEY || DEV_FALLBACK_KEY;
+}
+
+/**
+ * Call once at server boot. In production an unset ENCRYPTION_KEY means every stored
+ * credential is encrypted under the public fallback constant — that is not encryption,
+ * so refuse to start rather than offer false protection. Dev/test keep the fallback.
+ * Setting ENCRYPTION_KEY to ANY value satisfies the check, including the old fallback
+ * string, which is the migration path for data already encrypted under it.
+ */
+export function assertEncryptionKeyConfigured(env: NodeJS.ProcessEnv = process.env): void {
+	if (env.NODE_ENV !== 'production') return;
+	const key = env.ENCRYPTION_KEY;
+	if (!key) {
+		throw new Error(
+			'ENCRYPTION_KEY is not set. OpsiMate encrypts stored credentials with it and refuses ' +
+				'to start in production using the built-in fallback key (which is public). Set ' +
+				'ENCRYPTION_KEY to a strong secret — or, to keep data already encrypted under the old ' +
+				'default, to that previous value.'
+		);
+	}
+	if (key === DEV_FALLBACK_KEY) {
+		logger.warn('ENCRYPTION_KEY is set to the public fallback value — rotate it to a private secret.');
+	}
 }
 
 /**
@@ -49,11 +86,30 @@ export function encryptPassword(password: string | undefined): string | undefine
 	return combined.toString('base64');
 }
 
+// encryptPassword emits base64 of salt(64)+iv(16)+tag(16)+data(>=1). A value that is
+// not strict base64 of at least that length was never produced by us, so it is legacy
+// plaintext (e.g. a credential stored before encryption existed) — decryption must not
+// be attempted on it. Real ciphertext ALWAYS satisfies this, so nothing encrypted is
+// ever misrouted here.
+const MIN_CIPHERTEXT_BYTES = SALT_LENGTH + IV_LENGTH + TAG_LENGTH + 1;
+function looksLikeCiphertext(value: string): boolean {
+	if (value.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+		return false;
+	}
+	return Buffer.from(value, 'base64').length >= MIN_CIPHERTEXT_BYTES;
+}
+
 /**
  * Decrypt a password string
  */
 export function decryptPassword(encryptedPassword: string | undefined): string | undefined {
 	if (!encryptedPassword) {
+		return encryptedPassword;
+	}
+
+	// Legacy plaintext (anything not in our exact ciphertext shape) passes through
+	// unchanged — the backward-compatibility path for pre-encryption data.
+	if (!looksLikeCiphertext(encryptedPassword)) {
 		return encryptedPassword;
 	}
 
@@ -77,9 +133,12 @@ export function decryptPassword(encryptedPassword: string | undefined): string |
 
 		return decrypted;
 	} catch (error) {
-		logger.error('Failed to decrypt password:', error);
-		// Return the original value if decryption fails (for backward compatibility)
-		return encryptedPassword;
+		// Shaped exactly like our ciphertext but undecryptable: a changed ENCRYPTION_KEY
+		// or corrupted storage. The old code returned this base64 blob unchanged, so the
+		// caller silently used it as a live credential (or JSON.parsed garbage). Surface
+		// it instead of leaking a broken secret downstream.
+		logger.error('Failed to decrypt a stored secret (ENCRYPTION_KEY changed or data corrupted):', error);
+		throw new DecryptionError('Failed to decrypt a stored secret; ENCRYPTION_KEY may have changed.');
 	}
 }
 

--- a/apps/server/src/utils/encryption.ts
+++ b/apps/server/src/utils/encryption.ts
@@ -7,27 +7,11 @@ const SALT_LENGTH = 64;
 const TAG_LENGTH = 16;
 const KEY_LENGTH = 32;
 
-// Provenance marker prepended to everything we encrypt. Its presence means "this value
-// was produced by encryptPassword", so a decryption failure on it is a real problem
-// (changed key / corruption) rather than possibly-legacy-plaintext. It removes the need
-// to GUESS provenance from a value's shape.
-const CIPHERTEXT_PREFIX = 'gcm1:';
-
 const logger = new Logger('encryption-');
 
-// The built-in key is a PUBLIC constant (it ships in this repo). It exists so local
-// dev and the test suite work with zero config — it must never protect real data.
+// The built-in key is a PUBLIC constant (it ships in this repo). It exists so local dev
+// and the test suite work with zero config — it must never protect real data.
 const DEV_FALLBACK_KEY = 'test-key-should-be-changed';
-
-// Raised when a value shaped exactly like our ciphertext cannot be decrypted — almost
-// always a changed ENCRYPTION_KEY or corrupted storage. Distinct type so callers can
-// tell "this secret is unreadable" apart from any other failure.
-export class DecryptionError extends Error {
-	constructor(message: string) {
-		super(message);
-		this.name = 'DecryptionError';
-	}
-}
 
 /**
  * Get encryption key from environment variable or use default
@@ -37,27 +21,26 @@ function getEncryptionKey(): string {
 }
 
 /**
- * Call once at server boot. In production an unset ENCRYPTION_KEY means every stored
- * credential is encrypted under the public fallback constant — that is not encryption,
- * so refuse to start rather than offer false protection. Dev/test keep the fallback.
- * Setting ENCRYPTION_KEY to ANY value satisfies the check, including the old fallback
- * string, which is the migration path for data already encrypted under it.
+ * Called once at server boot. In production, an unset (or blank) ENCRYPTION_KEY means
+ * every stored credential is encrypted under the public fallback key — no real
+ * protection. We only WARN (loudly, and every boot) rather than refuse to start, so
+ * existing deployments upgrade without downtime; setting ENCRYPTION_KEY silences it.
+ * No-op outside production, where the zero-config fallback is expected. Env is injected
+ * so tests never mutate the shared process.env.
  */
-export function assertEncryptionKeyConfigured(env: NodeJS.ProcessEnv = process.env): void {
+export function warnIfEncryptionKeyInsecure(env: NodeJS.ProcessEnv = process.env): void {
 	if (env.NODE_ENV !== 'production') return;
 	const key = env.ENCRYPTION_KEY;
-	// Whitespace-only counts as unset: getEncryptionKey would otherwise use " " as a
-	// trivially guessable master key.
 	if (!key || key.trim().length === 0) {
-		throw new Error(
-			'ENCRYPTION_KEY is not set. OpsiMate encrypts stored credentials with it and refuses ' +
-				'to start in production using the built-in fallback key (which is public). Set ' +
-				'ENCRYPTION_KEY to a strong secret — or, to keep data already encrypted under the old ' +
-				'default, to that previous value.'
+		logger.warn(
+			'ENCRYPTION_KEY is not set. Stored credentials are being encrypted with the built-in ' +
+				'fallback key, which is PUBLIC (it ships in this repo). We highly recommend setting ' +
+				'ENCRYPTION_KEY to a strong, private secret. Continuing with the insecure default.'
 		);
+		return;
 	}
 	if (key === DEV_FALLBACK_KEY) {
-		logger.warn('ENCRYPTION_KEY is set to the public fallback value — rotate it to a private secret.');
+		logger.warn('ENCRYPTION_KEY is set to the public fallback value — we highly recommend rotating it.');
 	}
 }
 
@@ -91,38 +74,7 @@ export function encryptPassword(password: string | undefined): string | undefine
 	// Combine salt + iv + authTag + encrypted data
 	const combined = Buffer.concat([salt, iv, authTag, Buffer.from(encrypted, 'hex')]);
 
-	return CIPHERTEXT_PREFIX + combined.toString('base64');
-}
-
-// Decrypt a bare (unprefixed) base64 blob. Throws on any structural or auth failure.
-function decryptBlob(blob: string): string {
-	const masterKey = getEncryptionKey();
-	const combined = Buffer.from(blob, 'base64');
-
-	const salt = combined.subarray(0, SALT_LENGTH);
-	const iv = combined.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
-	const authTag = combined.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-	const encrypted = combined.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-
-	const key = deriveKey(masterKey, salt);
-	const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-	decipher.setAuthTag(authTag);
-
-	let decrypted = decipher.update(encrypted, undefined, 'utf8');
-	decrypted += decipher.final('utf8');
-	return decrypted;
-}
-
-// A pre-prefix (legacy-format) ciphertext: strict base64 of at least salt+iv+tag+data.
-// Only consulted for UNPREFIXED values, where we cannot be certain of provenance and so
-// never throw — a false positive here just means a failed decrypt returns the value
-// unchanged, exactly the long-standing backward-compatibility behavior.
-const MIN_CIPHERTEXT_BYTES = SALT_LENGTH + IV_LENGTH + TAG_LENGTH + 1;
-function looksLikeLegacyCiphertext(value: string): boolean {
-	if (value.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
-		return false;
-	}
-	return Buffer.from(value, 'base64').length >= MIN_CIPHERTEXT_BYTES;
+	return combined.toString('base64');
 }
 
 /**
@@ -133,30 +85,30 @@ export function decryptPassword(encryptedPassword: string | undefined): string |
 		return encryptedPassword;
 	}
 
-	// Prefixed: unambiguously ours. A failure here is a changed ENCRYPTION_KEY or
-	// corruption — surface it rather than silently hand a broken secret downstream
-	// (a caller would otherwise use base64 garbage as a live credential).
-	if (encryptedPassword.startsWith(CIPHERTEXT_PREFIX)) {
-		try {
-			return decryptBlob(encryptedPassword.slice(CIPHERTEXT_PREFIX.length));
-		} catch (error) {
-			logger.error('Failed to decrypt a stored secret (ENCRYPTION_KEY changed or data corrupted):', error);
-			throw new DecryptionError('Failed to decrypt a stored secret; ENCRYPTION_KEY may have changed.');
-		}
-	}
+	try {
+		const masterKey = getEncryptionKey();
+		const combined = Buffer.from(encryptedPassword, 'base64');
 
-	// Unprefixed: legacy plaintext, OR ciphertext written before the provenance prefix
-	// existed. Provenance is unknowable, so NEVER throw. Try to decrypt values shaped
-	// like the old ciphertext; on any failure return the value unchanged (this is why a
-	// legacy plaintext value — even a long, base64-looking one — is always preserved).
-	if (looksLikeLegacyCiphertext(encryptedPassword)) {
-		try {
-			return decryptBlob(encryptedPassword);
-		} catch {
-			return encryptedPassword;
-		}
+		// Extract components
+		const salt = combined.subarray(0, SALT_LENGTH);
+		const iv = combined.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+		const authTag = combined.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+		const encrypted = combined.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+
+		const key = deriveKey(masterKey, salt);
+
+		const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+		decipher.setAuthTag(authTag);
+
+		let decrypted = decipher.update(encrypted, undefined, 'utf8');
+		decrypted += decipher.final('utf8');
+
+		return decrypted;
+	} catch (error) {
+		logger.error('Failed to decrypt password:', error);
+		// Return the original value if decryption fails (for backward compatibility)
+		return encryptedPassword;
 	}
-	return encryptedPassword;
 }
 
 /**

--- a/apps/server/src/utils/encryption.ts
+++ b/apps/server/src/utils/encryption.ts
@@ -7,6 +7,12 @@ const SALT_LENGTH = 64;
 const TAG_LENGTH = 16;
 const KEY_LENGTH = 32;
 
+// Provenance marker prepended to everything we encrypt. Its presence means "this value
+// was produced by encryptPassword", so a decryption failure on it is a real problem
+// (changed key / corruption) rather than possibly-legacy-plaintext. It removes the need
+// to GUESS provenance from a value's shape.
+const CIPHERTEXT_PREFIX = 'gcm1:';
+
 const logger = new Logger('encryption-');
 
 // The built-in key is a PUBLIC constant (it ships in this repo). It exists so local
@@ -40,7 +46,9 @@ function getEncryptionKey(): string {
 export function assertEncryptionKeyConfigured(env: NodeJS.ProcessEnv = process.env): void {
 	if (env.NODE_ENV !== 'production') return;
 	const key = env.ENCRYPTION_KEY;
-	if (!key) {
+	// Whitespace-only counts as unset: getEncryptionKey would otherwise use " " as a
+	// trivially guessable master key.
+	if (!key || key.trim().length === 0) {
 		throw new Error(
 			'ENCRYPTION_KEY is not set. OpsiMate encrypts stored credentials with it and refuses ' +
 				'to start in production using the built-in fallback key (which is public). Set ' +
@@ -83,16 +91,34 @@ export function encryptPassword(password: string | undefined): string | undefine
 	// Combine salt + iv + authTag + encrypted data
 	const combined = Buffer.concat([salt, iv, authTag, Buffer.from(encrypted, 'hex')]);
 
-	return combined.toString('base64');
+	return CIPHERTEXT_PREFIX + combined.toString('base64');
 }
 
-// encryptPassword emits base64 of salt(64)+iv(16)+tag(16)+data(>=1). A value that is
-// not strict base64 of at least that length was never produced by us, so it is legacy
-// plaintext (e.g. a credential stored before encryption existed) — decryption must not
-// be attempted on it. Real ciphertext ALWAYS satisfies this, so nothing encrypted is
-// ever misrouted here.
+// Decrypt a bare (unprefixed) base64 blob. Throws on any structural or auth failure.
+function decryptBlob(blob: string): string {
+	const masterKey = getEncryptionKey();
+	const combined = Buffer.from(blob, 'base64');
+
+	const salt = combined.subarray(0, SALT_LENGTH);
+	const iv = combined.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+	const authTag = combined.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+	const encrypted = combined.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+
+	const key = deriveKey(masterKey, salt);
+	const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+	decipher.setAuthTag(authTag);
+
+	let decrypted = decipher.update(encrypted, undefined, 'utf8');
+	decrypted += decipher.final('utf8');
+	return decrypted;
+}
+
+// A pre-prefix (legacy-format) ciphertext: strict base64 of at least salt+iv+tag+data.
+// Only consulted for UNPREFIXED values, where we cannot be certain of provenance and so
+// never throw — a false positive here just means a failed decrypt returns the value
+// unchanged, exactly the long-standing backward-compatibility behavior.
 const MIN_CIPHERTEXT_BYTES = SALT_LENGTH + IV_LENGTH + TAG_LENGTH + 1;
-function looksLikeCiphertext(value: string): boolean {
+function looksLikeLegacyCiphertext(value: string): boolean {
 	if (value.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
 		return false;
 	}
@@ -107,39 +133,30 @@ export function decryptPassword(encryptedPassword: string | undefined): string |
 		return encryptedPassword;
 	}
 
-	// Legacy plaintext (anything not in our exact ciphertext shape) passes through
-	// unchanged — the backward-compatibility path for pre-encryption data.
-	if (!looksLikeCiphertext(encryptedPassword)) {
-		return encryptedPassword;
+	// Prefixed: unambiguously ours. A failure here is a changed ENCRYPTION_KEY or
+	// corruption — surface it rather than silently hand a broken secret downstream
+	// (a caller would otherwise use base64 garbage as a live credential).
+	if (encryptedPassword.startsWith(CIPHERTEXT_PREFIX)) {
+		try {
+			return decryptBlob(encryptedPassword.slice(CIPHERTEXT_PREFIX.length));
+		} catch (error) {
+			logger.error('Failed to decrypt a stored secret (ENCRYPTION_KEY changed or data corrupted):', error);
+			throw new DecryptionError('Failed to decrypt a stored secret; ENCRYPTION_KEY may have changed.');
+		}
 	}
 
-	try {
-		const masterKey = getEncryptionKey();
-		const combined = Buffer.from(encryptedPassword, 'base64');
-
-		// Extract components
-		const salt = combined.subarray(0, SALT_LENGTH);
-		const iv = combined.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
-		const authTag = combined.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-		const encrypted = combined.subarray(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
-
-		const key = deriveKey(masterKey, salt);
-
-		const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-		decipher.setAuthTag(authTag);
-
-		let decrypted = decipher.update(encrypted, undefined, 'utf8');
-		decrypted += decipher.final('utf8');
-
-		return decrypted;
-	} catch (error) {
-		// Shaped exactly like our ciphertext but undecryptable: a changed ENCRYPTION_KEY
-		// or corrupted storage. The old code returned this base64 blob unchanged, so the
-		// caller silently used it as a live credential (or JSON.parsed garbage). Surface
-		// it instead of leaking a broken secret downstream.
-		logger.error('Failed to decrypt a stored secret (ENCRYPTION_KEY changed or data corrupted):', error);
-		throw new DecryptionError('Failed to decrypt a stored secret; ENCRYPTION_KEY may have changed.');
+	// Unprefixed: legacy plaintext, OR ciphertext written before the provenance prefix
+	// existed. Provenance is unknowable, so NEVER throw. Try to decrypt values shaped
+	// like the old ciphertext; on any failure return the value unchanged (this is why a
+	// legacy plaintext value — even a long, base64-looking one — is always preserved).
+	if (looksLikeLegacyCiphertext(encryptedPassword)) {
+		try {
+			return decryptBlob(encryptedPassword);
+		} catch {
+			return encryptedPassword;
+		}
 	}
+	return encryptedPassword;
 }
 
 /**

--- a/apps/server/tests/encryption.test.ts
+++ b/apps/server/tests/encryption.test.ts
@@ -1,9 +1,4 @@
-import {
-	assertEncryptionKeyConfigured,
-	DecryptionError,
-	decryptPassword,
-	encryptPassword,
-} from '../src/utils/encryption';
+import { encryptPassword, decryptPassword, warnIfEncryptionKeyInsecure } from '../src/utils/encryption';
 
 describe('Password Encryption', () => {
 	test('should encrypt and decrypt password correctly', () => {
@@ -40,46 +35,22 @@ describe('Password Encryption', () => {
 		expect(decryptPassword(encrypted2)).toBe(password);
 	});
 
-	test('passes legacy plaintext (unprefixed) through unchanged, even when base64-shaped', () => {
-		// Never produced by encryptPassword (no provenance prefix) — the backward-compat
-		// path must never throw, whatever the value looks like.
-		expect(decryptPassword('invalidBase64String')).toBe('invalidBase64String');
-		expect(decryptPassword('{"user":"admin","pass":"hunter2"}')).toBe('{"user":"admin","pass":"hunter2"}');
-		// A long, strict-base64 legacy plaintext (>= a ciphertext's minimum length): it
-		// is NOT prefixed, so it decodes-and-fails-quietly and is returned unchanged
-		// rather than misclassified as our ciphertext and thrown on.
-		const longBase64Plaintext = 'A'.repeat(200);
-		expect(decryptPassword(longBase64Plaintext)).toBe(longBase64Plaintext);
+	test('should handle decryption failure gracefully', () => {
+		const invalidEncrypted = 'invalidBase64String';
+		const result = decryptPassword(invalidEncrypted);
+		// Should return the original value if decryption fails
+		expect(result).toBe(invalidEncrypted);
 	});
 
-	test('prefixed ciphertext round-trips, and throws if it cannot be decrypted', () => {
-		const encrypted = encryptPassword('a-real-secret')!;
-		expect(encrypted.startsWith('gcm1:')).toBe(true);
-		expect(decryptPassword(encrypted)).toBe('a-real-secret');
-
-		// Corrupt one byte of the blob (keeping the prefix) so GCM auth fails: because
-		// the value is provably ours, this must throw rather than pass garbage through.
-		const buffer = Buffer.from(encrypted.slice('gcm1:'.length), 'base64');
-		buffer[buffer.length - 1] ^= 0xff;
-		const tampered = `gcm1:${buffer.toString('base64')}`;
-		expect(() => decryptPassword(tampered)).toThrow(DecryptionError);
-	});
-
-	// Env injected, never mutating the shared process.env, so these can't leak into
-	// test files running in the same worker.
-	test('assertEncryptionKeyConfigured refuses a production boot with no (or blank) key', () => {
-		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'production' })).toThrow(/ENCRYPTION_KEY/);
-		// Whitespace-only is treated as unset — it must not satisfy the check.
-		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'production', ENCRYPTION_KEY: '   ' })).toThrow(
-			/ENCRYPTION_KEY/
-		);
+	// The key invariant: warning must NEVER throw, so it can't block a boot. Env is
+	// injected, so this never mutates the shared process.env (which would leak into
+	// other test files in the same worker).
+	test('warnIfEncryptionKeyInsecure never throws, in any environment', () => {
+		expect(() => warnIfEncryptionKeyInsecure({ NODE_ENV: 'production' })).not.toThrow();
+		expect(() => warnIfEncryptionKeyInsecure({ NODE_ENV: 'production', ENCRYPTION_KEY: '   ' })).not.toThrow();
 		expect(() =>
-			assertEncryptionKeyConfigured({ NODE_ENV: 'production', ENCRYPTION_KEY: 'a-strong-private-secret' })
+			warnIfEncryptionKeyInsecure({ NODE_ENV: 'production', ENCRYPTION_KEY: 'a-strong-secret' })
 		).not.toThrow();
-	});
-
-	test('assertEncryptionKeyConfigured is a no-op outside production', () => {
-		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'test' })).not.toThrow();
-		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'development' })).not.toThrow();
+		expect(() => warnIfEncryptionKeyInsecure({ NODE_ENV: 'development' })).not.toThrow();
 	});
 });

--- a/apps/server/tests/encryption.test.ts
+++ b/apps/server/tests/encryption.test.ts
@@ -1,4 +1,9 @@
-import { encryptPassword, decryptPassword } from '../src/utils/encryption';
+import {
+	assertEncryptionKeyConfigured,
+	DecryptionError,
+	decryptPassword,
+	encryptPassword,
+} from '../src/utils/encryption';
 
 describe('Password Encryption', () => {
 	test('should encrypt and decrypt password correctly', () => {
@@ -35,10 +40,32 @@ describe('Password Encryption', () => {
 		expect(decryptPassword(encrypted2)).toBe(password);
 	});
 
-	test('should handle decryption failure gracefully', () => {
-		const invalidEncrypted = 'invalidBase64String';
-		const result = decryptPassword(invalidEncrypted);
-		// Should return the original value if decryption fails
-		expect(result).toBe(invalidEncrypted);
+	test('passes legacy plaintext (not our ciphertext shape) through unchanged', () => {
+		// These were never produced by encryptPassword — the backward-compat path.
+		expect(decryptPassword('invalidBase64String')).toBe('invalidBase64String');
+		expect(decryptPassword('{"user":"admin","pass":"hunter2"}')).toBe('{"user":"admin","pass":"hunter2"}');
+	});
+
+	test('throws when a value shaped like our ciphertext cannot be decrypted', () => {
+		// Corrupt one byte of a real ciphertext so GCM auth fails but the shape stays.
+		const encrypted = encryptPassword('a-real-secret')!;
+		const buffer = Buffer.from(encrypted, 'base64');
+		buffer[buffer.length - 1] ^= 0xff;
+		const tampered = buffer.toString('base64');
+		expect(() => decryptPassword(tampered)).toThrow(DecryptionError);
+	});
+
+	// Env injected, never mutating the shared process.env, so these can't leak into
+	// test files running in the same worker.
+	test('assertEncryptionKeyConfigured refuses a production boot with no key', () => {
+		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'production' })).toThrow(/ENCRYPTION_KEY/);
+		expect(() =>
+			assertEncryptionKeyConfigured({ NODE_ENV: 'production', ENCRYPTION_KEY: 'a-strong-private-secret' })
+		).not.toThrow();
+	});
+
+	test('assertEncryptionKeyConfigured is a no-op outside production', () => {
+		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'test' })).not.toThrow();
+		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'development' })).not.toThrow();
 	});
 });

--- a/apps/server/tests/encryption.test.ts
+++ b/apps/server/tests/encryption.test.ts
@@ -40,25 +40,39 @@ describe('Password Encryption', () => {
 		expect(decryptPassword(encrypted2)).toBe(password);
 	});
 
-	test('passes legacy plaintext (not our ciphertext shape) through unchanged', () => {
-		// These were never produced by encryptPassword — the backward-compat path.
+	test('passes legacy plaintext (unprefixed) through unchanged, even when base64-shaped', () => {
+		// Never produced by encryptPassword (no provenance prefix) — the backward-compat
+		// path must never throw, whatever the value looks like.
 		expect(decryptPassword('invalidBase64String')).toBe('invalidBase64String');
 		expect(decryptPassword('{"user":"admin","pass":"hunter2"}')).toBe('{"user":"admin","pass":"hunter2"}');
+		// A long, strict-base64 legacy plaintext (>= a ciphertext's minimum length): it
+		// is NOT prefixed, so it decodes-and-fails-quietly and is returned unchanged
+		// rather than misclassified as our ciphertext and thrown on.
+		const longBase64Plaintext = 'A'.repeat(200);
+		expect(decryptPassword(longBase64Plaintext)).toBe(longBase64Plaintext);
 	});
 
-	test('throws when a value shaped like our ciphertext cannot be decrypted', () => {
-		// Corrupt one byte of a real ciphertext so GCM auth fails but the shape stays.
+	test('prefixed ciphertext round-trips, and throws if it cannot be decrypted', () => {
 		const encrypted = encryptPassword('a-real-secret')!;
-		const buffer = Buffer.from(encrypted, 'base64');
+		expect(encrypted.startsWith('gcm1:')).toBe(true);
+		expect(decryptPassword(encrypted)).toBe('a-real-secret');
+
+		// Corrupt one byte of the blob (keeping the prefix) so GCM auth fails: because
+		// the value is provably ours, this must throw rather than pass garbage through.
+		const buffer = Buffer.from(encrypted.slice('gcm1:'.length), 'base64');
 		buffer[buffer.length - 1] ^= 0xff;
-		const tampered = buffer.toString('base64');
+		const tampered = `gcm1:${buffer.toString('base64')}`;
 		expect(() => decryptPassword(tampered)).toThrow(DecryptionError);
 	});
 
 	// Env injected, never mutating the shared process.env, so these can't leak into
 	// test files running in the same worker.
-	test('assertEncryptionKeyConfigured refuses a production boot with no key', () => {
+	test('assertEncryptionKeyConfigured refuses a production boot with no (or blank) key', () => {
 		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'production' })).toThrow(/ENCRYPTION_KEY/);
+		// Whitespace-only is treated as unset — it must not satisfy the check.
+		expect(() => assertEncryptionKeyConfigured({ NODE_ENV: 'production', ENCRYPTION_KEY: '   ' })).toThrow(
+			/ENCRYPTION_KEY/
+		);
 		expect(() =>
 			assertEncryptionKeyConfigured({ NODE_ENV: 'production', ENCRYPTION_KEY: 'a-strong-private-secret' })
 		).not.toThrow();


### PR DESCRIPTION
Two independent hardening changes surfaced during the AI BYOK review (#838); neither is AI-specific.

## 1. Warn on an insecure `ENCRYPTION_KEY` (`apps/server/src/utils/encryption.ts`)

`encryptPassword`/`decryptPassword` guard every stored credential (users' reset tokens, secrets, integration credentials, the Bedrock key). If `ENCRYPTION_KEY` is unset they fall back to `'test-key-should-be-changed'` — a constant that ships in this public repo, i.e. no protection.

`warnIfEncryptionKeyInsecure()` (called at boot, before the DB opens) logs a loud, **production-only** warning when the key is unset/blank or equals the public fallback. **It does not stop the server.**

> **Why warn, not fail-closed?** An earlier version of this PR refused to boot without the key. But every stock production deployment sets `NODE_ENV=production` while **none** sets `ENCRYPTION_KEY` (it's absent from all Dockerfiles, `docker-compose.yml`, and docs), so a hard-fail would have broken every existing upgrade. And forcing the var gives no real security on its own: existing secrets stay encrypted under the public fallback until re-encrypted under a new key — which needs a migration this PR deliberately doesn't attempt. So: nudge now, proper key-rotation/re-encryption migration can follow.

`encryptPassword`/`decryptPassword` themselves are unchanged from `main`.

## 2. Client typecheck gate in CI (`.github/workflows/ci.yaml`)

`vite build` strips types, so client type errors reached `main` unnoticed — this exact gap shipped a query hook with the wrong argument shape during the Insights work (every request went out with no time window, all checks green).

`apps/client/scripts/check-types.mjs` runs `tsc` and compares normalized errors against a committed `type-errors-baseline.txt` (the pre-existing backlog), failing **only** on new errors. It is machine-portable (repo-root absolute paths in messages collapse to `<repo>`, so a locally-generated baseline matches CI), captures positionless global diagnostics, and hard-fails if `tsc` can't even launch. Self-tested both directions.

## Verification

- `encryption.test.ts` — original tests restored plus a `warnIfEncryptionKeyInsecure` never-throws test (env injected, no `process.env` mutation). Credential round-trips (integrations, aiConfig, auth) pass.
- Typecheck gate self-tested: catches a new error (exit 1), passes clean, fails on broken `tsc`.
- Server suite 300/300; client prettier/lint clean.

**Heads-up (out of scope, pre-existing):** the server suite has a ~25% parallel-setup flake (SMTP/registration races) — reproduced on clean `main`, not introduced here. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Production services now start with a warning when encryption settings are missing or insecure, instead of failing during startup.
  - Encryption remains compatible with existing stored values and safely falls back to the original value when decryption fails.

- **Chores**
  - Added automated client type checking to CI.
  - Added baseline tracking so newly introduced type errors are reported without blocking existing known issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->