### PR TITLE
fix(server): revert js-yaml to 4.x again — v5 crashes on existing user configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # js-yaml 5 made the parser spec-strict: it rejects the multi-line flow
+      # mapping that configs written before #854 contain, failing with
+      # "deficient indentation" and killing the server at startup. User configs
+      # are mounted into the container, so upgrading the image never rewrites
+      # them and the crash lands on existing installs.
+      #
+      # This has now shipped twice -- reverted in #854, bumped straight back by
+      # #879, released broken as 0.0.108. Majors stay blocked until the loader
+      # can migrate (or clearly diagnose) a legacy config. Minor and patch
+      # updates within 4.x still come through.
+      - dependency-name: "js-yaml"
+        update-types: ["version-update:semver-major"]
 
   # Backend + frontend Docker images
   - package-ecosystem: "docker"

--- a/apps/server/.prettierignore
+++ b/apps/server/.prettierignore
@@ -3,3 +3,10 @@ dist/
 coverage/
 pnpm-lock.yaml
 package-lock.json
+
+# Regression fixture for the js-yaml 4 -> 5 breakage. Its whole purpose is a
+# multi-line flow mapping whose closing brace sits at its key's indent -- the
+# shape js-yaml 5 rejects and older user configs contain. Prettier reformats it
+# to indent the continuation lines past the key, which is precisely the shape
+# js-yaml 5 accepts, so formatting this file would silently defeat the test.
+tests/fixtures/legacy-flow-mapping-config.yml

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -33,7 +33,7 @@
 		"compression": "^1.8.1",
 		"cors": "^2.8.6",
 		"express": "^5.2.1",
-		"js-yaml": "^5.4.1",
+		"js-yaml": "^4.3.0",
 		"jsonwebtoken": "^9.0.3",
 		"multer": "^2.2.0",
 		"node-ssh": "^13.2.1",

--- a/apps/server/tests/fixtures/legacy-flow-mapping-config.yml
+++ b/apps/server/tests/fixtures/legacy-flow-mapping-config.yml
@@ -1,0 +1,40 @@
+# A user config in the format this project shipped before #854 reformatted
+# default-config.yml to block style.
+#
+# Do NOT "fix" the indentation below. The multi-line flow mapping under
+# mailer.templates is the entire point of this fixture: js-yaml 4 accepts it,
+# js-yaml 5 rejects it with "deficient indentation", and configs in exactly
+# this shape are sitting on disk in existing installs. They are mounted into
+# the container, so upgrading the image does not rewrite them -- if the parser
+# stops accepting this, those deployments crash at startup.
+
+server:
+  port: 3001
+  host: "0.0.0.0"
+
+database:
+  path: "/app/data/database/opsimate.db"
+
+security:
+  private_keys_path: "/app/data/private-keys"
+  api_token: "opsimate"
+
+mailer:
+  enabled: false
+  default_encoding: "UTF-8"
+  host: "smtp.gmail.com"
+  port: 587
+  secure: false
+  mailLinkBaseUrl: "http://localhost:8080"
+  from: "<no-reply@yourdomain.com>"
+  replyTo: "ops@yourdomain.com"
+  templates:
+    welcomeTemplate: {
+        subject: 'Welcome to OpsiMate!',
+        content: 'Welcome aboard! We are happy to have you as part of the OpsiMate community.'
+    }
+  auth:
+    user: "your-email@domain.com"
+    pass: "your-smtp-password"
+  tls:
+    rejectUnauthorized: true

--- a/apps/server/tests/shippedConfigs.test.ts
+++ b/apps/server/tests/shippedConfigs.test.ts
@@ -9,6 +9,17 @@ import { describe, expect, test } from 'vitest';
 // when no config is mounted — had a multi-line flow mapping whose closing brace sat at
 // its key's indent. Every Docker user without a mounted config crashed on upgrade with
 // "deficient indentation", and nothing in the suite noticed.
+//
+// That happened twice. #854 reverted js-yaml to 4.x and reformatted the shipped files
+// to block style; dependabot #879 bumped it back to 5.x eight days later and 0.0.108
+// shipped the crash again. These tests stayed green through it, because reformatting
+// our own files is exactly what makes them parse under the strict parser.
+//
+// So the cases below split in two:
+//   - the shipped configs, which we control and keep in block style, and
+//   - a fixture in the OLD format, which we do NOT control. Users' configs are mounted
+//     into the container, so an image upgrade never rewrites them. Any parser we ship
+//     has to keep reading them, and that is the case a version bump can actually break.
 
 const repoRoot = path.resolve(__dirname, '../../..');
 
@@ -74,5 +85,30 @@ describe('shipped YAML configs', () => {
 				).toBe(false);
 			});
 		}
