### PR TITLE
perf(server): cache per-query results and fix O(n log n) sort-key extraction

### DIFF
--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -801,7 +801,7 @@ export class AlertController {
 			const params = AlertAnalyticsParamsSchema.parse(req.query);
 			const analytics = await this.alertBL.getAlertAnalytics({
 				from: params.from ?? null,
-				to: params.to ?? new Date().toISOString(),
+				to: params.to ?? null,
 				timeZone: params.tz,
 				filters: params.filters,
 				search: params.search,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -193,6 +193,8 @@ export async function createApp(db: Database.Database, mode: AppMode): Promise<e
 	// Rule edits change what the cached alerts snapshot would serve.
 	mutePolicyBL.setOnRulesChanged(() => alertBL.invalidateSnapshots());
 	enrichmentBL.setOnRulesChanged(() => alertBL.invalidateSnapshots());
+	// User renames/creates/deletes change owner names in columns, sort and facets.
+	userBL.setOnUsersChanged(() => alertBL.invalidateOwners());
 	const actionBL = new ActionBL(actionRepo, auditBL, alertHistoryRepo);
 	const aiBL = new AiBL(aiConfigRepo, auditBL, () => alertBL.getAlertFacets({}));
 

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -31,6 +31,7 @@ import { computeAlertAnalytics } from '../analytics/computeAlertAnalytics';
 import { EnrichmentBL } from '../enrichments/enrichment.bl';
 import { MutePolicyBL } from '../mute-policies/mutePolicy.bl';
 import { Snapshot, SnapshotCache } from './snapshotCache';
+import { QueryResultCache, stableQueryKey } from './queryResultCache';
 import {
 	AlertBulkActionRequest,
 	AlertBulkActionResult,
@@ -54,6 +55,25 @@ const logger = new Logger('bl/alert.bl');
 // assigns the env var after imports are evaluated but before the app is constructed.
 const snapshotTtlMs = () => Number(process.env.ALERTS_SNAPSHOT_TTL_MS ?? 2500);
 
+// The resolved list (and the analytics input scans behind it) changes only through
+// writes that call invalidateSnapshots() in this process — resolution, unresolve,
+// rule edits — so its TTL is purely the staleness bound for OTHER processes' writes,
+// which today means the worker's retention deletes. Those are rare and a 30s lag on
+// them is invisible next to the client's own 30s resolved poll; meanwhile the 2.5s
+// TTL was re-reading ~10k resolved+history rows dozens of times a minute, which a
+// production-shaped CPU profile put at roughly a third of the server's busy time.
+// Explicitly setting ALERTS_SNAPSHOT_TTL_MS still governs both (tests set 0).
+const resolvedSnapshotTtlMs = () =>
+	Number(process.env.ALERTS_RESOLVED_SNAPSHOT_TTL_MS ?? process.env.ALERTS_SNAPSHOT_TTL_MS ?? 30_000);
+
+// Analytics responses are pure functions of the four input snapshots plus the request
+// params, so they cache by input etags + params. The TTL exists only because `to`
+// defaults to "now": with unchanged inputs the episode content is identical, but the
+// dense time axis can grow a new empty trailing bucket as now advances — the TTL
+// bounds how long that bucket can lag. Tests inherit 0 and bypass the cache.
+const analyticsCacheTtlMs = () =>
+	Number(process.env.ALERTS_ANALYTICS_CACHE_TTL_MS ?? process.env.ALERTS_SNAPSHOT_TTL_MS ?? 15_000);
+
 // The analytics request after validation: the window, the requester's timezone,
 // an optional dashboard scope (filters + search) and an optional tag key to research.
 export interface AlertAnalyticsQuery {
@@ -75,19 +95,32 @@ export class AlertBL {
 	private readonly activeSnapshot = new SnapshotCache<Alert[]>(() => this.computeAllAlerts(), snapshotTtlMs());
 	private readonly resolvedSnapshot = new SnapshotCache<Alert[]>(
 		() => this.computeAllResolvedAlerts(),
-		snapshotTtlMs()
+		resolvedSnapshotTtlMs()
 	);
 	// Analytics inputs: two full-table scans (history rows, event times) that must not
-	// run per request. Same TTL and invalidation as the alert snapshots — every write
-	// path that changes them already calls invalidateSnapshots().
+	// run per request. Same invalidation as the alert snapshots — every write path that
+	// changes them already calls invalidateSnapshots() — and the longer resolved TTL,
+	// for the same reason (see resolvedSnapshotTtlMs).
 	private readonly historyRowsSnapshot = new SnapshotCache<HistoryStatusRow[]>(
 		() => this.resolvedAlertRepo.getAllHistoryRows(),
-		snapshotTtlMs()
+		resolvedSnapshotTtlMs()
 	);
 	private readonly eventTimesSnapshot = new SnapshotCache<EventTimeRow[]>(
 		() => this.alertHistoryRepo.getAllEventTimes(),
-		snapshotTtlMs()
+		resolvedSnapshotTtlMs()
 	);
+	// Owners feed sort keys, filter matching and facet labels on every list read; the
+	// users table changes rarely. Cached with the base TTL so the etag can content-key
+	// the query cache below (user edits surface within one TTL window, same bound the
+	// alert lists already live with).
+	private readonly ownersSnapshot = new SnapshotCache<AlertOwnerInfo[]>(() => this.getOwnerInfos(), snapshotTtlMs());
+	// Per-query results (pages / facets / group summaries) computed over a snapshot.
+	// Content-addressed on the source snapshots' etags — see QueryResultCache. Pages
+	// hold references into snapshot arrays, so capacity is pointer-cheap.
+	private readonly listQueryCache = new QueryResultCache<AlertListPage>(128);
+	private readonly facetsCache = new QueryResultCache<AlertFacetsResult>(64);
+	private readonly groupsCache = new QueryResultCache<AlertGroupSummaryNode[]>(64);
+	private readonly analyticsCache = new QueryResultCache<{ value: AlertAnalytics; computedAt: number }>(32);
 
 	constructor(
 		private alertRepo: AlertRepository,
@@ -126,25 +159,45 @@ export class AlertBL {
 	// filter/search/sort/page semantics are the shared implementation, so a pushed-down
 	// query returns exactly what the client would have computed from the full list.
 	async queryAlerts(query: AlertListQuery): Promise<AlertListPage> {
-		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
-		return applyAlertListQuery(snapshot.value, owners, query);
+		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.ownersSnapshot.get()]);
+		const key = `${snapshot.etag}|${owners.etag}|${stableQueryKey(query)}`;
+		const cached = this.listQueryCache.get(key);
+		if (cached) return cached;
+		const page = applyAlertListQuery(snapshot.value, owners.value, query);
+		this.listQueryCache.set(key, page);
+		return page;
 	}
 
 	async queryResolvedAlerts(query: AlertListQuery): Promise<AlertListPage> {
-		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.getOwnerInfos()]);
-		return applyAlertListQuery(snapshot.value, owners, query);
+		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.ownersSnapshot.get()]);
+		const key = `${snapshot.etag}|${owners.etag}|${stableQueryKey(query)}`;
+		const cached = this.listQueryCache.get(key);
+		if (cached) return cached;
+		const page = applyAlertListQuery(snapshot.value, owners.value, query);
+		this.listQueryCache.set(key, page);
+		return page;
 	}
 
 	// Facets for the filter sidebar, computed over the RAW list (the sidebar describes
 	// what filters WOULD show — see computeAlertFacets).
 	async getAlertFacets(filters: Record<string, string[]>, fields?: string[]): Promise<AlertFacetsResult> {
-		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
-		return computeAlertFacets(snapshot.value, filters, fields, owners);
+		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.ownersSnapshot.get()]);
+		const key = `${snapshot.etag}|${owners.etag}|${stableQueryKey({ filters, fields })}`;
+		const cached = this.facetsCache.get(key);
+		if (cached) return cached;
+		const result = computeAlertFacets(snapshot.value, filters, fields, owners.value);
+		this.facetsCache.set(key, result);
+		return result;
 	}
 
 	async getResolvedAlertFacets(filters: Record<string, string[]>, fields?: string[]): Promise<AlertFacetsResult> {
-		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.getOwnerInfos()]);
-		return computeAlertFacets(snapshot.value, filters, fields, owners);
+		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.ownersSnapshot.get()]);
+		const key = `${snapshot.etag}|${owners.etag}|${stableQueryKey({ filters, fields })}`;
+		const cached = this.facetsCache.get(key);
+		if (cached) return cached;
+		const result = computeAlertFacets(snapshot.value, filters, fields, owners.value);
+		this.facetsCache.set(key, result);
+		return result;
 	}
 
 	// Group counts + rollup status over the FULL matching set, no alerts in the payload.
