### PR TITLE
feat(alerts): render tables and colors in alert descriptions

### DIFF
--- a/apps/client/src/components/shared/FormattedText.test.tsx
+++ b/apps/client/src/components/shared/FormattedText.test.tsx
@@ -1,0 +1,93 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { FormattedText, stripHtml } from './FormattedText';
+
+// FormattedText renders integration/webhook-provided HTML, so these tests are as much a
+// security contract as a formatting one: the allow-listed subset must render, and every
+// script / CSS-injection vector must be neutralized.
+
+const html = (text: string): string => {
+	const { container } = render(<FormattedText text={text} />);
+	return container.innerHTML;
+};
+
+describe('FormattedText — allowed formatting', () => {
+	test('renders a table with rows and cells', () => {
+		const out = html('<table><thead><tr><th>Metric</th></tr></thead><tbody><tr><td>CPU</td></tr></tbody></table>');
+		expect(out).toContain('<table');
+		expect(out).toContain('<th>Metric</th>');
+		expect(out).toContain('<td>CPU</td>');
+	});
+
+	test('keeps allow-listed inline colors (color, background-color)', () => {
+		const out = html('<span style="color: red; background-color: yellow">alert</span>');
+		expect(out).toContain('color: red');
+		expect(out).toContain('background-color: yellow');
+	});
+
+	test('keeps presentational bgcolor/colspan on table cells', () => {
+		const out = html('<table><tr><td colspan="2" bgcolor="#ffcc00">x</td></tr></table>');
+		expect(out).toContain('colspan="2"');
+		expect(out).toContain('bgcolor="#ffcc00"');
+	});
+
+	test('keeps bold, links (forced safe), and lists', () => {
+		const out = html('<b>bold</b> <a href="https://x.example">link</a> <ul><li>item</li></ul>');
+		expect(out).toContain('<b>bold</b>');
+		expect(out).toContain('rel="noopener noreferrer"');
+		expect(out).toContain('target="_blank"');
+		expect(out).toContain('<li>item</li>');
+	});
+});
+
+describe('FormattedText — security', () => {
+	test('strips <script> entirely', () => {
+		const out = html('<p>hi</p><script>window.__pwned = 1</script>');
+		expect(out).not.toContain('<script');
+		expect(out.toLowerCase()).not.toContain('__pwned');
+	});
+
+	test('strips event-handler attributes', () => {
+		const out = html('<img src=x onerror="alert(1)"><div onclick="alert(1)">x</div>');
+		expect(out.toLowerCase()).not.toContain('onerror');
+		expect(out.toLowerCase()).not.toContain('onclick');
+	});
+
+	test('neutralizes javascript: hrefs', () => {
+		const out = html('<a href="javascript:alert(1)">x</a>');
+		expect(out.toLowerCase()).not.toContain('javascript:alert');
+	});
+
+	test('drops layout/position CSS that could overlay or hide the UI', () => {
+		const out = html('<span style="position: fixed; top: 0; z-index: 9999; color: red">x</span>');
+		expect(out).not.toContain('position');
+		expect(out).not.toContain('z-index');
+		// the allow-listed color on the same element survives
+		expect(out).toContain('color: red');
+	});
+
+	test('drops url()/expression() CSS values even on allow-listed properties', () => {
+		const out = html(
+			'<span style="background-color: url(https://evil.example/x); color: expression(alert(1))">x</span>'
+		);
+		expect(out.toLowerCase()).not.toContain('url(');
+		expect(out.toLowerCase()).not.toContain('expression');
+	});
+
+	test('strips iframes', () => {
+		const out = html('<iframe src="https://evil.example"></iframe>');
+		expect(out.toLowerCase()).not.toContain('<iframe');
+	});
+});
+
+describe('stripHtml', () => {
+	test('flattens a table to its cell text for single-line contexts', () => {
+		// Tag removal concatenates adjacent cell text; the details view is where tables
+		// render structurally. The list column just needs a compact, safe one-liner.
+		expect(stripHtml('<table><tr><td>CPU</td><td>98%</td></tr></table>')).toBe('CPU98%');
+	});
+
+	test('leaves plain text untouched', () => {
+		expect(stripHtml('just text')).toBe('just text');
+	});
+});

--- a/apps/client/src/components/shared/FormattedText.test.tsx
+++ b/apps/client/src/components/shared/FormattedText.test.tsx
@@ -25,6 +25,12 @@ describe('FormattedText — allowed formatting', () => {
 		expect(out).toContain('background-color: yellow');
 	});
 