+	});
+
+	// The case that #879 slipped past. This fixture is a user config in the pre-#854
+	// format; it is deliberately NOT in SHIPPED_CONFIGS, because the flow-mapping check
+	// above would (correctly) reject it. Nothing rewrites a mounted config on upgrade,
+	// so if this stops parsing, existing installs crash at startup on the new image.
+	test('a legacy user config with a multi-line flow mapping still parses', () => {
+		const fixture = path.join(__dirname, 'fixtures/legacy-flow-mapping-config.yml');
+		expect(fs.existsSync(fixture), 'legacy config fixture is missing').toBe(true);
+
+		const raw = fs.readFileSync(fixture, 'utf8');
+		// Guard the fixture itself: if someone tidies the indentation away, the test
+		// would keep passing while covering nothing.
+		expect(
+			raw.split('\n').some((line) => line.split('#')[0].trimEnd().endsWith('{')),
+			'fixture no longer contains a multi-line flow mapping — it must, or it tests nothing'
+		).toBe(true);
+
+		const parsed = yaml.load(raw) as Record<string, any>;
+		expect(parsed, 'legacy config parsed to nothing').toBeTruthy();
+		expect(parsed.mailer?.templates?.welcomeTemplate?.subject).toBe('Welcome to OpsiMate!');
+		// The fields loadConfig() needs, same as the shipped configs.
+		expect(parsed.server?.port).toBeTruthy();
+		expect(parsed.database?.path).toBeTruthy();
+		expect(parsed.security?.private_keys_path).toBeTruthy();
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,8 +319,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       js-yaml:
-        specifier: ^5.4.1
-        version: 5.4.1
+        specifier: ^4.3.0
+        version: 4.3.2
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -3796,8 +3796,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.4.1:
-    resolution: {integrity: sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -8837,7 +8837,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.4.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
**0.0.108 fails to start for users whose `config.yml` predates #854.** Reported from a client hitting an error on line 37 of their config.

## The crash

Configs written in the format this project shipped before #854 look like this:

```yaml
33:  templates:
34:    welcomeTemplate: {
35:        subject: 'Welcome to OpsiMate!',
36:        content: 'Welcome aboard! ...'
37:    }          ← closing brace at the key's indent
```

js-yaml 5 made the parser spec-strict and rejects that shape. js-yaml 4 accepts it.

```
YAMLException: deficient indentation (37:5)
    at throwError (/app/node_modules/.pnpm/js-yaml@5.4.1/.../js-yaml.mjs:1849:16)
```

Same config, same command, both images:

| | js-yaml | Result |
|---|---|---|
| `0.0.107` | 4.3.1 | `Server running on 0.0.0.0:3001` |
| `0.0.108` | 5.4.1 | **`Exited (1)`** |

User configs are bind-mounted into the container, so upgrading the image never rewrites them — the crash lands squarely on existing installs.

## This is the second time it has shipped

- **#854** (Aug 16) — reverted js-yaml to 4.x for exactly this reason, and reformatted the shipped configs to block style.
- **#879** (Aug 23) — dependabot bumped it back to 5.3.0.
- **0.0.108** (Aug 30) — released with 5.4.1. Same crash, back in production.

## Why CI stayed green

`shippedConfigs.test.ts` only parses files **we** control — `default-config.yml` and `configuration_example/docker-config.yml`. #854 reformatted both to block style *in the same commit* as the downgrade, so they parse fine under js-yaml 5 and the suite could never have failed on #879.

The tests were guarding the wrong surface: that *our* files parse, not that the parser still reads configs **we previously told users to write**.

## Changes

1. **`apps/server/package.json` → `js-yaml: ^4.3.0`.** Lockfile resolves 4.3.2; the lockfile diff touches nothing but js-yaml (5 lines).

2. **A regression test with an old-format fixture** (`tests/fixtures/legacy-flow-mapping-config.yml`), deliberately *not* in `SHIPPED_CONFIGS` — the existing flow-mapping lint would correctly reject it. It also asserts the fixture still *contains* a multi-line flow mapping, so a future tidy-up can't quietly hollow the test out.

3. **A dependabot `ignore` for js-yaml majors**, with the history in a comment. Minor/patch within 4.x still flows through.

## Verification

- New test verified **in both directions**: fails with `deficient indentation` on js-yaml 5.4.1, passes on 4.3.2. This is the check that would have failed #879.
- Full server suite: **307 tests / 21 files, all passing**.
- Built `Dockerfile.server` from this branch and ran it against the exact config that kills 0.0.108 — starts cleanly, `/health` → 200.

## Follow-up, not in this PR

If you want js-yaml 5 eventually, the loader needs a migration path for legacy configs — normalize the old shape at startup, or fail with a message naming the block to reformat instead of a raw `YAMLException`. That's a feature, and it shouldn't ride along with a hotfix.

Suggest cutting **0.0.109** off this once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved compatibility with existing server configuration files using legacy multi-line YAML mappings.
  * Prevented startup failures when loading older configurations.

* **Tests**
  * Added regression coverage verifying legacy configurations parse correctly and retain required settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->