### PR TITLE
perf(alerts): drop backdrop-blur from sticky group headers

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/StickyGroupHeader/StickyGroupHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/StickyGroupHeader/StickyGroupHeader.tsx
@@ -34,7 +34,12 @@ export const StickyGroupHeader = ({ item, onToggle, columnLabels = {} }: StickyG
 	return (
 		<div
 			key={`sticky-${item.key}`}
-			className="flex items-center h-8 border-b bg-muted/50 backdrop-blur-md hover:bg-muted/70 px-2 cursor-pointer"
+			// No backdrop-blur: these copies are pinned while the virtualized rows scroll
+			// underneath, and backdrop-filter re-blurs that region every frame (several stack
+			// when grouping is nested) — real scroll jank on integrated GPUs. It was also
+			// vestigial: the opaque bg-background backing behind these copies is what the
+			// filter would sample, so removing it leaves the bg-muted/50 look unchanged.
+			className="flex items-center h-8 border-b bg-muted/50 hover:bg-muted/70 px-2 cursor-pointer"
 			style={{
 				paddingLeft: `${item.level * 24 + 8}px`,
 			}}


### PR DESCRIPTION
## What

Removes `backdrop-blur-md` from the sticky group-header copies (`StickyGroupHeader.tsx`).

## Why

These copies stay pinned at the top of the alerts table while the virtualized rows scroll underneath. `backdrop-filter: blur()` forces the GPU to re-sample and re-blur that full-width region **every scroll frame**, and several stack when grouping is nested (`activeStickyHeaders.map(...)`). On integrated GPUs this is real scroll jank — reported as "the view slows down" on some machines.

It was also **visually vestigial**: an opaque `bg-background` layer already sits directly behind these copies (`AlertsTable.tsx`, added to prevent double-translucency darkening), so the filter was sampling a solid color and produced no visible blur. Removing it keeps the `bg-muted/50` appearance identical.

## Verification

- Grouped the alerts table (by Severity) and confirmed the group headers render unchanged — clean muted background, crisp text, no transparency bleed — with the blur gone.
- Passes eslint, prettier, and the client typecheck gate.

Pure CSS-class removal; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scrolling performance in the alerts table by removing an unnecessary visual blur effect from sticky group headers.
  - Sticky headers now maintain their existing layout, background, hover, and interaction behavior while scrolling more smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->