### PR TITLE
ci(client): gate tsc against a baseline so new type errors fail the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,11 @@ jobs:
       - name: Lint apps/client
         run: pnpm --filter @OpsiMate/client lint
 
+      # vite build strips types, so tsc is the only thing that type-checks the client.
+      # Gates on NEW errors vs a committed baseline (the pre-existing backlog).
+      - name: Typecheck apps/client
+        run: pnpm --filter @OpsiMate/client typecheck
+
       - name: Format apps/server
         run: pnpm --filter @OpsiMate/server format
 

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -17,6 +17,8 @@
 		"test:coverage": "vitest run --coverage",
 		"lint": "eslint .",
 		"lint-fix": "eslint . --fix",
+		"typecheck": "node scripts/check-types.mjs",
+		"typecheck:update": "node scripts/check-types.mjs --update",
 		"format": "prettier --check .",
 		"check": "npm run format && npm run lint",
 		"fix": "npm run format-fix && npm run lint-fix"

--- a/apps/client/scripts/check-types.mjs
+++ b/apps/client/scripts/check-types.mjs
@@ -1,0 +1,102 @@
+// Gate the client's `tsc` output against a committed baseline. `vite build` strips
+// types, so type errors otherwise reach main unnoticed (this exact gap once shipped a
+// hook calling a function with the wrong argument shape). The client carries a set of
+// pre-existing type errors we don't fix in one sweep; this script FAILS only on errors
+// NOT already in the baseline, so new code is gated while the backlog shrinks over time.
+//
+//   node scripts/check-types.mjs            check (used by CI); exits 1 on new errors
+//   node scripts/check-types.mjs --update   rewrite the baseline from current output
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const clientDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const baselineFile = join(clientDir, 'type-errors-baseline.txt');
+// Some error messages embed absolute paths (e.g. a type printed as
+// import("<repo>/packages/shared/dist/types")). That prefix differs by machine
+// (/Users/... locally vs /home/runner/... on CI), so collapse it or the baseline
+// would never match across environments.
+const repoRoot = resolve(clientDir, '..', '..');
+
+// tsc exits 1 (or 2) when it reports diagnostics — expected. Any OTHER failure means
+// tsc never actually ran (binary missing, bad config path), which must fail the gate
+// loudly instead of looking like "no errors".
+const runTsc = () => {
+	try {
+		execSync('pnpm exec tsc -p tsconfig.app.json --noEmit', {
+			cwd: clientDir,
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		return '';
+	} catch (error) {
+		const output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+		if (error.status !== 1 && error.status !== 2) {
+			console.error(`Could not run tsc — the client typecheck gate did not execute:\n${output}`);
+			process.exit(2);
+		}
+		return output;
+	}
+};
+
+// Normalize each diagnostic to a machine- and line-stable identity:
+//   "path(line,col): error TSxxxx: message" -> "path: error TSxxxx: message"
+//   "error TSxxxx: message" (global, no position) -> kept as-is
+// Global diagnostics (e.g. TS5058 "specified path does not exist") must be captured or
+// a broken invocation would normalize to nothing and pass green.
+const normalize = (output) => {
+	const ids = new Set();
+	for (const rawLine of output.split('\n')) {
+		const line = rawLine.split(repoRoot).join('<repo>');
+		const positioned = line.match(/^(.*?)\(\d+,\d+\): (error TS\d+: .*)$/);
+		if (positioned) {
+			ids.add(`${positioned[1]}: ${positioned[2]}`.trim());
+			continue;
+		}
+		const global = line.match(/^(error TS\d+: .*)$/);
+		if (global) ids.add(global[1].trim());
+	}
+	return [...ids].sort();
+};
+
+const current = normalize(runTsc());
+
+if (process.argv.includes('--update')) {
+	writeFileSync(baselineFile, current.length ? `${current.join('\n')}\n` : '');
+	console.log(`Wrote ${current.length} baseline type-error(s) to ${baselineFile}`);
+	process.exit(0);
+}
+
+const baseline = existsSync(baselineFile)
+	? new Set(
+			readFileSync(baselineFile, 'utf8')
+				.split('\n')
+				.map((line) => line.trim())
+				.filter(Boolean)
+		)
+	: new Set();
+
+const introduced = current.filter((id) => !baseline.has(id));
+const currentSet = new Set(current);
+const cleared = [...baseline].filter((id) => !currentSet.has(id));
+
+if (cleared.length > 0) {
+	console.log(
+		`\n${cleared.length} baseline error(s) no longer occur — run ` +
+			'`pnpm --filter @OpsiMate/client typecheck:update` to shrink the baseline.'
+	);
+}
+
+if (introduced.length > 0) {
+	console.error(`\n✖ ${introduced.length} NEW client type error(s) not in the baseline:\n`);
+	for (const id of introduced) console.error(`  ${id}`);
+	console.error(
+		'\nFix them, or — if intentional — update the baseline with ' +
+			'`pnpm --filter @OpsiMate/client typecheck:update`.'
+	);
+	process.exit(1);
+}
+
+console.log(`✓ No new client type errors (${baseline.size} known baseline error(s)).`);

--- a/apps/client/type-errors-baseline.txt
+++ b/apps/client/type-errors-baseline.txt
@@ -1,0 +1,25 @@
+src/App.tsx: error TS2322: Type '{ children: Element; future: { v7_startTransition: boolean; v7_relativeSplatPath: boolean; }; }' is not assignable to type 'IntrinsicAttributes & BrowserRouterProps'.
+src/components/Alerts/AlertsTable/AlertRow/CopyCellButton.tsx: error TS2554: Expected 1 arguments, but got 0.
+src/components/Dashboards/Dashboards.tsx: error TS2345: Argument of type '{ id: string; name: string; type: "services" | "alerts"; description: string; visibleColumns: string[]; filters: Record<string, string[]>; columnOrder: string[]; groupBy: string[]; query: string; timeRange: TimeRange; }' is not assignable to parameter of type 'DashboardState'.
+src/components/shared/FormattedText.tsx: error TS2503: Cannot find namespace 'DOMPurify'.
+src/hooks/queries/integrations/useIntegrationUrls.ts: error TS2559: Type 'string' has no properties in common with type 'LogOptions'.
+src/hooks/useFormErrors.ts: error TS2559: Type '{ success: boolean; error?: string; errors?: Record<string, string>; }' has no properties in common with type 'LogOptions'.
+src/lib/errorMapper.ts: error TS2339: Property 'details' does not exist on type 'unknown'.
+src/lib/errorMapper.ts: error TS2339: Property 'error' does not exist on type 'unknown'.
+src/lib/errorMapper.ts: error TS2339: Property 'success' does not exist on type 'unknown'.
+src/lib/sslKeys.ts: error TS2322: Type '{ id: string; name: string; value: string; }[]' is not assignable to type 'SecretMetadata[]'.
+src/mocks/handlers.ts: error TS2352: Conversion of type 'ActionConfig' to type 'Record<string, string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+src/mocks/mockAlerts.ts: error TS2322: Type '{ alertTypes: { Grafana: number; GCP: number; UptimeKuma: number; Custom: number; }; statuses: { firing: number; resolved: number; pending: number; suppressed: number; inhibited: number; }; tags: { production: number; ... 8 more ...; warning: number; }; alertNames: {}; }' is not assignable to type '{ alertTypes?: Record<AlertType, number>; statuses?: Record<string, number>; tags?: Record<string, number>; alertNames?: Record<string, number>; }'.
+src/mocks/mockAlerts.ts: error TS2561: Object literal may only specify known properties, but 'tag' does not exist in type 'Alert'. Did you mean to write 'tags'?
+src/mocks/mockAlerts.ts: error TS2739: Type '{ GCP: number; Grafana: number; Custom: number; UptimeKuma: number; }' is missing the following properties from type 'Record<AlertType, number>': Datadog, Zabbix
+src/mocks/mockAlerts.ts: error TS2739: Type '{ UptimeKuma: number; Grafana: number; GCP: number; Custom: number; }' is missing the following properties from type 'Record<AlertType, number>': Datadog, Zabbix
+src/mocks/mockAlerts.utils.ts: error TS2739: Type '{ Grafana: number; GCP: number; UptimeKuma: number; Custom: number; }' is missing the following properties from type 'Record<AlertType, number>': Datadog, Zabbix
+src/pages/Integrations.tsx: error TS2339: Property 'toLowerCase' does not exist on type 'never'.
+src/pages/Integrations.tsx: error TS2345: Argument of type '{ name: string; type: IntegrationType; externalUrl: string; credentials: {}; }' is not assignable to parameter of type '{ name: string; type: IntegrationType; externalUrl: string; credentials: Record<string, string>; }'.
+src/pages/Integrations.tsx: error TS2367: This comparison appears to be unintentional because the types 'IntegrationType' and 'import("<repo>/packages/shared/dist/types").IntegrationType' have no overlap.
+src/pages/Login.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
+src/pages/NotFound.tsx: error TS2559: Type 'string' has no properties in common with type 'LogOptions'.
+src/pages/Register.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
+src/pages/Settings.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'SetStateAction<number>'.
+src/test/severity.utils.test.ts: error TS2550: Property 'hasOwn' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
+src/test/useColumnManagement.test.tsx: error TS2741: Property 'values' is missing in type '{ key: string; label: string; }' but required in type 'TagKeyInfo'.


### PR DESCRIPTION
## What

`vite build` strips types, so **client type errors never fail CI** — they reach `main` unnoticed. This exact gap shipped a bug during the Insights work: a query hook was left calling a function with the wrong argument shape (object vs positional), so every request went out with no time window, and every check was green.

This adds a typecheck gate. Because the client carries a backlog of pre-existing type errors that we don't fix in one sweep, the gate compares against a committed baseline and fails **only on new errors**.

## How

`apps/client/scripts/check-types.mjs`:
- runs `tsc -p tsconfig.app.json --noEmit`;
- normalizes each diagnostic to a **line- and machine-stable** identity — line/column dropped so unrelated edits don't churn, and repo-root absolute paths that some messages embed (`import("<abs>/packages/shared/dist/types")`) collapsed to `<repo>` so a locally-generated baseline matches CI's `/home/runner` paths;
- captures **positionless global diagnostics** (e.g. `TS5058`), so a broken invocation can't normalize to an empty set and pass green;
- **hard-fails** if `tsc` never launches (binary missing, bad config) instead of reporting "no errors";
- fails only on errors absent from `type-errors-baseline.txt`, and reports cleared baseline entries so the file shrinks over time (`pnpm --filter @OpsiMate/client typecheck:update`).

Wired into CI right after the client lint step.

## Verification

- Clean tree passes with 25 known baseline errors.
- Injecting a type error makes the gate exit 1.
- A broken `--project` path surfaces `TS5058`, which the normalizer now catches.
- Script passes eslint + prettier.

The 25 baseline errors are pre-existing and out of scope here; the gate stops the pile from growing and nudges it down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)