### PR TITLE
Fix for Issue #772

### DIFF
--- a/apps/server/src/api/v1/ai/controller.ts
+++ b/apps/server/src/api/v1/ai/controller.ts
@@ -1,5 +1,5 @@
 import { Response } from 'express';
-import { AiFilterQuerySchema, Logger, Role, UpdateAiConfigSchema } from '@OpsiMate/shared';
+import { AiFilterQuerySchema, Logger, UpdateAiConfigSchema } from '@OpsiMate/shared';
 import { AiBL, AiDisabledError, AiValidationError, BedrockCallError } from '../../../bl/ai/ai.bl';
 import { AuthenticatedRequest } from '../../../middleware/auth';
 import { isZodError } from '../../../utils/isZodError.ts';
@@ -34,18 +34,7 @@ export class AiController {
 		return true;
 	}
 
-	// Org-wide configuration holding a credential — admin-only, same gate the
-	// retention and silence-reset settings use.
-	private requireAdmin(req: AuthenticatedRequest, res: Response): boolean {
-		if (!req.user || req.user.role !== Role.Admin) {
-			res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-			return false;
-		}
-		return true;
-	}
-
-	getConfigHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
+	getConfigHandler = async (_req: AuthenticatedRequest, res: Response) => {
 		try {
 			const config = await this.aiBL.getConfig();
 			return res.json({ success: true, data: config });
@@ -56,7 +45,6 @@ export class AiController {
 	};
 
 	updateConfigHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
 		try {
 			const updates = UpdateAiConfigSchema.parse(req.body ?? {});
 			const config = await this.aiBL.updateConfig(updates, req.user);
@@ -111,8 +99,7 @@ export class AiController {
 		}
 	};
 
-	testConnectionHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
+	testConnectionHandler = async (_req: AuthenticatedRequest, res: Response) => {
 		try {
 			const result = await this.aiBL.testConnection();
 			// Always 200: a failed Bedrock call is a RESULT the user asked for, not a

--- a/apps/server/src/api/v1/ai/router.ts
+++ b/apps/server/src/api/v1/ai/router.ts
@@ -1,14 +1,15 @@
 import { Router } from 'express';
 import { AiController } from './controller';
+import { requireAdmin } from '../../../middleware/auth';
 
 export default function createAiRouter(controller: AiController) {
 	const router = Router();
 
 	router.get('/status', controller.statusHandler);
 	router.post('/filter', controller.filterHandler);
-	router.get('/config', controller.getConfigHandler);
-	router.put('/config', controller.updateConfigHandler);
-	router.post('/test', controller.testConnectionHandler);
+	router.get('/config', requireAdmin, controller.getConfigHandler);
+	router.put('/config', requireAdmin, controller.updateConfigHandler);
+	router.post('/test', requireAdmin, controller.testConnectionHandler);
 
 	return router;
 }

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -6,7 +6,6 @@ import {
 	AlertStatus,
 	CreateCommentSchema,
 	Logger,
-	Role,
 	UpdateCommentSchema,
 	UpdateSilenceResetSettingsSchema,
 } from '@OpsiMate/shared';
@@ -179,18 +178,7 @@ export class AlertController {
 		return res.type('application/json').send(`{"success":true,"data":{"alerts":${snapshot.json}}}`);
 	}
 
-	// Both silence-reset endpoints are admin-only: this is org-wide configuration, same
-	// gate the retention settings use.
-	private requireAdmin(req: AuthenticatedRequest, res: Response): boolean {
-		if (!req.user || req.user.role !== Role.Admin) {
-			res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-			return false;
-		}
-		return true;
-	}
-
-	async getSilenceResetSettings(req: AuthenticatedRequest, res: Response) {
-		if (!this.requireAdmin(req, res)) return;
+	async getSilenceResetSettings(_req: AuthenticatedRequest, res: Response) {
 		try {
 			const settings = await this.alertBL.getSilenceResetSettings();
 			return res.json({ success: true, data: settings });
@@ -201,7 +189,6 @@ export class AlertController {
 	}
 
 	async updateSilenceResetSettings(req: AuthenticatedRequest, res: Response) {
-		if (!this.requireAdmin(req, res)) return;
 		try {
 			const updates = UpdateSilenceResetSettingsSchema.parse(req.body ?? {});
 			const settings = await this.alertBL.updateSilenceResetSettings(updates);

--- a/apps/server/src/api/v1/alerts/router.ts
+++ b/apps/server/src/api/v1/alerts/router.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { AlertController } from './controller';
+import { requireAdmin } from '../../../middleware/auth';
 
 export default function createAlertRouter(controller: AlertController) {
 	const router = Router();
@@ -15,8 +16,8 @@ export default function createAlertRouter(controller: AlertController) {
 	router.post('/bulk', controller.bulkAlertAction.bind(controller));
 
 	// Daily silence reset settings (admin; must be before /:alertId to avoid route conflicts)
-	router.get('/silence-reset', controller.getSilenceResetSettings.bind(controller));
-	router.put('/silence-reset', controller.updateSilenceResetSettings.bind(controller));
+	router.get('/silence-reset', requireAdmin, controller.getSilenceResetSettings.bind(controller));
+	router.put('/silence-reset', requireAdmin, controller.updateSilenceResetSettings.bind(controller));
 
 	// Resolved alerts (must be before /:alertId to avoid route conflicts)
 	router.get('/resolved', controller.getResolvedAlerts.bind(controller));

--- a/apps/server/src/api/v1/oncall/controller.ts
+++ b/apps/server/src/api/v1/oncall/controller.ts
@@ -1,4 +1,4 @@
-import { Logger, OncallTeamMembersSchema, OncallTeamSchema, Role } from '@OpsiMate/shared';
+import { Logger, OncallTeamMembersSchema, OncallTeamSchema } from '@OpsiMate/shared';
 import { Response } from 'express';
 import { DuplicateTeamNameError, OncallBL } from '../../../bl/oncall/oncall.bl';
 import { AuthenticatedRequest } from '../../../middleware/auth.ts';
@@ -8,16 +8,6 @@ const logger = new Logger('api/v1/oncall/controller');
 
 export class OncallController {
 	constructor(private oncallBL: OncallBL) {}
-
-	// Reading the schedule is open to any authenticated user (the NOC needs it);
-	// changing it is admins only.
-	private requireAdmin(req: AuthenticatedRequest, res: Response): boolean {
-		if (!req.user || req.user.role !== Role.Admin) {
-			res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-			return false;
-		}
-		return true;
-	}
 
 	private parseTeamId(req: AuthenticatedRequest, res: Response): number | null {
 		const teamId = parseInt(req.params.teamId, 10);
@@ -39,7 +29,6 @@ export class OncallController {
 	};
 
 	createTeamHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
 		try {
 			const { name, rotationIntervalDays } = OncallTeamSchema.parse(req.body);
 			const team = await this.oncallBL.createTeam(name, rotationIntervalDays ?? null);
@@ -57,7 +46,6 @@ export class OncallController {
 	};
 
 	updateTeamHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
 		const teamId = this.parseTeamId(req, res);
 		if (teamId === null) return;
 		try {
@@ -80,7 +68,6 @@ export class OncallController {
 	};
 
 	deleteTeamHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
 		const teamId = this.parseTeamId(req, res);
 		if (teamId === null) return;
 		try {
@@ -93,7 +80,6 @@ export class OncallController {
 	};
 
 	setTeamMembersHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
 		const teamId = this.parseTeamId(req, res);
 		if (teamId === null) return;
 		try {

--- a/apps/server/src/api/v1/oncall/router.ts
+++ b/apps/server/src/api/v1/oncall/router.ts
@@ -1,14 +1,17 @@
 import { Router } from 'express';
 import { OncallController } from './controller';
+import { requireAdmin } from '../../../middleware/auth';
 
 export default function createOncallRouter(controller: OncallController) {
 	const router = Router();
 
+	// Reading the schedule is open to any authenticated user (the NOC needs it);
+	// changing it is admins only.
 	router.get('/teams', controller.listTeamsHandler);
-	router.post('/teams', controller.createTeamHandler);
-	router.patch('/teams/:teamId', controller.updateTeamHandler);
-	router.delete('/teams/:teamId', controller.deleteTeamHandler);
-	router.put('/teams/:teamId/members', controller.setTeamMembersHandler);
+	router.post('/teams', requireAdmin, controller.createTeamHandler);
+	router.patch('/teams/:teamId', requireAdmin, controller.updateTeamHandler);
+	router.delete('/teams/:teamId', requireAdmin, controller.deleteTeamHandler);
+	router.put('/teams/:teamId/members', requireAdmin, controller.setTeamMembersHandler);
 
 	return router;
 }

--- a/apps/server/src/api/v1/retention/controller.ts
+++ b/apps/server/src/api/v1/retention/controller.ts
@@ -1,7 +1,6 @@
 import { Response } from 'express';
 import {
 	Logger,
-	Role,
 	UpdateRetentionConfigSchema,
 	UpdateRetentionPolicySchema,
 	RetentionResourceParamSchema,
@@ -15,16 +14,7 @@ const logger = new Logger('api/v1/retention/controller');
 export class RetentionController {
 	constructor(private retentionBL: RetentionBL) {}
 
-	private requireAdmin(req: AuthenticatedRequest, res: Response): boolean {
-		if (!req.user || req.user.role !== Role.Admin) {
-			res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-			return false;
-		}
-		return true;
-	}
-
-	getSettings = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
+	getSettings = async (_req: AuthenticatedRequest, res: Response) => {
 		try {
 			const settings = await this.retentionBL.getSettings();
 			return res.json({ success: true, data: settings });
@@ -35,7 +25,6 @@ export class RetentionController {
 	};
 
 	updateConfig = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
 		try {
 			const updates = UpdateRetentionConfigSchema.parse(req.body as unknown);
 			const config = await this.retentionBL.updateConfig(updates);
@@ -50,7 +39,6 @@ export class RetentionController {
 	};
 
 	updatePolicy = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
 		try {
 			const { resourceType } = RetentionResourceParamSchema.parse(req.params);
 			const updates = UpdateRetentionPolicySchema.parse(req.body as unknown);
@@ -65,8 +53,7 @@ export class RetentionController {
 		}
 	};
 
-	runNow = async (req: AuthenticatedRequest, res: Response) => {
-		if (!this.requireAdmin(req, res)) return;
+	runNow = async (_req: AuthenticatedRequest, res: Response) => {
 		try {
 			const result = await this.retentionBL.runCleanup();
 			return res.json({ success: true, data: result });

--- a/apps/server/src/api/v1/retention/router.ts
+++ b/apps/server/src/api/v1/retention/router.ts
@@ -1,8 +1,12 @@
 import { Router } from 'express';
 import { RetentionController } from './controller';
+import { requireAdmin } from '../../../middleware/auth';
 
 export default function createRetentionRouter(controller: RetentionController) {
 	const router = Router();
+
+	// Every retention endpoint is org-wide configuration: admins only.
+	router.use(requireAdmin);
 
 	router.get('/', controller.getSettings);
 	router.put('/config', controller.updateConfig);

--- a/apps/server/src/api/v1/users/controller.ts
+++ b/apps/server/src/api/v1/users/controller.ts
@@ -43,9 +43,6 @@ export class UsersController {
 	};
 
 	createUserHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!req.user || req.user.role !== Role.Admin) {
-			return res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-		}
 		try {
 			const { email, fullName, password, role } = CreateUserSchema.parse(req.body);
 			const result = await this.userBL.createUser(email, fullName, password, role);
@@ -62,9 +59,6 @@ export class UsersController {
 	};
 
 	updateUserRoleHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!req.user || req.user.role !== Role.Admin) {
-			return res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-		}
 		try {
 			const { email, newRole } = UpdateUserRoleSchema.parse(req.body);
 			await this.userBL.updateUserRole(email, newRole);
@@ -96,6 +90,9 @@ export class UsersController {
 	};
 
 	getAllUsersHandler = async (req: AuthenticatedRequest, res: Response) => {
+		// Not admin-gated on purpose: the alerts UI resolves owner and comment-author
+		// names for every role. This rejects API-token callers only, which carry no
+		// user identity. (Message kept as-is for backward compatibility.)
 		if (!req.user) {
 			return res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
 		}
@@ -108,9 +105,6 @@ export class UsersController {
 	};
 
 	deleteUserHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!req.user || req.user.role !== Role.Admin) {
-			return res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-		}
 		const userId = parseInt(req.params.id);
 		if (isNaN(userId)) {
 			return res.status(400).json({ success: false, error: 'Invalid user ID' });
@@ -200,10 +194,6 @@ export class UsersController {
 	};
 
 	updateUserPasswordHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!req.user || req.user.role !== Role.Admin) {
-			return res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-		}
-
 		const userId = parseInt(req.params.id);
 		if (isNaN(userId)) {
 			return res.status(400).json({ success: false, error: 'Invalid user ID' });
@@ -219,8 +209,9 @@ export class UsersController {
 				});
 			}
 
-			// Don't allow admin to reset their own password this way
-			if (userId === parseInt(req.user.id, 10)) {
+			// Don't allow admin to reset their own password this way.
+			// requireAdmin (users/router.ts) guarantees req.user is present.
+			if (req.user && userId === parseInt(req.user.id, 10)) {
 				return res.status(400).json({
 					success: false,
 					error: 'Cannot reset your own password. Use profile settings instead.',
@@ -245,10 +236,6 @@ export class UsersController {
 	};
 
 	updateUserHandler = async (req: AuthenticatedRequest, res: Response) => {
-		if (!req.user || req.user.role !== Role.Admin) {
-			return res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
-		}
-
 		const userId = parseInt(req.params.id);
 		if (isNaN(userId)) {
 			return res.status(400).json({ success: false, error: 'Invalid user ID' });

--- a/apps/server/src/api/v1/users/router.ts
+++ b/apps/server/src/api/v1/users/router.ts
@@ -1,17 +1,19 @@
 import { Router } from 'express';
 import { UsersController } from './controller';
+import { requireAdmin } from '../../../middleware/auth';
 
 export default function createUsersRouter(usersController: UsersController) {
 	const router = Router();
 
 	// POST /users - admin creates new user
-	router.post('/', usersController.createUserHandler);
+	router.post('/', requireAdmin, usersController.createUserHandler);
 
-	// GET /users - get all users (admin only)
+	// GET /users - list users. Deliberately NOT admin-gated: the alerts UI resolves
+	// owner and comment-author names for every authenticated role.
 	router.get('/', usersController.getAllUsersHandler);
 
 	// PATCH /users/role - update user role
-	router.patch('/role', usersController.updateUserRoleHandler);
+	router.patch('/role', requireAdmin, usersController.updateUserRoleHandler);
 
 	// GET /users/profile - get user profile
 	router.get('/profile', usersController.getProfileHandler);
@@ -20,13 +22,13 @@ export default function createUsersRouter(usersController: UsersController) {
 	router.patch('/profile', usersController.updateProfileHandler);
 
 	// DELETE /users/:id - delete user by ID (admin only)
-	router.delete('/:id', usersController.deleteUserHandler);
+	router.delete('/:id', requireAdmin, usersController.deleteUserHandler);
 
 	// PATCH /users/password - update user password
-	router.patch('/:id/reset-password', usersController.updateUserPasswordHandler);
+	router.patch('/:id/reset-password', requireAdmin, usersController.updateUserPasswordHandler);
 
 	//PATCH /user/:id - update user info by admin
-	router.patch('/:id', usersController.updateUserHandler);
+	router.patch('/:id', requireAdmin, usersController.updateUserHandler);
 
 	return router;
 }

--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -29,6 +29,18 @@ export function authenticateJWT(req: AuthenticatedRequest, res: Response, next: 
 	return authenticateUserJWT(bearerToken, req, res, next);
 }
 
+/**
+ * Router-level admin gate. MUST be mounted after `authenticateJWT`, which is what
+ * populates `req.user`. API-token callers have no `req.user` and are rejected here —
+ * org-wide configuration is a human-admin operation.
+ */
+export function requireAdmin(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+	if (!req.user || req.user.role !== Role.Admin) {
+		return res.status(403).json({ success: false, error: 'Forbidden: Admins only' });
+	}
+	return next();
+}
+
 function authenticateApiToken(apiToken: string, res: Response, next: NextFunction) {
 	// Double check the apiToken is not empty
 	if (apiToken !== getSecurityConfig().api_token && apiToken.length > 0) {

--- a/apps/server/tests/requireAdmin.test.ts
+++ b/apps/server/tests/requireAdmin.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { SuperTest, Test } from 'supertest';
+import Database from 'better-sqlite3';
+import { setupDB, setupExpressApp, setupUserWithToken } from './setup';
+
+// Covers the shared `requireAdmin` middleware (src/middleware/auth.ts) now that the
+// gate lives in the routers instead of being re-implemented in five controllers.
+// The point of these tests is the *layering*: `authenticateJWT` must still run first
+// (401 before 403, and the viewer write-block before the admin check), API-token
+// callers must still be rejected, and the routes that were deliberately left open
+// must stay open.
+
+let app: SuperTest<Test>;
+let db: Database.Database;
+let adminToken: string;
+let editorToken: string;
+let viewerToken: string;
+let operationToken: string;
+
+// Every route the middleware now guards, one per router-level decision.
+const ADMIN_ROUTES = [
+	['get', '/api/v1/alerts/silence-reset'],
+	['put', '/api/v1/alerts/silence-reset'],
+	['get', '/api/v1/retention'],
+	['put', '/api/v1/retention/config'],
+	['post', '/api/v1/retention/run'],
+	['put', '/api/v1/retention/policies/alerts'],
+	['post', '/api/v1/oncall/teams'],
+	['patch', '/api/v1/oncall/teams/1'],
+	['delete', '/api/v1/oncall/teams/1'],
+	['put', '/api/v1/oncall/teams/1/members'],
+	['get', '/api/v1/ai/config'],
+	['put', '/api/v1/ai/config'],
+	['post', '/api/v1/ai/test'],
+	['post', '/api/v1/users'],
+	['patch', '/api/v1/users/role'],
+	['delete', '/api/v1/users/999'],
+	['patch', '/api/v1/users/999/reset-password'],
+	['patch', '/api/v1/users/999'],
+] as const;
+
+const send = (method: string, path: string) => (app as unknown as Record<string, (p: string) => Test>)[method](path);
+
+const createUserWithRole = async (role: string): Promise<string> => {
+	const email = `${role}@requireadmin.test`;
+	const password = 'password123';
+	await app
+		.post('/api/v1/users')
+		.set('Authorization', `Bearer ${adminToken}`)
+		.send({ email, fullName: `${role} user`, password, role });
+	const login = await app.post('/api/v1/users/login').send({ email, password });
+	expect(login.body.token).toBeTruthy();
+	return login.body.token as string;
+};
+
+beforeAll(async () => {
+	db = await setupDB();
+	app = await setupExpressApp(db);
+	// The first registered user is auto-promoted to admin.
+	adminToken = await setupUserWithToken(app);
+	editorToken = await createUserWithRole('editor');
+	viewerToken = await createUserWithRole('viewer');
+	operationToken = await createUserWithRole('operation');
+});
+
+afterAll(() => {
+	db.close();
+});
+
+describe('requireAdmin middleware', () => {
+	test('unauthenticated requests are rejected by authenticateJWT, before the admin gate', async () => {
+		for (const [method, path] of ADMIN_ROUTES) {
+			const res = await send(method, path);
+			expect(res.status, `${method.toUpperCase()} ${path}`).toBe(401);
+			expect(res.body.error, `${method.toUpperCase()} ${path}`).toBe('Missing Authorization header or API token');
+		}
+	});
+
+	// Editors are the only non-admin role that reaches requireAdmin on write methods
+	// (viewers are stopped earlier), so this is the strongest probe of the gate itself.
+	test('editors get 403 Forbidden: Admins only on every gated route', async () => {
+		for (const [method, path] of ADMIN_ROUTES) {
+			const res = await send(method, path).set('Authorization', `Bearer ${editorToken}`);
+			expect(res.status, `${method.toUpperCase()} ${path}`).toBe(403);
+			expect(res.body).toEqual({ success: false, error: 'Forbidden: Admins only' });
+		}
+	});
+
+	test('the operation role is not treated as admin', async () => {
+		for (const [method, path] of ADMIN_ROUTES) {
+			const res = await send(method, path).set('Authorization', `Bearer ${operationToken}`);
+			expect(res.status, `${method.toUpperCase()} ${path}`).toBe(403);
+			expect(res.body).toEqual({ success: false, error: 'Forbidden: Admins only' });
+		}
+	});
+
+	// Layering assertion: the viewer write-block lives in authenticateJWT and must
+	// still fire *before* requireAdmin, so the two roles get different messages.
+	test('viewers hit the write-block on writes and the admin gate on reads', async () => {
+		for (const [method, path] of ADMIN_ROUTES) {
+			const res = await send(method, path).set('Authorization', `Bearer ${viewerToken}`);
+			expect(res.status, `${method.toUpperCase()} ${path}`).toBe(403);
+			expect(res.body.error, `${method.toUpperCase()} ${path}`).toBe(
+				method === 'get' ? 'Forbidden: Admins only' : 'Forbidden: Viewer users cannot edit data'
+			);
+		}
+	});
+
+	// API-token auth calls next() without populating req.user, so the `!req.user`
+	// clause in requireAdmin is what keeps these endpoints human-admin only.
+	test('API-token callers are rejected (they carry no user identity)', async () => {
+		for (const [method, path] of ADMIN_ROUTES) {
+			const res = await send(method, path).set('x-api-token', process.env.API_TOKEN ?? 'opsimate');
+			expect(res.status, `${method.toUpperCase()} ${path}`).toBe(403);
+			expect(res.body).toEqual({ success: false, error: 'Forbidden: Admins only' });
+		}
+	});
+
+	// Not pinned to 200: several of these legitimately 400/404 on placeholder ids and
+	// empty bodies. What matters is that the gate itself lets admins through.
+	test('admins are never blocked by the gate', async () => {
+		for (const [method, path] of ADMIN_ROUTES) {
+			const res = await send(method, path).set('Authorization', `Bearer ${adminToken}`);
+			expect(res.status, `${method.toUpperCase()} ${path}`).not.toBe(403);
+		}
+	});
+});
+
+describe('routes deliberately left open to non-admins', () => {
+	const OPEN_ROUTES = [
+		'/api/v1/oncall/teams',
+		'/api/v1/ai/status',
+		'/api/v1/users',
+		'/api/v1/users/profile',
+		'/api/v1/alerts',
+	];
+
+	test('every authenticated role can still read them', async () => {
+		for (const token of [editorToken, viewerToken, operationToken]) {
+			for (const path of OPEN_ROUTES) {
+				const res = await app.get(path).set('Authorization', `Bearer ${token}`);
+				expect(res.status, path).toBe(200);
+			}
+		}
+	});
+
+	// GET /users feeds the alerts UI (owner pickers, comment authors, grouping and
+	// sorting) for every role — gating it would be a silent client regression.
+	test('GET /users stays ungated', async () => {
+		const res = await app.get('/api/v1/users').set('Authorization', `Bearer ${viewerToken}`);
+		expect(res.status).toBe(200);
+		expect(Array.isArray(res.body.data)).toBe(true);
+	});
+});
+
+// A router-level `router.use(requireAdmin)` on any of the mixed routers would break
+// one of these; they lock the per-route application in place.
+describe('route ordering is unaffected by the added middleware', () => {
+	test('the alerts silence-reset gate does not leak onto /:alertId', async () => {
+		const res = await app.delete('/api/v1/alerts/some-id').set('Authorization', `Bearer ${editorToken}`);
+		expect(res.body.error).not.toBe('Forbidden: Admins only');
+	});
+
+	test('PATCH /users/profile still matches before the gated /:id', async () => {
+		const res = await app
+			.patch('/api/v1/users/profile')
+			.set('Authorization', `Bearer ${editorToken}`)
+			.send({ fullName: 'Renamed Editor' });
+		expect(res.status).toBe(200);
+	});
+
+	test('PATCH /users/role is gated and still matches before /:id', async () => {
+		const res = await app.patch('/api/v1/users/role').set('Authorization', `Bearer ${editorToken}`);
+		expect(res.status).toBe(403);
+		expect(res.body.error).toBe('Forbidden: Admins only');
+	});
+
+	test('POST /ai/filter stayed open', async () => {
+		const res = await app.post('/api/v1/ai/filter').set('Authorization', `Bearer ${editorToken}`);
+		expect(res.status).not.toBe(403);
+	});
+});


### PR DESCRIPTION
## Issue Reference

Closes #772

---

## What Was Changed

Extracted the duplicated admin authorization check into a single `requireAdmin`
Express
middleware in `apps/server/src/middleware/auth.ts`, next to `authenticateJWT`, and
applied
it at the router level.

**Removed 18 copies of the same check across 5 controllers:**

| Controller | Removed |
|---|---|
| `alerts/controller.ts` | private helper + 2 call sites |
| `oncall/controller.ts` | private helper + 4 call sites |
| `retention/controller.ts` | private helper + 4 call sites |
| `ai/controller.ts` | private helper + 3 call sites |
| `users/controller.ts` | 5 longhand `if (!req.user \|\| req.user.role !==
Role.Admin)` blocks |

**Applied in the routers:**

- `retention/router.ts` — `router.use(requireAdmin)`; all four routes are
admin-only.
- `alerts`, `oncall`, `ai`, `users` — per-route, since each of these routers mixes
admin and open endpoints (`GET /oncall/teams`, `GET /ai/status`, `POST /ai/filter`,
  `GET /users`, `/users/profile`).

**Incidental cleanups the refactor required:** dropped four now-unused `Role`
imports,
renamed three handler `req` params to `_req` where the guard was their only
consumer, and moved the "reading the schedule is open, changing it is admins only" rationale
comment from the deleted oncall helper onto the router where the split is now expressed.

**New tests:** `apps/server/tests/requireAdmin.test.ts` — 12 tests over all 18
gated routes.

Net **-94 / +51** lines in `src/`.

---

## Why Was It Changed

The same six-line check was maintained in five places, and it had already drifted.
Two concrete symptoms found while doing this:

1. **`ai/controller.ts` had a fourth copy** that the issue didn't list — the drift
was already spreading beyond the three known sites.
2. **`getAllUsersHandler` had silently degraded.** It checks only `if (!req.user)`
— the role comparison is missing — while still returning the `'Forbidden: Admins
only'` message and sitting under a `// (admin only)` router comment. Five near-identical copies is exactly how a load-bearing check loses a clause without anyone noticing.

Putting the gate in `router.ts` also makes it visible where routes are declared, so a reviewer adding an admin route can see the gate rather than having to read the handler body.

**This PR is behavior-preserving.** Status code, error message and JSON body are identical for every request shape:

| Request | Before | After |
|---|---|---|
| Admin JWT | passes | passes |
| Editor / Operation | 403 `Forbidden: Admins only` | same |
| Viewer, write | 403 `Forbidden: Viewer users cannot edit data` (from
`authenticateJWT`, upstream) | same |
| Viewer, read | 403 `Forbidden: Admins only` | same |
| `x-api-token` caller | 403 (API-token auth sets no `req.user`) | same |
| No credentials | 401 from `authenticateJWT` | same |

Ordering is structurally guaranteed: `requireAdmin` reads `req.user`, and all five routers mount below `router.use(authenticateJWT)` at `v1.ts:65`, which is `createV1Router`'s only mount point.

---
## Additional Context

**`GET /users` is deliberately left ungated.** It looks like the same check but isn't, and `apps/client/src/hooks/queries/users/useUsers.ts` is consumed by `AlertsFilterPanel`, `AlertsSelectionBar`, `AlertOwnerColumn`, `useAlertGrouping`, `useAlertSorting`, `AlertInfoSection`, `CommentsWall`, `AlertLastCommentSection` and `pages/Oncall.tsx` — every authenticated role depends on it for owner and comment-author names. 
Applying `requireAdmin` here would 403 the alerts UI for editors, viewers and operation users. The handler keeps its `!req.user` check (which rejects API-token callers) and both it and the route now carry a comment saying why it's open. **The stale `'Forbidden: Admins only'` message and the `(admin only)` router comment were a copy-paste artifact; the router comment is corrected here, the response body is left untouched since changing it is client-visible.**
If the gate is actually wanted, that's a deliberate breaking change and belongs in its own issue.

**One intentional divergence:** `router.use(requireAdmin)` on the retention router means unmatched paths under `/api/v1/retention/*` now return **403 instead of 404** for non-admins.
Arguably an improvement (it stops leaking route existence), but flagging it as a real change.

**Type narrowing at `users/controller.ts`.** `updateUserPasswordHandler`'s self-reset guard reads `req.user.id` and only compiled because the deleted check narrowed `req.user`. It's now `if (req.user && userId === parseInt(req.user.id, 10))` — eslint's `recommended` config bans non-null assertions, so `req.user!` wasn't an option. `ai/controller.ts` needed no equivalent change: `AiBL.updateConfig(updates, user?: User)` already takes an optional user.

**No boolean helper was exported alongside the middleware.** After this refactor zero call sites need one, and exporting two shapes of the same rule is how the duplication would grow back.

### Verification

- `pnpm --filter @OpsiMate/server test` — **351 passed** (339 pre-existing + 12
new).
- Typecheck clean.
- The new tests were mutation-checked: neutering `requireAdmin` to a bare `next()`
fails 5
  of the 12, so they aren't passing vacuously.
- Pre-existing regressions kept green: `alerts.test.ts:1799` (silence-reset rejects
  non-admins), `aiConfig.test.ts:117` (viewer 403 on `GET /ai/config`),
`auth.test.ts:174`
  (non-admin cannot delete a user).

The new suite asserts the *layering*, not just the status code — 401 before 403 for unauthenticated calls, viewers getting the write-block message on writes vs admins-only on reads, API-token callers rejected, and route-ordering locks (`/users/profile` before `/:id`, the silence-reset gate not leaking onto `/alerts/:alertId`) that would catch a stray `router.use` on a mixed router.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Access Control**
  - Centralized admin authorization for AI configuration and connection testing, alert silence-reset settings, retention management, on-call team changes, and user administration.
  - Non-admin authenticated users can continue accessing designated shared endpoints, including on-call team lists, AI status, user lists, and alert-related data.
  - Unauthorized requests now receive consistent authentication or forbidden responses across protected routes.

- **Tests**
  - Added coverage for protected routes, permitted shared routes, role-based responses, and route-isolation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->