### PR TITLE
fix: handle overnight mute policy schedules

### DIFF
--- a/apps/client/src/pages/MutePolicies.tsx
+++ b/apps/client/src/pages/MutePolicies.tsx
@@ -23,16 +23,11 @@ import { BellOff, Calendar, CheckCircle2, Clock, Hourglass, Pencil, Plus, Repeat
 import { describeCriteriaScope, hasMatcherCriteria, MatcherGroupBadges } from '@/components/shared/MatcherGroupsEditor';
 import { SortableTableHead, useTableSort } from '@/components/shared/SortableTable';
 import { useMemo, useState } from 'react';
+import { isScheduleActiveNow } from '@OpsiMate/shared';
 
 type MutePolicyStatus = 'active' | 'scheduled' | 'expired';
 
 const DAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-const isScheduleActiveNow = (schedule: NonNullable<MutePolicy['schedule']>, now: Date = new Date()): boolean => {
-	if (!schedule.daysOfWeek?.includes(now.getDay())) return false;
-	const current = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
-	return current >= schedule.startTime && current < schedule.endTime;
-};
 
 const getStatus = (s: MutePolicy): MutePolicyStatus => {
 	if (s.schedule) {

--- a/apps/server/src/bl/mute-policies/mutePolicy.bl.ts
+++ b/apps/server/src/bl/mute-policies/mutePolicy.bl.ts
@@ -3,6 +3,7 @@ import {
 	AuditActionType,
 	AuditResourceType,
 	criteriaMatchesAlert,
+	isScheduleActiveNow,
 	Logger,
 	MutePolicy,
 	User,
@@ -117,9 +118,7 @@ export class MutePolicyBL {
 		if (mutePolicy.schedule) {
 			const { daysOfWeek, startTime, endTime } = mutePolicy.schedule;
 			if (!daysOfWeek?.length || !startTime || !endTime) return false;
-			if (!daysOfWeek.includes(now.getDay())) return false;
-			const current = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
-			return current >= startTime && current < endTime;
+			return isScheduleActiveNow(mutePolicy.schedule, now);
 		}
 		const ts = now.getTime();
 		if (mutePolicy.startsAt) {

--- a/apps/server/tests/mutePolicy.utils.test.ts
+++ b/apps/server/tests/mutePolicy.utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { isScheduleActiveNow } from '@OpsiMate/shared';
+
+describe('isScheduleActiveNow', () => {
+	test('is active during an overnight schedule', () => {
+		const schedule = {
+			startTime: '22:00',
+			endTime: '06:00',
+			daysOfWeek: [1],
+		};
+
+		expect(isScheduleActiveNow(schedule, new Date(2026, 8, 7, 23, 0))).toBe(true);
+		expect(isScheduleActiveNow(schedule, new Date(2026, 8, 8, 5, 0))).toBe(true);
+		expect(isScheduleActiveNow(schedule, new Date(2026, 8, 7, 5, 0))).toBe(false);
+		expect(isScheduleActiveNow(schedule, new Date(2026, 8, 8, 23, 0))).toBe(false);
+	});
+	test('is active during a normal same-day schedule', () => {
+		const schedule = {
+			startTime: '09:00',
+			endTime: '17:00',
+			daysOfWeek: [1],
+		};
+
+		expect(isScheduleActiveNow(schedule, new Date(2026, 8, 7, 12, 0))).toBe(true);
+		expect(isScheduleActiveNow(schedule, new Date(2026, 8, 7, 18, 0))).toBe(false);
+	});
+	test('is inactive when today is not in the schedule', () => {
+		const schedule = {
+			startTime: '22:00',
+			endTime: '06:00',
+			daysOfWeek: [1],
+		};
+
+		expect(isScheduleActiveNow(schedule, new Date(2026, 8, 8, 23, 0))).toBe(false);
+	});
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,4 @@ export * from './alerts/alertQuery';
 export * from './alerts/alertAnalytics';
 export * from './alerts/computeAlertAnalytics';
 export * from './alerts/alertGroups';
+export * from './mutePolicy.utils';

--- a/packages/shared/src/mutePolicy.utils.ts
+++ b/packages/shared/src/mutePolicy.utils.ts
@@ -1,0 +1,17 @@
+import { MutePolicy } from './types';
+
+export const isScheduleActiveNow = (schedule: NonNullable<MutePolicy['schedule']>, now: Date = new Date()): boolean => {
+	const days = schedule.daysOfWeek ?? [];
+	const current = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+
+	if (schedule.startTime <= schedule.endTime) {
+		return days.includes(now.getDay()) && current >= schedule.startTime && current < schedule.endTime;
+	}
+
+	const yesterday = (now.getDay() + 6) % 7;
+
+	return (
+		(current >= schedule.startTime && days.includes(now.getDay())) ||
+		(current < schedule.endTime && days.includes(yesterday))
+	);
+};


### PR DESCRIPTION
## What does this PR do?

Fixes mute policy schedules that cross midnight, such as `22:00 → 06:00`.

Previously, these schedules were never considered active because the time comparison only handled same-day ranges.

### Changes

- Extracted `isScheduleActiveNow` into a reusable utility
- Added support for overnight schedules
- Added unit tests for:
  - Overnight schedules
  - Normal same-day schedules
  - Days outside the schedule

### Testing

- `isScheduleActiveNow` tests: 3/3 passed
- Full client test suite: 260/260 passed

Closes #763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mute policy schedule evaluation for consistent handling of same-day and overnight time windows.
  * Mute policies now correctly determine whether they are active before and after midnight while respecting configured days of the week.
  * Corrected calculation of the next scheduled end time for windows that cross midnight.

* **Tests**
  * Added coverage for standard schedules, overnight schedules, inactive days, and time-window boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->