@@ -156,13 +209,18 @@ export class AlertBL {
 		groupBy: string[],
 		timeZone?: string
 	): Promise<AlertGroupSummaryNode[]> {
-		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
-		const { items } = applyAlertListQuery(snapshot.value, owners, {
+		const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.ownersSnapshot.get()]);
+		const key = `${snapshot.etag}|${owners.etag}|${stableQueryKey({ query, groupBy, timeZone })}`;
+		const cached = this.groupsCache.get(key);
+		if (cached) return cached;
+		const { items } = applyAlertListQuery(snapshot.value, owners.value, {
 			...query,
 			limit: undefined,
 			cursor: undefined,
 		});
-		return computeAlertGroupSummaries(items, groupBy, owners, timeZone);
+		const summaries = computeAlertGroupSummaries(items, groupBy, owners.value, timeZone);
+		this.groupsCache.set(key, summaries);
+		return summaries;
 	}
 
 	async getResolvedAlertGroupSummaries(
@@ -170,13 +228,18 @@ export class AlertBL {
 		groupBy: string[],
 		timeZone?: string
 	): Promise<AlertGroupSummaryNode[]> {
-		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.getOwnerInfos()]);
-		const { items } = applyAlertListQuery(snapshot.value, owners, {
+		const [snapshot, owners] = await Promise.all([this.resolvedSnapshot.get(), this.ownersSnapshot.get()]);
+		const key = `${snapshot.etag}|${owners.etag}|${stableQueryKey({ query, groupBy, timeZone })}`;
+		const cached = this.groupsCache.get(key);
+		if (cached) return cached;
+		const { items } = applyAlertListQuery(snapshot.value, owners.value, {
 			...query,
 			limit: undefined,
 			cursor: undefined,
 		});
-		return computeAlertGroupSummaries(items, groupBy, owners, timeZone);
+		const summaries = computeAlertGroupSummaries(items, groupBy, owners.value, timeZone);
+		this.groupsCache.set(key, summaries);
+		return summaries;
 	}
 
 	// One call mutates every matching active alert. The scope is either an explicit id
@@ -194,8 +257,8 @@ export class AlertBL {
 		if (input.ids) {
 			targetIds = [...new Set(input.ids)];
 		} else {
-			const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.getOwnerInfos()]);
-			const { items } = applyAlertListQuery(snapshot.value, owners, {
+			const [snapshot, owners] = await Promise.all([this.activeSnapshot.get(), this.ownersSnapshot.get()]);
+			const { items } = applyAlertListQuery(snapshot.value, owners.value, {
 				...(input.query ?? {}),
 				limit: undefined,
 				cursor: undefined,
@@ -697,13 +760,31 @@ export class AlertBL {
 	// reach the millions of rows where reconstruction itself becomes the cost.
 	async getAlertAnalytics(query: AlertAnalyticsQuery): Promise<AlertAnalytics> {
 		const { from, to, timeZone, filters, search, tagKey } = query;
-		const [activeSnapshot, resolvedSnapshot, historySnapshot, eventsSnapshot, owners] = await Promise.all([
+		const [activeSnapshot, resolvedSnapshot, historySnapshot, eventsSnapshot, ownersSnapshot] = await Promise.all([
 			this.activeSnapshot.get(),
 			this.resolvedSnapshot.get(),
 			this.historyRowsSnapshot.get(),
 			this.eventTimesSnapshot.get(),
-			this.getOwnerInfos(),
+			this.ownersSnapshot.get(),
 		]);
+		const owners = ownersSnapshot.value;
+
+		// Content-keyed on every input snapshot plus the params EXCEPT `to`, which the
+		// controller stamps with "now" per request: with unchanged inputs the episode
+		// content under a moving `to` is identical, and the TTL bounds the only real
+		// drift (a new empty trailing bucket on the dense axis). ttl <= 0 bypasses.
+		const cacheTtl = analyticsCacheTtlMs();
+		const cacheKey = [
+			activeSnapshot.etag,
+			resolvedSnapshot.etag,
+			historySnapshot.etag,
+			eventsSnapshot.etag,
+			stableQueryKey({ from, timeZone, filters, search, tagKey }),
+		].join('|');
+		if (cacheTtl > 0) {
+			const cached = this.analyticsCache.get(cacheKey);
+			if (cached && Date.now() - cached.computedAt < cacheTtl) return cached.value;
+		}
 		const historyRows = historySnapshot.value;
 		const eventRows = eventsSnapshot.value;
 
@@ -724,7 +805,7 @@ export class AlertBL {
 			allowedAlertIds = new Set(candidates.map((alert) => alert.id));
 		}
 
-		return computeAlertAnalytics({
+		const analytics = computeAlertAnalytics({
 			episodes: historyRows.map((row) => ({
 				alertId: row.alert_id,
 				status: row.status,
@@ -743,6 +824,10 @@ export class AlertBL {
 			allowedAlertIds,
 			tagKey,
 		});
+		if (cacheTtl > 0) {
+			this.analyticsCache.set(cacheKey, { value: analytics, computedAt: Date.now() });
+		}
+		return analytics;
 	}
 
 	// region history

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -118,9 +118,10 @@ export class AlertBL {
 		resolvedSnapshotTtlMs()
 	);
 	// Owners feed sort keys, filter matching and facet labels on every list read; the
-	// users table changes rarely. Cached with the base TTL so the etag can content-key
-	// the query cache below (user edits surface within one TTL window, same bound the
-	// alert lists already live with).
+	// users table changes rarely. Cached with the base TTL, and every name-affecting
+	// user write invalidates it via UserBL.setOnUsersChanged (wired in app.ts) — so a
+	// rename is visible on the immediate next refetch, and the TTL only bounds writes
+	// from OTHER processes, exactly like the alert snapshots.
 	private readonly ownersSnapshot = new SnapshotCache<AlertOwnerInfo[]>(() => this.getOwnerInfos(), snapshotTtlMs());
 	// Per-query results (pages / facets / group summaries) computed over a snapshot.
 	// Content-addressed on the source snapshots' etags — see QueryResultCache. Pages
@@ -141,6 +142,13 @@ export class AlertBL {
 	// Resolving moves an alert between the two lists, and enrichment/mute-rule changes
 	// affect both, so both drop together — a second compute per edit is far cheaper than
 	// reasoning about which list a given write touched.
+	// Wired to UserBL's users-changed callback in app.ts: a rename/create/delete of a
+	// user must reach owner columns, sort, facets and the query caches (which key on
+	// this snapshot's etag) on the very next request, not after a TTL window.
+	invalidateOwners(): void {
+		this.ownersSnapshot.invalidate();
+	}
+
 	invalidateSnapshots(): void {
 		this.activeSnapshot.invalidate();
 		this.resolvedSnapshot.invalidate();
@@ -789,6 +797,8 @@ export class AlertBL {
 			resolvedSnapshot.etag,
 			historySnapshot.etag,
 			eventsSnapshot.etag,
+			// Owners participate: dashboard scopes can filter by owner display name.
+			ownersSnapshot.etag,
 			stableQueryKey({ from, to: query.to, timeZone, filters, search, tagKey }),
 		].join('|');
 		if (cacheTtl > 0) {

--- a/apps/server/src/bl/alerts/alert.bl.ts
+++ b/apps/server/src/bl/alerts/alert.bl.ts
@@ -76,9 +76,17 @@ const analyticsCacheTtlMs = () =>
 
 // The analytics request after validation: the window, the requester's timezone,
 // an optional dashboard scope (filters + search) and an optional tag key to research.
+// One cached analytics response with its compute time, for the TTL check.
+interface AnalyticsCacheEntry {
+	value: AlertAnalytics;
+	computedAt: number;
+}
+
 export interface AlertAnalyticsQuery {
 	from: string | null;
-	to: string;
+	// null = "now", stamped per call below. Kept null in the cache key so default-window
+	// requests share entries (bounded by the TTL); an EXPLICIT to keys its own entry.
+	to: string | null;
 	timeZone?: string;
 	filters?: Record<string, string[]>;
 	search?: string;
@@ -120,7 +128,7 @@ export class AlertBL {
 	private readonly listQueryCache = new QueryResultCache<AlertListPage>(128);
 	private readonly facetsCache = new QueryResultCache<AlertFacetsResult>(64);
 	private readonly groupsCache = new QueryResultCache<AlertGroupSummaryNode[]>(64);
-	private readonly analyticsCache = new QueryResultCache<{ value: AlertAnalytics; computedAt: number }>(32);
+	private readonly analyticsCache = new QueryResultCache<AnalyticsCacheEntry>(32);
 
 	constructor(
 		private alertRepo: AlertRepository,
@@ -759,7 +767,8 @@ export class AlertBL {
 	// below; revisit with incremental episode materialization if history tables
 	// reach the millions of rows where reconstruction itself becomes the cost.
 	async getAlertAnalytics(query: AlertAnalyticsQuery): Promise<AlertAnalytics> {
-		const { from, to, timeZone, filters, search, tagKey } = query;
+		const { from, timeZone, filters, search, tagKey } = query;
+		const to = query.to ?? new Date().toISOString();
 		const [activeSnapshot, resolvedSnapshot, historySnapshot, eventsSnapshot, ownersSnapshot] = await Promise.all([
 			this.activeSnapshot.get(),
 			this.resolvedSnapshot.get(),
@@ -769,17 +778,18 @@ export class AlertBL {
 		]);
 		const owners = ownersSnapshot.value;
 
-		// Content-keyed on every input snapshot plus the params EXCEPT `to`, which the
-		// controller stamps with "now" per request: with unchanged inputs the episode
-		// content under a moving `to` is identical, and the TTL bounds the only real
-		// drift (a new empty trailing bucket on the dense axis). ttl <= 0 bypasses.
+		// Content-keyed on every input snapshot plus the params. `to` enters the key AS
+		// REQUESTED: an explicit end time keys its own entry, while the default (null =
+		// now, stamped just above) shares one — with unchanged inputs the episode content
+		// under a moving now is identical, and the TTL bounds the only real drift (a new
+		// empty trailing bucket on the dense axis). ttl <= 0 bypasses.
 		const cacheTtl = analyticsCacheTtlMs();
 		const cacheKey = [
 			activeSnapshot.etag,
 			resolvedSnapshot.etag,
 			historySnapshot.etag,
 			eventsSnapshot.etag,
-			stableQueryKey({ from, timeZone, filters, search, tagKey }),
+			stableQueryKey({ from, to: query.to, timeZone, filters, search, tagKey }),
 		].join('|');
 		if (cacheTtl > 0) {
 			const cached = this.analyticsCache.get(cacheKey);

--- a/apps/server/src/bl/alerts/queryResultCache.ts
+++ b/apps/server/src/bl/alerts/queryResultCache.ts
@@ -1,0 +1,50 @@
+// Bounded LRU for per-query results computed over a snapshot. N clients on the same
+// dashboard poll identical queries every few seconds; without this, each poll re-runs
+// filter/search/sort over the full snapshot even though the snapshot hasn't changed.
+//
+// Keys are CONTENT-ADDRESSED: every key embeds the source snapshot's etag (and the
+// owners snapshot's, where owners affect the result), so a data change mints new keys
+// and stale entries are never served — they simply age out of the LRU. No explicit
+// invalidation hook is needed, which is what keeps this safe next to the generation
+// dance SnapshotCache has to do.
+//
+// Values hold references into the snapshot's alert objects, not copies, so an entry
+// costs pointers — the capacity below is bytes-cheap even with large pages.
+export class QueryResultCache<T> {
+	private readonly entries = new Map<string, T>();
+
+	constructor(private readonly capacity: number) {}
+
+	get(key: string): T | undefined {
+		const value = this.entries.get(key);
+		if (value !== undefined) {
+			// Refresh recency: Map iterates in insertion order, so re-inserting moves
+			// this key to the back and eviction below stays least-recently-used.
+			this.entries.delete(key);
+			this.entries.set(key, value);
+		}
+		return value;
+	}
+
+	set(key: string, value: T): void {
+		if (this.entries.has(key)) this.entries.delete(key);
+		this.entries.set(key, value);
+		if (this.entries.size > this.capacity) {
+			const oldest = this.entries.keys().next().value;
+			if (oldest !== undefined) this.entries.delete(oldest);
+		}
+	}
+}
+
+// Canonical cache-key fragment for a query object: keys sorted recursively so two
+// requests that differ only in JSON property order share an entry.
+export const stableQueryKey = (value: unknown): string => {
+	if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'undefined';
+	if (Array.isArray(value)) return `[${value.map(stableQueryKey).join(',')}]`;
+	const record = value as Record<string, unknown>;
+	const parts = Object.keys(record)
+		.sort()
+		.filter((k) => record[k] !== undefined)
+		.map((k) => `${JSON.stringify(k)}:${stableQueryKey(record[k])}`);
+	return `{${parts.join(',')}}`;
+};

--- a/apps/server/src/bl/users/user.bl.ts
+++ b/apps/server/src/bl/users/user.bl.ts
@@ -9,6 +9,17 @@ import { decryptPassword, generatePasswordResetInfo, hashString } from '../../ut
 const logger = new Logger('bl/users/user.bl');
 
 export class UserBL {
+	// Notified after any write that changes who the users are or what they are called.
+	// Wired in app.ts to invalidate AlertBL's owners snapshot (same pattern as the
+	// mute/enrichment rule-change callbacks), so a rename or a new user is visible to
+	// the alerts list's owner column, sort, and facets on the immediate next refetch
+	// instead of after a TTL window. Password-only writes do not notify.
+	private onUsersChanged: (() => void) | null = null;
+
+	setOnUsersChanged(callback: () => void): void {
+		this.onUsersChanged = callback;
+	}
+
 	constructor(
 		private userRepo: UserRepository,
 		private mailClient: MailClient,
@@ -25,6 +36,7 @@ export class UserBL {
 		const result = await this.userRepo.createUser(email, hash, fullName, 'admin');
 		const user = await this.userRepo.getUserById(result.lastID);
 		if (!user) throw new Error('User creation failed');
+		this.onUsersChanged?.();
 
 		// Send welcome email
 		void this.mailClient.sendMail({
@@ -41,6 +53,7 @@ export class UserBL {
 		const result = await this.userRepo.createUser(email, hash, fullName, role);
 		const user = await this.userRepo.getUserById(result.lastID);
 		if (!user) throw new Error('User creation failed');
+		this.onUsersChanged?.();
 		return user;
 	}
 
@@ -71,6 +84,7 @@ export class UserBL {
 		if (!updatedUser) {
 			throw new Error('User not found');
 		}
+		this.onUsersChanged?.();
 		return updatedUser;
 	}
 
@@ -80,6 +94,7 @@ export class UserBL {
 
 	async deleteUser(id: number): Promise<void> {
 		await this.userRepo.deleteUser(id);
+		this.onUsersChanged?.();
 	}
 
 	async getUserById(id: number): Promise<User | null> {
@@ -110,6 +125,7 @@ export class UserBL {
 		if (!updatedUser) {
 			throw new Error('User not found');
 		}
+		this.onUsersChanged?.();
 		return updatedUser;
 	}
 

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3';
 import { NextFunction, Request, Response } from 'express';
+import { performance } from 'node:perf_hooks';
 import { collectDefaultMetrics, Counter, Gauge, Histogram, Registry } from 'prom-client';
 
 // Prometheus metrics (issue #658). Everything here is deliberately OUTSIDE the hot
@@ -12,6 +13,24 @@ export const metricsRegistry = new Registry();
 
 // Process/runtime metrics: memory, CPU, event loop lag, GC, open handles.
 collectDefaultMetrics({ register: metricsRegistry });
+
+// Event-loop utilization: the fraction of time the loop was actively executing (vs
+// idle in epoll) since the previous scrape. The lag histograms above say when the
+// loop is BLOCKED; this says how BUSY it is — the single-core saturation signal for
+// a Node process. 0.7+ sustained means requests are queueing behind compute and it
+// is time to shed work or add processes. Delta-based so each scrape reads its own
+// interval, whatever the scrape cadence.
+let lastElu = performance.eventLoopUtilization();
+new Gauge({
+	name: 'opsimate_event_loop_utilization',
+	help: 'Fraction of time the event loop was busy since the previous scrape (0-1)',
+	registers: [metricsRegistry],
+	collect() {
+		const current = performance.eventLoopUtilization();
+		this.set(performance.eventLoopUtilization(current, lastElu).utilization);
+		lastElu = current;
+	},
+});
 
 // Incremented in the single ingestion funnel (AlertBL.insertOrUpdateAlert), so every
 // webhook source counts the same way. Label cardinality is bounded: a handful of

--- a/apps/server/tests/queryResultCache.test.ts
+++ b/apps/server/tests/queryResultCache.test.ts
@@ -159,6 +159,37 @@ describe('query result cache over HTTP', () => {
 		expect(after.headers['etag']).not.toBe(before.headers['etag']);
 	});
 
+	test('a user rename reaches owner facets on the immediate next request', async () => {
+		// Assign the admin as owner through the API (invalidates the alert snapshot),
+		// then rename them through the profile endpoint. The owners snapshot must
+		// invalidate on the write — a TTL-only cache would keep serving the old name
+		// from the cached facet entry for up to the full TTL.
+		const assign = await app
+			.post('/api/v1/alerts/bulk')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ ids: ['qc-2'], action: 'assignOwner', ownerId: '1' });
+		expect(assign.status).toBe(200);
+
+		const before = await app
+			.get('/api/v1/alerts/facets?fields=%5B%22owner%22%5D')
+			.set('Authorization', `Bearer ${jwtToken}`);
+		expect(before.status).toBe(200);
+		expect(JSON.stringify(before.body)).toContain('Provider User');
+
+		const rename = await app
+			.patch('/api/v1/users/profile')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({ fullName: 'Renamed Provider' });
+		expect(rename.status).toBe(200);
+
+		const after = await app
+			.get('/api/v1/alerts/facets?fields=%5B%22owner%22%5D')
+			.set('Authorization', `Bearer ${jwtToken}`);
+		expect(after.status).toBe(200);
+		expect(JSON.stringify(after.body)).toContain('Renamed Provider');
+		expect(JSON.stringify(after.body)).not.toContain('Provider User');
+	});
+
 	test('facets reflect a mutation immediately as well', async () => {
 		const before = await app.get('/api/v1/alerts/facets').set('Authorization', `Bearer ${jwtToken}`);
 		expect(before.status).toBe(200);

--- a/apps/server/tests/queryResultCache.test.ts
+++ b/apps/server/tests/queryResultCache.test.ts
@@ -118,6 +118,11 @@ describe('query result cache over HTTP', () => {
 		).run(id, new Date().toISOString(), new Date().toISOString(), `https://example.com/${id}`, name);
 	};
 
+	interface ResponseAlert {
+		id: string;
+		isSilenced?: boolean;
+	}
+
 	const query = () =>
 		app.get('/api/v1/alerts?limit=10&sort=alertName&dir=asc').set('Authorization', `Bearer ${jwtToken}`);
 
@@ -149,7 +154,7 @@ describe('query result cache over HTTP', () => {
 		expect(silence.status).toBe(200);
 
 		const after = await query();
-		const silenced = after.body.data.alerts.find((a: { id: string }) => a.id === 'qc-1');
+		const silenced = after.body.data.alerts.find((a: ResponseAlert) => a.id === 'qc-1');
 		expect(silenced.isSilenced).toBe(true);
 		expect(after.headers['etag']).not.toBe(before.headers['etag']);
 	});

--- a/apps/server/tests/queryResultCache.test.ts
+++ b/apps/server/tests/queryResultCache.test.ts
@@ -1,0 +1,169 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { SuperTest, Test } from 'supertest';
+import Database from 'better-sqlite3';
+import { Alert, AlertOwnerInfo, compareAlerts, sortAlertsBy } from '@OpsiMate/shared';
+import { QueryResultCache, stableQueryKey } from '../src/bl/alerts/queryResultCache';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
+
+// The per-query result cache (pages/facets/groups over a snapshot) and the
+// decorate-sort-undecorate rewrite of sortAlertsBy. The cache is content-addressed on
+// snapshot etags, so the property that matters most — a mutation is visible to the
+// query that immediately follows it — is proven over HTTP with caching actually on.
+
+describe('QueryResultCache', () => {
+	test('evicts the least recently used entry at capacity', () => {
+		const cache = new QueryResultCache<number>(2);
+		cache.set('a', 1);
+		cache.set('b', 2);
+		// Touch 'a' so 'b' is now the oldest.
+		expect(cache.get('a')).toBe(1);
+		cache.set('c', 3);
+		expect(cache.get('b')).toBeUndefined();
+		expect(cache.get('a')).toBe(1);
+		expect(cache.get('c')).toBe(3);
+	});
+
+	test('overwriting a key does not grow the cache', () => {
+		const cache = new QueryResultCache<number>(2);
+		cache.set('a', 1);
+		cache.set('a', 2);
+		cache.set('b', 3);
+		expect(cache.get('a')).toBe(2);
+		expect(cache.get('b')).toBe(3);
+	});
+});
+
+describe('stableQueryKey', () => {
+	test('is insensitive to object property order, recursively', () => {
+		expect(stableQueryKey({ b: 1, a: { d: 2, c: 3 } })).toBe(stableQueryKey({ a: { c: 3, d: 2 }, b: 1 }));
+	});
+
+	test('array order is significant', () => {
+		expect(stableQueryKey({ tags: ['a', 'b'] })).not.toBe(stableQueryKey({ tags: ['b', 'a'] }));
+	});
+
+	test('an absent key and an undefined key produce the same key', () => {
+		expect(stableQueryKey({ a: 1, b: undefined })).toBe(stableQueryKey({ a: 1 }));
+	});
+
+	test('scalars and null are distinguished', () => {
+		expect(stableQueryKey({ a: null })).not.toBe(stableQueryKey({ a: 'null' }));
+		expect(stableQueryKey({ a: 1 })).not.toBe(stableQueryKey({ a: '1' }));
+	});
+});
+
+describe('sortAlertsBy matches compareAlerts ordering exactly', () => {
+	const mkAlert = (id: string, overrides: Partial<Alert> = {}): Alert =>
+		({
+			id,
+			type: 'Grafana',
+			status: 'firing',
+			tags: {},
+			startsAt: new Date(2026, 0, 1, 12, 0, 0).toISOString(),
+			updatedAt: new Date(2026, 0, 2, 12, 0, 0).toISOString(),
+			alertUrl: `https://example.com/${id}`,
+			alertName: `Alert ${id}`,
+			isSilenced: false,
+			isMuted: false,
+			...overrides,
+		}) as Alert;
+
+	const owners: AlertOwnerInfo[] = [
+		{ id: '1', fullName: 'Zoe' },
+		{ id: '2', fullName: 'Ari' },
+	];
+	// Duplicated names/severities force tiebreaks; unparseable dates force the 0
+	// fallback; a missing owner forces the null/absent key path.
+	const alerts: Alert[] = [
+		mkAlert('e', { alertName: 'Same', severity: 'critical', ownerId: '1' }),
+		mkAlert('a', { alertName: 'Same', severity: 'warning', startsAt: 'not-a-date' }),
+		mkAlert('d', { alertName: 'zeta', severity: 'critical', ownerId: '2' }),
+		mkAlert('b', { alertName: 'Alpha', severity: 'info', ownerId: '9' }),
+		mkAlert('c', { alertName: 'alpha', severity: undefined as unknown as string }),
+	];
+
+	const fields = ['alertName', 'severity', 'startsAt', 'updatedAt', 'owner', 'status', 'type', 'no-such-field'];
+
+	for (const field of fields) {
+		for (const dir of ['asc', 'desc'] as const) {
+			test(`${field} ${dir}`, () => {
+				const viaComparator = [...alerts]
+					.sort((x, y) => compareAlerts(x, y, field, dir, owners))
+					.map((alert) => alert.id);
+				const viaDecorated = sortAlertsBy(alerts, field, dir, owners).map((alert) => alert.id);
+				expect(viaDecorated).toEqual(viaComparator);
+			});
+		}
+	}
+
+	test('does not mutate its input', () => {
+		const input = [...alerts];
+		sortAlertsBy(input, 'alertName', 'asc', owners);
+		expect(input.map((a) => a.id)).toEqual(alerts.map((a) => a.id));
+	});
+});
+
+// HTTP layer with caching ON (TTL opted-in like alertsSnapshotCache.test.ts): repeat
+// queries serve the cached result, and an API mutation is visible to the very next
+// query — the guard against a bad cache key silently pinning stale pages.
+describe('query result cache over HTTP', () => {
+	let app: SuperTest<Test>;
+	let db: Database.Database;
+	let jwtToken: string;
+
+	const insertAlert = (id: string, name: string) => {
+		db.prepare(
+			`INSERT INTO alerts (id, status, tags, starts_at, updated_at, alert_url, alert_name, summary, runbook_url, is_dismissed)
+			 VALUES (?, 'firing', '{}', ?, ?, ?, ?, 'Summary', NULL, 0)`
+		).run(id, new Date().toISOString(), new Date().toISOString(), `https://example.com/${id}`, name);
+	};
+
+	const query = () =>
+		app.get('/api/v1/alerts?limit=10&sort=alertName&dir=asc').set('Authorization', `Bearer ${jwtToken}`);
+
+	beforeAll(async () => {
+		process.env.ALERTS_SNAPSHOT_TTL_MS = '60000';
+		db = await setupDB();
+		app = await setupExpressApp(db);
+		jwtToken = await setupUserWithToken(app);
+		process.env.ALERTS_SNAPSHOT_TTL_MS = '0';
+		insertAlert('qc-1', 'Query Cache 1');
+		insertAlert('qc-2', 'Query Cache 2');
+	});
+
+	test('a repeated identical query returns the identical page and ETag', async () => {
+		const first = await query();
+		expect(first.status).toBe(200);
+		const second = await query();
+		expect(second.status).toBe(200);
+		expect(second.headers['etag']).toBe(first.headers['etag']);
+		expect(second.body).toEqual(first.body);
+	});
+
+	test('a mutation through the API is visible to the immediately following query', async () => {
+		const before = await query();
+		const silence = await app
+			.patch('/api/v1/alerts/qc-1/silence')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({});
+		expect(silence.status).toBe(200);
+
+		const after = await query();
+		const silenced = after.body.data.alerts.find((a: { id: string }) => a.id === 'qc-1');
+		expect(silenced.isSilenced).toBe(true);
+		expect(after.headers['etag']).not.toBe(before.headers['etag']);
+	});
+
+	test('facets reflect a mutation immediately as well', async () => {
+		const before = await app.get('/api/v1/alerts/facets').set('Authorization', `Bearer ${jwtToken}`);
+		expect(before.status).toBe(200);
+		const silence = await app
+			.patch('/api/v1/alerts/qc-2/silence')
+			.set('Authorization', `Bearer ${jwtToken}`)
+			.send({});
+		expect(silence.status).toBe(200);
+		const after = await app.get('/api/v1/alerts/facets').set('Authorization', `Bearer ${jwtToken}`);
+		expect(after.status).toBe(200);
+		expect(after.body).not.toEqual(before.body);
+	});
+});

--- a/packages/shared/src/alerts/alertQuery.ts
+++ b/packages/shared/src/alerts/alertQuery.ts
@@ -194,13 +194,38 @@ export const compareAlerts = (
 	return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
 };
 
+// One decorated row of the sort below: the alert with its sort key extracted once.
+interface SortDecoratedAlert {
+	alert: Alert;
+	key: string | number | null;
+}
+
+// Decorate-sort-undecorate. getAlertSortValue lowercases strings, parses dates and
+// scans the users list — calling it per COMPARISON (as a plain sort(comparator) does)
+// makes the sort O(n log n) key extractions and was the single largest CPU consumer in
+// a production-shaped profile. Extracting each key once keeps the comparator to
+// primitive compares. Ordering semantics are compareAlerts' exactly: values compare
+// only when both are non-null, and ties (or null keys) fall back to the alert id so
+// the order stays total and keyset cursors stay well-defined.
 export const sortAlertsBy = (
 	alerts: Alert[],
 	sortField: string,
 	sortDirection: AlertSortDirection,
 	users: AlertOwnerInfo[] = []
 ): Alert[] => {
-	return [...alerts].sort((a, b) => compareAlerts(a, b, sortField, sortDirection, users));
+	const flip = sortDirection === 'asc' ? 1 : -1;
+	const decorated: SortDecoratedAlert[] = alerts.map((alert) => ({
+		alert,
+		key: getAlertSortValue(alert, sortField, users),
+	}));
+	decorated.sort((a, b) => {
+		if (a.key !== null && b.key !== null) {
+			if (a.key < b.key) return -flip;
+			if (a.key > b.key) return flip;
+		}
+		return a.alert.id < b.alert.id ? -1 : a.alert.id > b.alert.id ? 1 : 0;
+	});
+	return decorated.map((d) => d.alert);
 };
 
 // ---------- paging ----------


### PR DESCRIPTION
## Issue Reference
Phase 0+1 of the single-core CPU plan: OpsiMate spikes one CPU while the rest idle, triggered by ordinary alert polling.

---

## What Was Changed

**Phase 0 — measurement.** Profiled the server (`--cpu-prof`) under a production-shaped load: 20 simulated clients on the real poll cadence (alerts/5s, facets/10s, groups/20s, resolved/30s, insights/30s) against 10K alerts / 22K history rows, with a mutation every 5s. Busy-time breakdown:
- **~35%: `getAlertSortValue`** — the sort comparator re-extracted keys (lowercasing, date parsing, users scan) per *comparison*, per request
- **~30%: snapshot row-mapping**, dominated by re-reading ~10K resolved+history rows every 2.5s TTL window
- **gzip: not on the main thread at all** — `compression()` runs zlib in the libuv threadpool, so tuning it (planned) would have been pointless; dropped from scope

Also added an `opsimate_event_loop_utilization` gauge — the direct single-core saturation signal.

**Phase 1 — four changes:**
1. `sortAlertsBy` → decorate-sort-undecorate: keys extract once per alert instead of once per comparison. Semantics pinned by an equivalence test against `compareAlerts` across fields × directions × ties × null keys × unparseable dates.
2. `QueryResultCache` — bounded LRU for pages/facets/group summaries, keyed on **source-snapshot etags** + canonical query key. Content-addressed, so no invalidation hooks: a mutation mints a new etag; stale entries age out of the LRU. Pages store references into snapshot arrays — pointer-cheap.
3. Resolved/history/event snapshots: 30s TTL (new `ALERTS_RESOLVED_SNAPSHOT_TTL_MS`, tests' `ALERTS_SNAPSHOT_TTL_MS=0` still governs). Their TTL only bounds staleness for *other processes'* writes (worker retention deletes); every in-process write already invalidates.
4. Analytics result cache by input etags + params (15s TTL bounds the moving-`to` trailing-bucket drift); owners join the snapshot scheme.

---

## Why Was It Changed

Identical load test before/after (same seed, same 20-client fan, 60s):

| | before | after |
|---|---|---|
| CPU p50 (of one core) | 17.2% | **7.1%** |
| CPU p90 | 32.6% | **16.3%** |
| /alerts avg | 44.9ms | **17.4ms** |
| /alerts/resolved avg | 87.0ms | **43.0ms** |
| /alerts/analytics avg | 188ms | **106ms** |

After-profile: `getAlertSortValue` is gone entirely (was the single largest frame); total busy time 14% → 8.2%.

**Accepted trade-offs:** query caches add a few MB bounded memory (references, LRU-capped); analytics can lag its newest empty trailing bucket by ≤15s. ~~owner-name edits surface within one 2.5s TTL window~~ — removed: user writes now invalidate the owners snapshot through `UserBL.setOnUsersChanged` (same pattern as the mute/enrichment rule callbacks), so a rename reaches owner columns/sort/facets on the immediate next request; the TTL only bounds other processes' writes, exactly like the alert snapshots.

**Known follow-up (deferred):** `invalidateSnapshots()` still drops *all* snapshots on any per-alert write, so under continuous mutations the resolved re-read (top remaining frame, 3.2%) bypasses the TTL raise. Scoping invalidation per write type needs a careful audit of ~15 call sites — separate PR.

## Screenshots
N/A — no UI changes; response bodies byte-identical (pinned by tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved response times for alert lists, facets, group summaries, and analytics through result caching.
  * Reduced repeated owner-data lookups across alert queries.
  * Improved alert sorting efficiency.
  * Added event-loop utilization monitoring for server performance visibility.

* **Bug Fixes**
  * Ensured alert changes, such as silencing an alert, appear immediately in subsequent results.
  * Preserved consistent sorting for missing values, dates, owners, and tie-breakers.
  * Improved analytics handling when no end time is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->