### PR TITLE
[FIX]: Remove redundant auth middleware checks

### DIFF
--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -30,8 +30,7 @@ export function authenticateJWT(req: AuthenticatedRequest, res: Response, next: 
 }
 
 function authenticateApiToken(apiToken: string, res: Response, next: NextFunction) {
-	// Double check the apiToken is not empty
-	if (apiToken !== getSecurityConfig().api_token && apiToken.length > 0) {
+	if (apiToken !== getSecurityConfig().api_token) {
 		return res.status(401).json({ success: false, error: 'Invalid API token' });
 	}
 
@@ -46,7 +45,7 @@ function authenticateUserJWT(bearerToken: string, req: AuthenticatedRequest, res
 		req.user = payload;
 
 		// Viewer edit restrictions
-		const editMethods = ['PUT', 'PATCH', 'DELETE', 'POST', 'OPTIONS'];
+		const editMethods = ['PUT', 'PATCH', 'DELETE', 'POST'];
 		if (editMethods.includes(req.method) && payload.role === Role.Viewer) {
 			return res.status(403).json({ success: false, error: 'Forbidden: Viewer users cannot edit data' });
 		}


### PR DESCRIPTION
## Issue Reference

Closes #885

---

## What Was Changed

* Removed `OPTIONS` from the Viewer edit-method restrictions.
* Removed the redundant `apiToken.length > 0` condition from API-token validation.

---

## Why Was It Changed

CORS middleware already handles `OPTIONS` requests before they reach the authentication middleware, making the `OPTIONS` entry dead and misleading.

The API-token length condition was also unnecessary because `hasApiToken` already guarantees that the token is non-empty before validation.

---

## Screenshots

Not applicable — this change does not affect the UI.

---

## Additional Context (Optional)

Validation completed:

* Auth middleware tests passed: 16/16
* Prettier check passed
* Server production build passed
* `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API token authentication now consistently validates tokens against the configured token.
  * Viewer users can now make `OPTIONS` requests without being blocked by edit restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->