### PR TITLE
perf(server): index alerts_history so history growth stops taxing the main page

### DIFF
--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -67,6 +67,16 @@ export class ResolvedAlertRepository {
 																	  status TEXT NOT NULL
 						);
 
+						-- Every hot read of this table probes by alert_id:
+						-- getFiringTimesByAlert runs inside EVERY active-snapshot recompute
+						-- (feeding the alerts list, facets and groups) and getAlertHistory
+						-- backs the per-alert history drawer. Without the index both were
+						-- full scans, so main-page latency grew with TOTAL history size —
+						-- history a user never looks at taxed every poll. archived_at as the
+						-- second column keeps the drawer's time-ordered read index-only.
+						CREATE INDEX IF NOT EXISTS idx_alerts_history_alert
+							ON alerts_history (alert_id, archived_at);
+
 						CREATE TRIGGER IF NOT EXISTS archive_alert_history_on_update
 							BEFORE UPDATE ON alerts_resolved
 							FOR EACH ROW

--- a/apps/server/src/dal/resolvedAlertRepository.ts
+++ b/apps/server/src/dal/resolvedAlertRepository.ts
@@ -73,7 +73,9 @@ export class ResolvedAlertRepository {
 						-- backs the per-alert history drawer. Without the index both were
 						-- full scans, so main-page latency grew with TOTAL history size —
 						-- history a user never looks at taxed every poll. archived_at as the
-						-- second column keeps the drawer's time-ordered read index-only.
+						-- second column serves the drawer's ORDER BY straight off the index
+						-- (status still comes from the row — a covering index isn't worth
+						-- the write cost on the trigger-driven insert path).
 						CREATE INDEX IF NOT EXISTS idx_alerts_history_alert
 							ON alerts_history (alert_id, archived_at);
 

--- a/apps/server/tests/historyIndex.test.ts
+++ b/apps/server/tests/historyIndex.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { setupDB } from './setup';
+
+// alerts_history is probed by alert_id on every active-snapshot recompute
+// (getFiringTimesByAlert) and on every history-drawer open (getAlertHistory). Both
+// were full table scans before idx_alerts_history_alert existed, which made main-page
+// cost grow with TOTAL history size — these tests pin the index and, more importantly,
+// that SQLite actually chooses it for both hot queries. An index that exists but goes
+// unused (say, after a query rewrite wraps the column in a function) fails here too.
+
+interface IndexListRow {
+	name: string;
+}
+
+interface QueryPlanRow {
+	detail: string;
+}
+
+describe('alerts_history index', () => {
+	test('idx_alerts_history_alert exists after init', async () => {
+		const db = await setupDB();
+		const indexes = db.prepare(`PRAGMA index_list(alerts_history)`).all() as IndexListRow[];
+		expect(indexes.map((index) => index.name)).toContain('idx_alerts_history_alert');
+	});
+
+	test('the firing-times probe and the drawer read both use it', async () => {
+		const db = await setupDB();
+		const firingPlan = db
+			.prepare(
+				`EXPLAIN QUERY PLAN
+				 SELECT alert_id, archived_at FROM alerts_history
+				 WHERE status = 'firing' AND alert_id IN (?, ?)`
+			)
+			.all('a', 'b') as QueryPlanRow[];
+		const drawerPlan = db
+			.prepare(
+				`EXPLAIN QUERY PLAN
+				 SELECT archived_at, status FROM alerts_history
+				 WHERE alert_id = ? ORDER BY archived_at DESC`
+			)
+			.all('a') as QueryPlanRow[];
+
+		for (const plan of [firingPlan, drawerPlan]) {
+			const details = plan.map((row) => row.detail).join(' | ');
+			expect(details).toContain('USING INDEX idx_alerts_history_alert');
+			expect(details).not.toContain('SCAN alerts_history');
+		}
+	});
+});


### PR DESCRIPTION
## Issue Reference
Phase A of the history-scaling plan (follow-up to #895): accumulated alert history should not slow down pages that never look at it.

---

## What Was Changed
One composite index, created in the same `initResolvedAlertsTable` migration path that owns the table, plus tests that pin both the index **and** the query plans:

```sql
CREATE INDEX IF NOT EXISTS idx_alerts_history_alert ON alerts_history (alert_id, archived_at);
```

`alerts_history` had no index at all, and two hot reads probe it by `alert_id`:
- `getFiringTimesByAlert` — runs inside **every active-snapshot recompute** (every TTL tick / mutation), feeding the alerts list, facets and groups. The query was already scoped to active ids ("so the work doesn't grow with total history retention") — but without an index SQLite full-scanned anyway, so the scoping intent was never honored.
- `getAlertHistory` — the per-alert history drawer; full scan per open.

The plan test guards regressions: it asserts `USING INDEX` and no `SCAN` for both queries, so a future rewrite that quietly defeats the index (e.g. wrapping the column in a function) fails CI.

---

## Why Was It Changed
Measured on a scratch instance with **502,000 history rows** (what accumulates in production — retention defaults to off):

| | before | after |
|---|---|---|
| active-snapshot recompute (runs every 2.5s) | 83ms | **24ms** |
| `/alerts` immediately after a mutation | 105ms | **23ms** |
| history drawer open | 25ms | **1.3ms** |

Both queries flip from `SCAN alerts_history` to `SEARCH … USING INDEX` (verified via `EXPLAIN QUERY PLAN`). More important than the ratios: the remaining costs are now O(active alerts), not O(total history) — the table can keep growing without the main page feeling it.

**Upgrade cost:** the `CREATE INDEX IF NOT EXISTS` runs once at boot on existing DBs — measured 356ms on the 502K-row table. Server tests 341/341 (2 new; one unrelated #896 flake reran clean).

**Known follow-ups, deliberately out of scope:** retention's `WHERE datetime(archived_at) < …` still can't use an index — unwrapping it requires normalizing the column's mixed timestamp formats first (backfill migration); and Phases B/C of the plan (time-bounded resolved snapshot, episode materialization for analytics) remain tracked separately.

## Screenshots
N/A — server-only; behavior byte-identical, only faster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved alert history query performance for faster access to alert activity and history details.
  * Optimized time-ordered history retrieval for more efficient browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->