### PR TITLE
fix(server): validate audit pagination and wrap response in envelope

### DIFF
--- a/apps/client/src/pages/Settings.tsx
+++ b/apps/client/src/pages/Settings.tsx
@@ -710,9 +710,9 @@ const AuditLogTable: React.FC = () => {
 
 		auditApi.getAuditLogs(page, pageSize).then((res) => {
 			if (mounted) {
-				if (res && Array.isArray(res.logs)) {
-					setLogs(res.logs);
-					setTotal(res.total || 0);
+				if (res?.success && res.data && Array.isArray(res.data.logs)) {
+					setLogs(res.data.logs);
+					setTotal(res.data.total || 0);
 					setError(null);
 				} else {
 					setError(res?.error || 'Failed to fetch audit logs');

--- a/apps/server/src/api/v1/audit/controller.ts
+++ b/apps/server/src/api/v1/audit/controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express';
 import { AuditBL } from '../../../bl/audit/audit.bl';
 import { Logger } from '@OpsiMate/shared';
+import { AuditListQueryParamsSchema } from './models';
+import { isZodError } from '../../../utils/isZodError.ts';
 
 const logger = new Logger('api/v1/audit/controller');
 
@@ -8,15 +10,17 @@ export class AuditController {
 	constructor(private auditBL: AuditBL) {}
 
 	getAuditLogsPaginated = async (req: Request, res: Response) => {
-		const page = parseInt(req.query.page as string) || 1;
-		const pageSize = parseInt(req.query.pageSize as string) || 20;
 		try {
+			const { page, pageSize } = AuditListQueryParamsSchema.parse(req.query);
 			const result = await this.auditBL.getAuditLogsPaginated(page, pageSize);
 			// result.logs now includes userName and resourceName
-			return res.json(result);
+			return res.json({ success: true, data: result });
 		} catch (error) {
+			if (isZodError(error)) {
+				return res.status(400).json({ success: false, error: 'Validation error', details: error.issues });
+			}
 			logger.error('Error fetching audit logs:', error);
-			return res.status(500).json({ error: 'Failed to fetch audit logs' });
+			return res.status(500).json({ success: false, error: 'Failed to fetch audit logs' });
 		}
 	};
 }

--- a/apps/server/src/api/v1/audit/models.ts
+++ b/apps/server/src/api/v1/audit/models.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// Mirrors AlertListQueryParamsSchema (apps/server/src/api/v1/alerts/models.ts) — same
+// coercion + bounds pattern, capped at 100 since audit pages are rendered in a UI table,
+// not consumed as a bulk export.
+export const AuditListQueryParamsSchema = z.object({
+	page: z.coerce.number().int().min(1).optional().default(1),
+	pageSize: z.coerce.number().int().min(1).max(100).optional().default(20),
+});

--- a/apps/server/tests/action-audit.test.ts
+++ b/apps/server/tests/action-audit.test.ts
@@ -46,10 +46,10 @@ describe('Action Audit Logs', () => {
 
 		const auditRes = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
 		expect(auditRes.status).toBe(200);
-		expect(Array.isArray(auditRes.body.logs)).toBe(true);
-		expect(auditRes.body.logs.length).toBe(1);
+		expect(Array.isArray(auditRes.body.data.logs)).toBe(true);
+		expect(auditRes.body.data.logs.length).toBe(1);
 
-		const log: AuditLog = auditRes.body.logs[0];
+		const log: AuditLog = auditRes.body.data.logs[0];
 		expect(log.actionType).toBe(AuditActionType.CREATE);
 		expect(log.resourceType).toBe(AuditResourceType.ACTION);
 		expect(log.resourceId).toBe(String(createRes.body.data.id));
@@ -80,7 +80,7 @@ describe('Action Audit Logs', () => {
 		const auditRes = await app.get('/api/v1/audit?page=1&pageSize=10').set('Authorization', `Bearer ${jwtToken}`);
 		expect(auditRes.status).toBe(200);
 
-		const logs = auditRes.body.logs as AuditLog[];
+		const logs = auditRes.body.data.logs as AuditLog[];
 		const actionLogs = logs.filter(
 			(log) => log.resourceType === AuditResourceType.ACTION && log.resourceId === resourceId
 		);

--- a/apps/server/tests/audit.test.ts
+++ b/apps/server/tests/audit.test.ts
@@ -54,10 +54,11 @@ describe('Audit Logs API', () => {
 
 		const auditRes = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
 		expect(auditRes.status).toBe(200);
-		expect(Array.isArray(auditRes.body.logs)).toBe(true);
-		expect(auditRes.body.logs.length).toBe(1);
+		expect(auditRes.body.success).toBe(true);
+		expect(Array.isArray(auditRes.body.data.logs)).toBe(true);
+		expect(auditRes.body.data.logs.length).toBe(1);
 
-		const log: AuditLog = auditRes.body.logs[0];
+		const log: AuditLog = auditRes.body.data.logs[0];
 		expect(log.actionType).toBe(AuditActionType.CREATE);
 		expect(log.resourceType).toBe(AuditResourceType.ENRICHMENT);
 		expect(log.resourceId).toBe(String(createRes.body.data.id));
@@ -100,7 +101,7 @@ describe('Audit Logs API', () => {
 		const auditRes = await app.get('/api/v1/audit?page=1&pageSize=10').set('Authorization', `Bearer ${jwtToken}`);
 		expect(auditRes.status).toBe(200);
 
-		const logs = auditRes.body.logs as AuditLog[];
+		const logs = auditRes.body.data.logs as AuditLog[];
 		const enrichmentLogs = logs.filter(
 			(log) => log.resourceType === AuditResourceType.ENRICHMENT && log.resourceId === resourceId
 		);
@@ -144,7 +145,7 @@ describe('Audit Logs API', () => {
 
 		const auditRes = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
 		expect(auditRes.status).toBe(200);
-		expect(auditRes.body.logs).toHaveLength(0);
+		expect(auditRes.body.data.logs).toHaveLength(0);
 	});
 
 	test('should log mute policy create, update and delete audit entries', async () => {
@@ -176,7 +177,7 @@ describe('Audit Logs API', () => {
 		const auditRes = await app.get('/api/v1/audit?page=1&pageSize=10').set('Authorization', `Bearer ${jwtToken}`);
 		expect(auditRes.status).toBe(200);
 
-		const logs = (auditRes.body.logs as AuditLog[]).filter(
+		const logs = (auditRes.body.data.logs as AuditLog[]).filter(
 			(log) => log.resourceType === AuditResourceType.MUTE_POLICY && log.resourceId === resourceId
 		);
 		const createLog = logs.find((log) => log.actionType === AuditActionType.CREATE);
@@ -295,19 +296,64 @@ describe('Audit Logs API', () => {
 		// Fetch first page
 		const res1 = await app.get('/api/v1/audit?page=1&pageSize=3').set('Authorization', `Bearer ${jwtToken}`);
 		expect(res1.status).toBe(200);
-		expect(res1.body.logs.length).toBe(3);
-		expect(res1.body.total).toBe(5);
+		expect(res1.body.data.logs.length).toBe(3);
+		expect(res1.body.data.total).toBe(5);
 		// Fetch second page
 		const res2 = await app.get('/api/v1/audit?page=2&pageSize=3').set('Authorization', `Bearer ${jwtToken}`);
 		expect(res2.status).toBe(200);
-		expect(res2.body.logs.length).toBe(2);
+		expect(res2.body.data.logs.length).toBe(2);
 	});
 
 	test('should return empty logs if none exist', async () => {
 		db.exec('DELETE FROM audit_logs');
 		const res = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
 		expect(res.status).toBe(200);
-		expect(Array.isArray(res.body.logs)).toBe(true);
-		expect(res.body.logs.length).toBe(0);
+		expect(Array.isArray(res.body.data.logs)).toBe(true);
+		expect(res.body.data.logs.length).toBe(0);
+	});
+
+	test('should wrap the response in the standard success envelope', async () => {
+		const res = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual(
+			expect.objectContaining({
+				success: true,
+				data: expect.objectContaining({
+					logs: expect.any(Array),
+					total: expect.any(Number),
+				}),
+			})
+		);
+	});
+
+	test('should default to page 1 / pageSize 20 when params are omitted', async () => {
+		const res = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
+		expect(res.status).toBe(200);
+		expect(res.body.success).toBe(true);
+		// No way to observe page/pageSize directly, so assert on the resulting page shape:
+		// at most the default pageSize of logs come back, and the request doesn't error out.
+		expect(res.body.data.logs.length).toBeLessThanOrEqual(20);
+	});
+
+	test('should reject a zero or negative page number', async () => {
+		const zeroRes = await app.get('/api/v1/audit?page=0').set('Authorization', `Bearer ${jwtToken}`);
+		expect(zeroRes.status).toBe(400);
+		expect(zeroRes.body.success).toBe(false);
+
+		const negativeRes = await app.get('/api/v1/audit?page=-1').set('Authorization', `Bearer ${jwtToken}`);
+		expect(negativeRes.status).toBe(400);
+		expect(negativeRes.body.success).toBe(false);
+	});
+
+	test('should reject a pageSize over the cap', async () => {
+		const res = await app.get('/api/v1/audit?pageSize=1000000').set('Authorization', `Bearer ${jwtToken}`);
+		expect(res.status).toBe(400);
+		expect(res.body.success).toBe(false);
+	});
+
+	test('should reject a zero or negative pageSize', async () => {
+		const res = await app.get('/api/v1/audit?pageSize=0').set('Authorization', `Bearer ${jwtToken}`);
+		expect(res.status).toBe(400);
+		expect(res.body.success).toBe(false);
 	});
 });

--- a/apps/server/tests/audit.test.ts
+++ b/apps/server/tests/audit.test.ts
@@ -327,12 +327,30 @@ describe('Audit Logs API', () => {
 	});
 
 	test('should default to page 1 / pageSize 20 when params are omitted', async () => {
+		// The default is only observable when MORE than a page of rows exist: against a
+		// short table every page size looks alike, so an upper-bound assertion would pass
+		// for any default. 25 rows pin both halves — the size of page 1, and that it is
+		// page 1 rather than some later slice.
+		db.exec('DELETE FROM audit_logs');
+		const insert = db.prepare(
+			`INSERT INTO audit_logs (id, action_type, resource_type, resource_id, user_id, user_name, timestamp, details)
+			 VALUES (?, 'CREATE', 'ENRICHMENT', ?, 1, 'tester', ?, '{}')`
+		);
+		// Descending timestamps so row id 1 is newest — the endpoint returns newest first,
+		// which makes page 1 exactly ids 1..20.
+		for (let i = 1; i <= 25; i++) {
+			insert.run(i, String(i), `2026-08-${String(31 - i).padStart(2, '0')} 12:00:00`);
+		}
+
 		const res = await app.get('/api/v1/audit').set('Authorization', `Bearer ${jwtToken}`);
 		expect(res.status).toBe(200);
 		expect(res.body.success).toBe(true);
-		// No way to observe page/pageSize directly, so assert on the resulting page shape:
-		// at most the default pageSize of logs come back, and the request doesn't error out.
-		expect(res.body.data.logs.length).toBeLessThanOrEqual(20);
+		expect(res.body.data.total).toBe(25);
+		expect(res.body.data.logs).toHaveLength(20);
+		// Page 1, not a later slice: the newest row is present and the 21st is not.
+		const ids = res.body.data.logs.map((log: AuditLog) => Number(log.resourceId));
+		expect(ids).toContain(1);
+		expect(ids).not.toContain(21);
 	});
 
 	test('should reject a zero or negative page number', async () => {


### PR DESCRIPTION
## Issue Reference
Closes #881

## What Was Changed
- Added `AuditListQueryParamsSchema` (Zod) to validate `page`/`pageSize` on GET /api/v1/audit
- Wrapped the endpoint's response in the standard `{ success, data }` / `{ success: false, error }` envelope
- Updated `Settings.tsx` audit log table to read the new envelope shape
- Extended `audit.test.ts` and fixed `action-audit.test.ts` (both hit this endpoint) for the new response shape, plus added tests for invalid page/pageSize

## Why Was It Changed
The audit endpoint returned raw data instead of the app's standard response envelope, and accepted unvalidated pagination params (negative page, unbounded pageSize). This also required updating the one client call site still reading the raw shape, since the response format change is breaking.

## Screenshots
N/A : backend/API change, no UI changes.

## Additional Context
Tests updated per maintainer guidance on the issue thread. I wasn't able to run the test suite locally due to a native-module build issue in my environment — CI should confirm; happy to fix anything it flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated audit log loading to support the standardized success response format.
  - Improved handling of missing or invalid audit log data and API errors.
  - Added validation for pagination values, including valid page ranges and page-size limits.
  - Invalid pagination requests now return clear client errors instead of being silently defaulted.

- **Tests**
  - Expanded coverage for response formatting, default pagination, and invalid pagination parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->