+	test('keeps rgb() and hex colors (the value guard must not eat function syntax)', () => {
+		const out = html('<span style="color: rgb(255, 0, 0); background-color: #c8f7c5">alert</span>');
+		expect(out).toContain('rgb(255, 0, 0)');
+		expect(out).toContain('#c8f7c5');
+	});
+
 	test('keeps presentational bgcolor/colspan on table cells', () => {
 		const out = html('<table><tr><td colspan="2" bgcolor="#ffcc00">x</td></tr></table>');
 		expect(out).toContain('colspan="2"');
@@ -77,6 +83,43 @@ describe('FormattedText — security', () => {
 	test('strips iframes', () => {
 		const out = html('<iframe src="https://evil.example"></iframe>');
 		expect(out.toLowerCase()).not.toContain('<iframe');
+	});
+
+	test('rejects CSS-escaped url() that dodges a literal match', () => {
+		// \\28/\\29 are escaped parens; \\75 is an escaped "u" — a naive /url\(/ guard
+		// would miss these, so the value guard rejects any backslash or "url" substring.
+		const out = html(
+			'<span style="background-color:url\\28 https://evil.example\\29">a</span>' +
+				'<span style="color:\\75rl(https://evil.example)">b</span>'
+		);
+		expect(out.toLowerCase()).not.toContain('evil.example');
+		expect(out).not.toContain('\\28');
+		expect(out).not.toContain('75rl');
+	});
+
+	test('drops URL-fetching CSS properties even if someone crafts them', () => {
+		// These are not in the allow-list; a value that fetches must never survive.
+		const out = html(
+			'<span style="background-image:url(https://evil.example/a)">a</span>' +
+				'<span style="background:url(https://evil.example/b)">b</span>' +
+				'<span style="border-image:url(https://evil.example/c)">c</span>' +
+				'<span style="cursor:url(https://evil.example/d),auto">d</span>'
+		);
+		expect(out.toLowerCase()).not.toContain('evil.example');
+		expect(out.toLowerCase()).not.toContain('background-image');
+		expect(out.toLowerCase()).not.toContain('border-image');
+	});
+
+	test('neutralizes mutation-XSS via svg/style nesting', () => {
+		const out = html('<svg><style><img src=x onerror=alert(1)></style></svg>');
+		expect(out.toLowerCase()).not.toContain('onerror');
+		expect(out.toLowerCase()).not.toContain('<svg');
+	});
+
+	test('forces target=_blank even when the input sets target=_self', () => {
+		const out = html('<a href="https://x.example" target="_self">x</a>');
+		expect(out).toContain('target="_blank"');
+		expect(out).not.toContain('_self');
 	});
 });
 

--- a/apps/client/src/components/shared/FormattedText.test.tsx
+++ b/apps/client/src/components/shared/FormattedText.test.tsx
@@ -110,6 +110,17 @@ describe('FormattedText — security', () => {
 		expect(out.toLowerCase()).not.toContain('border-image');
 	});
 
+	test('drops disallowed CSS properties by NAME, independent of the value guard', () => {
+		// Innocent values (no url()/escape to trip DANGEROUS_CSS_VALUE), so this proves the
+		// property allow-list itself blocks URL-capable properties — the one allow-listed
+		// property on the same element survives.
+		const out = html('<span style="background: red; cursor: auto; position: static; color: green">x</span>');
+		expect(out).not.toContain('background');
+		expect(out).not.toContain('cursor');
+		expect(out).not.toContain('position');
+		expect(out).toContain('color: green');
+	});
+
 	test('neutralizes mutation-XSS via svg/style nesting', () => {
 		const out = html('<svg><style><img src=x onerror=alert(1)></style></svg>');
 		expect(out.toLowerCase()).not.toContain('onerror');

--- a/apps/client/src/components/shared/FormattedText.tsx
+++ b/apps/client/src/components/shared/FormattedText.tsx
@@ -17,6 +17,7 @@ const SANITIZE_CONFIG: DOMPurify.Config = {
 		'hr',
 		'div',
 		'span',
+		'font',
 		'ul',
 		'ol',
 		'li',
@@ -27,9 +28,64 @@ const SANITIZE_CONFIG: DOMPurify.Config = {
 		'h2',
 		'h3',
 		'h4',
+		'table',
+		'thead',
+		'tbody',
+		'tfoot',
+		'tr',
+		'th',
+		'td',
+		'caption',
 	],
-	ALLOWED_ATTR: ['href', 'target', 'rel'],
+	// `style` is allowed but hard-filtered to a color/formatting property allow-list (see
+	// the hook below); `color`/`bgcolor`/`align`/`colspan`/`rowspan` are presentational
+	// only (they carry no script or URL vector).
+	ALLOWED_ATTR: ['href', 'target', 'rel', 'style', 'color', 'bgcolor', 'align', 'colspan', 'rowspan'],
 };
+
+// The only CSS properties an inline style may set. Anything else — layout/positioning
+// (position, display, z-index, width, height, margin), which could overlay or hide UI —
+// is dropped. Colors and basic text/table styling are what integrations actually use.
+const ALLOWED_STYLE_PROPERTIES = new Set([
+	'color',
+	'background-color',
+	'font-weight',
+	'font-style',
+	'text-decoration',
+	'text-align',
+	'border',
+	'border-color',
+	'border-width',
+	'border-style',
+	'padding',
+]);
+
+// Value-level guard, independent of the property allow-list: reject anything that could
+// smuggle a fetch or script — url(), expression(), javascript:, @import, CSS comments, or
+// angle brackets.
+const DANGEROUS_CSS_VALUE = /url\(|expression|javascript:|@import|[<>]|\/\*/i;
+
+// Keep only allow-listed, safe-valued declarations from a style attribute.
+const sanitizeStyle = (raw: string): string =>
+	raw
+		.split(';')
+		.map((declaration) => declaration.trim())
+		.filter(Boolean)
+		.filter((declaration) => {
+			const colon = declaration.indexOf(':');
+			if (colon === -1) return false;
+			const property = declaration.slice(0, colon).trim().toLowerCase();
+			const value = declaration.slice(colon + 1).trim();
+			return ALLOWED_STYLE_PROPERTIES.has(property) && !DANGEROUS_CSS_VALUE.test(value);
+		})
+		.join('; ');
+
+// Filter the style attribute down to the allow-list before DOMPurify keeps it.
+DOMPurify.addHook('uponSanitizeAttribute', (_node, event) => {
+	if (event.attrName === 'style') {
+		event.attrValue = sanitizeStyle(event.attrValue);
+	}
+});
 
 // Links open in a new tab and can't reach back into the opener.
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
@@ -56,7 +112,7 @@ interface FormattedTextProps {
 }
 
 // Renders user/integration-provided text with formatting: newlines are preserved, and a safe
-// subset of HTML (bold, links, lists, ...) is rendered after sanitization.
+// subset of HTML (bold, links, lists, tables, colors, ...) is rendered after sanitization.
 export const FormattedText = ({ text, className }: FormattedTextProps) => {
 	if (!containsHtml(text)) {
 		// overflow-wrap:anywhere (not just break-words) so a single very long token with no
@@ -71,9 +127,15 @@ export const FormattedText = ({ text, className }: FormattedTextProps) => {
 				'[&_a]:text-primary [&_a]:underline [&_ul]:list-disc [&_ol]:list-decimal [&_ul]:pl-5 [&_ol]:pl-5',
 				'[&_code]:bg-muted [&_code]:px-1 [&_code]:rounded [&_code]:font-mono [&_code]:text-xs',
 				'[&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_h4]:text-sm [&_h4]:font-semibold',
+				// Tables get visible structure by default; any inline colors layer on top.
+				'[&_table]:my-2 [&_table]:border-collapse [&_table]:text-xs',
+				'[&_caption]:text-xs [&_caption]:text-muted-foreground [&_caption]:mb-1',
+				'[&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_th]:bg-muted [&_th]:font-semibold [&_th]:text-left',
+				'[&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1',
 				className
 			)}
-			// Safe: content is sanitized by DOMPurify with an explicit allow-list just above.
+			// Safe: content is sanitized by DOMPurify with an explicit allow-list above, and
+			// the style attribute is filtered to a color/formatting property allow-list.
 			dangerouslySetInnerHTML={{ __html: safe }}
 		/>
 	);

--- a/apps/client/src/components/shared/FormattedText.tsx
+++ b/apps/client/src/components/shared/FormattedText.tsx
@@ -46,6 +46,12 @@ const SANITIZE_CONFIG: DOMPurify.Config = {
 // The only CSS properties an inline style may set. Anything else — layout/positioning
 // (position, display, z-index, width, height, margin), which could overlay or hide UI —
 // is dropped. Colors and basic text/table styling are what integrations actually use.
+//
+// SECURITY INVARIANT: never add a property that can RESOLVE A URL (`background`,
+// `background-image`, `border-image`, `cursor`, `content`, `list-style-image`, `mask`,
+// `filter`, ...). This content is attacker-controlled; such a property turns an inline
+// style into an SSRF / tracking / exfiltration vector. The value guard below is
+// defense-in-depth, not a substitute for keeping this list URL-free.
 const ALLOWED_STYLE_PROPERTIES = new Set([
 	'color',
 	'background-color',
@@ -61,9 +67,11 @@ const ALLOWED_STYLE_PROPERTIES = new Set([
 ]);
 
 // Value-level guard, independent of the property allow-list: reject anything that could
-// smuggle a fetch or script — url(), expression(), javascript:, @import, CSS comments, or
-// angle brackets.
-const DANGEROUS_CSS_VALUE = /url\(|expression|javascript:|@import|[<>]|\/\*/i;
+// smuggle a fetch, script, or at-rule. `url` (in any form), `expression`, `javascript:`,
+// angle brackets, CSS comments — plus any backslash (a CSS escape, which could spell
+// `\75rl(...)` past a literal match) and any `@` (at-rules). None of the allow-listed
+// properties above ever legitimately need these, so rejecting them breaks no real color.
+const DANGEROUS_CSS_VALUE = /url|expression|javascript:|[<>]|\/\*|\\|@/i;
 
 // Keep only allow-listed, safe-valued declarations from a style attribute.
 const sanitizeStyle = (raw: string): string =>


### PR DESCRIPTION
## What

Alert summaries (and enrichment text) render through `FormattedText` → DOMPurify with an allow-list. Tables and colors were stripped; this enables both.

- **Tables**: `table/thead/tbody/tfoot/tr/th/td/caption` added to `ALLOWED_TAGS`, with default styling (borders, header background) so a bare `<table>` is legible; inline colors layer on top.
- **Colors**: the `style` attribute is now allowed **but hard-filtered** to a property allow-list — `color`, `background-color`, `font-weight`, `font-style`, `text-decoration`, `text-align`, `border*`, `padding`. Presentational `color`/`bgcolor`/`align`/`colspan`/`rowspan` attributes are allowed too (no script or URL vector).

## Security

This deliberately loosens a sanitizer that renders **external, webhook-provided** content, so the guard rails matter:

- **Layout/positioning CSS is dropped** — `position`, `z-index`, `width`, `height`, `margin`, `display`, etc. are not in the allow-list, so a style can't create a fullscreen overlay or hide the UI.
- **Dangerous CSS values are rejected** regardless of property — `url(...)`, `expression(...)`, `javascript:`, `@import`, CSS comments, angle brackets.
- **Unchanged**: scripts, event handlers (`onerror`/`onclick`/…), iframes, and `javascript:` hrefs are still stripped; links are still forced to `target=_blank` + `rel=noopener noreferrer`.

## Verification

`FormattedText.test.tsx` (new, 12 tests) covers the allowed formatting **and** the attack vectors: `<script>`, `onerror`/`onclick`, `javascript:` href, `position/z-index` overlay, `url()`/`expression()` in allowed properties, `<iframe>`.

Verified **live** by ingesting a real alert whose summary mixed a table + colors with an embedded XSS/overlay payload:
- table renders with borders/header; "RED BOLD" computes to `rgb(255,0,0)`+bold; a cell background computes to the sent green; a cell text to red.
- `window.__pwned` stayed `undefined` (no script/onerror/js-link ran); the fullscreen-overlay span was reduced to a static 154px inline box (`position:static`, `z-index:auto`).

Passes the new client typecheck gate, eslint, prettier.

Note: the alerts *list* Summary column still shows plain text (`stripHtml`) — tables render in the details drawer, which is the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rich text now supports tables, captions, inline colors, bold text, lists, and improved table styling.
  - Safe links and selected formatting attributes are preserved when displaying formatted content.

- **Bug Fixes**
  - Improved HTML sanitization removes scripts, unsafe links, event handlers, dangerous styles, embedded frames, and other unsafe content.
  - Plain text and table content are handled more reliably while preserving safe formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->