### PR TITLE
feat(server): warn when ENCRYPTION_KEY is missing or insecure

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,11 +1,16 @@
 import { initializeDb } from './dal/db';
 import { createApp, AppMode } from './app';
 import { getServerConfig } from './config/config';
+import { warnIfEncryptionKeyInsecure } from './utils/encryption';
 import { Logger } from '@OpsiMate/shared';
 
 const logger = new Logger('server');
 
 await (async () => {
+	// Nudge, don't block: a production boot with no ENCRYPTION_KEY encrypts credentials
+	// under the public fallback key — warn loudly but keep existing deployments running.
+	warnIfEncryptionKeyInsecure();
+
 	const serverConfig = getServerConfig();
 
 	// Allow environment variable to override config file

--- a/apps/server/src/utils/encryption.ts
+++ b/apps/server/src/utils/encryption.ts
@@ -31,11 +31,21 @@ function getEncryptionKey(): string {
 export function warnIfEncryptionKeyInsecure(env: NodeJS.ProcessEnv = process.env): void {
 	if (env.NODE_ENV !== 'production') return;
 	const key = env.ENCRYPTION_KEY;
-	if (!key || key.trim().length === 0) {
+	// Cases are kept distinct because getEncryptionKey() uses `|| fallback`: an unset or
+	// EMPTY value resolves to the fallback, but a whitespace-only value is truthy and is
+	// used verbatim as the key — the warning must say which is actually protecting data.
+	if (!key) {
 		logger.warn(
 			'ENCRYPTION_KEY is not set. Stored credentials are being encrypted with the built-in ' +
 				'fallback key, which is PUBLIC (it ships in this repo). We highly recommend setting ' +
 				'ENCRYPTION_KEY to a strong, private secret. Continuing with the insecure default.'
+		);
+		return;
+	}
+	if (key.trim().length === 0) {
+		logger.warn(
+			'ENCRYPTION_KEY is set to a whitespace-only value, which is used verbatim as a weak, ' +
+				'easily-guessed encryption key. We highly recommend setting it to a strong, private secret.'
 		);
 		return;
 	}

--- a/apps/server/src/utils/encryption.ts
+++ b/apps/server/src/utils/encryption.ts
@@ -9,11 +9,39 @@ const KEY_LENGTH = 32;
 
 const logger = new Logger('encryption-');
 
+// The built-in key is a PUBLIC constant (it ships in this repo). It exists so local dev
+// and the test suite work with zero config — it must never protect real data.
+const DEV_FALLBACK_KEY = 'test-key-should-be-changed';
+
 /**
  * Get encryption key from environment variable or use default
  */
 function getEncryptionKey(): string {
-	return process.env.ENCRYPTION_KEY || 'test-key-should-be-changed';
+	return process.env.ENCRYPTION_KEY || DEV_FALLBACK_KEY;
+}
+
+/**
+ * Called once at server boot. In production, an unset (or blank) ENCRYPTION_KEY means
+ * every stored credential is encrypted under the public fallback key — no real
+ * protection. We only WARN (loudly, and every boot) rather than refuse to start, so
+ * existing deployments upgrade without downtime; setting ENCRYPTION_KEY silences it.
+ * No-op outside production, where the zero-config fallback is expected. Env is injected
+ * so tests never mutate the shared process.env.
+ */
+export function warnIfEncryptionKeyInsecure(env: NodeJS.ProcessEnv = process.env): void {
+	if (env.NODE_ENV !== 'production') return;
+	const key = env.ENCRYPTION_KEY;
+	if (!key || key.trim().length === 0) {
+		logger.warn(
+			'ENCRYPTION_KEY is not set. Stored credentials are being encrypted with the built-in ' +
+				'fallback key, which is PUBLIC (it ships in this repo). We highly recommend setting ' +
+				'ENCRYPTION_KEY to a strong, private secret. Continuing with the insecure default.'
+		);
+		return;
+	}
+	if (key === DEV_FALLBACK_KEY) {
+		logger.warn('ENCRYPTION_KEY is set to the public fallback value — we highly recommend rotating it.');
+	}
 }
 
 /**

--- a/apps/server/tests/encryption.test.ts
+++ b/apps/server/tests/encryption.test.ts
@@ -1,4 +1,4 @@
-import { encryptPassword, decryptPassword } from '../src/utils/encryption';
+import { encryptPassword, decryptPassword, warnIfEncryptionKeyInsecure } from '../src/utils/encryption';
 
 describe('Password Encryption', () => {
 	test('should encrypt and decrypt password correctly', () => {
@@ -40,5 +40,17 @@ describe('Password Encryption', () => {
 		const result = decryptPassword(invalidEncrypted);
 		// Should return the original value if decryption fails
 		expect(result).toBe(invalidEncrypted);
+	});
+
+	// The key invariant: warning must NEVER throw, so it can't block a boot. Env is
+	// injected, so this never mutates the shared process.env (which would leak into
+	// other test files in the same worker).
+	test('warnIfEncryptionKeyInsecure never throws, in any environment', () => {
+		expect(() => warnIfEncryptionKeyInsecure({ NODE_ENV: 'production' })).not.toThrow();
+		expect(() => warnIfEncryptionKeyInsecure({ NODE_ENV: 'production', ENCRYPTION_KEY: '   ' })).not.toThrow();
+		expect(() =>
+			warnIfEncryptionKeyInsecure({ NODE_ENV: 'production', ENCRYPTION_KEY: 'a-strong-secret' })
+		).not.toThrow();
+		expect(() => warnIfEncryptionKeyInsecure({ NODE_ENV: 'development' })).not.toThrow();
 	});
 });


### PR DESCRIPTION
## What

Stored credentials — users' password-reset tokens, secrets, integration credentials, and the Bedrock API key — are AES-GCM encrypted with a key derived from `ENCRYPTION_KEY`. When that env var is unset, the code falls back to `'test-key-should-be-changed'`: a constant that ships in this public repo, so the data is effectively unprotected.

`warnIfEncryptionKeyInsecure()` is called once at boot (before the DB opens) and logs a loud, **production-only** warning when `ENCRYPTION_KEY` is unset, blank, or still equals the public fallback. The server keeps running.

## Why a warning, not a hard failure

Every stock production deployment sets `NODE_ENV=production`, but **none** sets `ENCRYPTION_KEY` (it's absent from all Dockerfiles, `docker-compose.yml`, and docs). Refusing to boot would break every existing upgrade — and forcing the var gives no real security by itself, because existing secrets stay encrypted under the public fallback until they're re-encrypted under a new key. That re-encryption migration is the real fix and belongs in its own PR; this is the safe, non-breaking nudge in the meantime.

## Notes

- `encryptPassword` / `decryptPassword` are unchanged.
- Production-only, so local dev and tests (which legitimately use the fallback) aren't spammed.
- The env is injected into the function, so the test asserts the key invariant — **it never throws** (can't block a boot) — without mutating the shared `process.env`.

`encryption.test.ts`: original tests intact + the never-throws test. 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a startup warning when production encryption settings are missing, blank, or using an insecure fallback value.
  * Startup continues normally after displaying the warning.
* **Tests**
  * Added coverage for encryption warning behavior across production and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->