### PR TITLE
fix(alerts): reject partial Uptime Kuma payloads instead of persisting phantom test alerts

### DIFF
--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -270,7 +270,11 @@ export class AlertController {
 		try {
 			const body = req.body as UptimeKumaWebhookTestPayload;
 
-			if (!body?.heartbeat || !body?.monitor) {
+			// Uptime Kuma's "Test" notification sends NEITHER heartbeat nor monitor. Only
+			// that shape bypasses validation; a payload carrying one but not the other is
+			// a malformed real alert and must fall through to the strict parse (400), not
+			// be persisted as a phantom "Test Alert".
+			if (!body?.heartbeat && !body?.monitor) {
 				logger.info('UptimeKuma Test Alert Created');
 				await this.alertBL.insertOrUpdateAlert({
 					id: randomUUID(),

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -24,7 +24,6 @@ import {
 	SilenceAlertBodySchema,
 	UptimeKumaWebhookPayloadSchema,
 	ZabbixWebhookPayloadSchema,
-	UptimeKumaWebhookTestPayload,
 } from './models';
 import { isZodError } from '../../../utils/isZodError.ts';
 import { RootCauseBL, RootCauseNotFoundError } from '../../../bl/rootCause/rootCause.bl.ts';
@@ -268,13 +267,17 @@ export class AlertController {
 
 	async createUptimeKumaAlert(req: Request, res: Response) {
 		try {
-			const body = req.body as UptimeKumaWebhookTestPayload;
-
 			// Uptime Kuma's "Test" notification sends NEITHER heartbeat nor monitor. Only
-			// that shape bypasses validation; a payload carrying one but not the other is
-			// a malformed real alert and must fall through to the strict parse (400), not
-			// be persisted as a phantom "Test Alert".
-			if (!body?.heartbeat && !body?.monitor) {
+			// that shape bypasses validation; anything else — one field but not the other,
+			// or a field present but null/invalid — is a malformed real alert and must fall
+			// through to the strict parse (400), not be persisted as a phantom "Test
+			// Alert". Hence PRESENCE, not truthiness: `{ heartbeat: null }` is not a test.
+			const raw: unknown = req.body;
+			const isTestRequest =
+				raw === undefined ||
+				raw === null ||
+				(typeof raw === 'object' && !('heartbeat' in raw) && !('monitor' in raw));
+			if (isTestRequest) {
 				logger.info('UptimeKuma Test Alert Created');
 				await this.alertBL.insertOrUpdateAlert({
 					id: randomUUID(),

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -267,16 +267,18 @@ export class AlertController {
 
 	async createUptimeKumaAlert(req: Request, res: Response) {
 		try {
-			// Uptime Kuma's "Test" notification sends NEITHER heartbeat nor monitor. Only
-			// that shape bypasses validation; anything else — one field but not the other,
-			// or a field present but null/invalid — is a malformed real alert and must fall
-			// through to the strict parse (400), not be persisted as a phantom "Test
-			// Alert". Hence PRESENCE, not truthiness: `{ heartbeat: null }` is not a test.
+			// Uptime Kuma's "Test" button calls Notification.send(notification, msg) with
+			// monitorJSON/heartbeatJSON left at their null defaults (server.js, the
+			// testNotification handler), so the webhook body is { heartbeat: null,
+			// monitor: null, msg } — keys PRESENT, values null. An empty body is accepted as
+			// the same thing for hand-sent probes. Only that shape bypasses validation: a
+			// payload with one real field and the other missing/null is a malformed alert
+			// and must fall through to the strict parse (400), not become a phantom
+			// "Test Alert".
 			const raw: unknown = req.body;
-			const isTestRequest =
-				raw === undefined ||
-				raw === null ||
-				(typeof raw === 'object' && !('heartbeat' in raw) && !('monitor' in raw));
+			const field = (key: 'heartbeat' | 'monitor'): unknown =>
+				typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>)[key] : undefined;
+			const isTestRequest = field('heartbeat') == null && field('monitor') == null;
 			if (isTestRequest) {
 				logger.info('UptimeKuma Test Alert Created');
 				await this.alertBL.insertOrUpdateAlert({

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1337,22 +1337,20 @@ describe('Alerts API', () => {
 			expect(response.body.error).toBe('Validation error');
 		});
 
-		test('a partial payload (heartbeat without monitor) is a 400, not a phantom test alert', async () => {
-			const before = (
-				db.prepare("SELECT COUNT(*) AS c FROM alerts WHERE alert_name = 'Test Alert'").get() as { c: number }
-			).c;
+		// Grounded in Uptime Kuma's source: the Test button calls
+		// Notification.send(notification, msg) with monitorJSON/heartbeatJSON at their
+		// null defaults, so the real test body is { heartbeat: null, monitor: null, msg }.
+		// A presence check ("key in body") would 400 it and break every integration setup.
+		test('the REAL Uptime Kuma Test payload (both fields null) creates a test alert', async () => {
 			const response = await app
 				.post('/api/v1/alerts/custom/uptimekuma')
 				.set('Authorization', `Bearer ${jwtToken}`)
-				.send({ heartbeat: baseHeartbeat, msg: 'no monitor' });
-			expect(response.status).toBe(400);
-			const after = (
-				db.prepare("SELECT COUNT(*) AS c FROM alerts WHERE alert_name = 'Test Alert'").get() as { c: number }
-			).c;
-			expect(after).toBe(before);
+				.send({ heartbeat: null, monitor: null, msg: 'My Webhook Testing' });
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ success: true, data: null });
 		});
 
-		test('a present-but-null heartbeat or monitor is a 400, not a phantom test alert', async () => {
+		test('one real field with the other null/missing is a 400, not a phantom test alert', async () => {
 			const count = () =>
 				(db.prepare("SELECT COUNT(*) AS c FROM alerts WHERE alert_name = 'Test Alert'").get() as { c: number })
 					.c;
@@ -1360,7 +1358,7 @@ describe('Alerts API', () => {
 			for (const payload of [
 				{ heartbeat: null, monitor: baseMonitor, msg: 'x' },
 				{ heartbeat: baseHeartbeat, monitor: null, msg: 'x' },
-				{ heartbeat: null, monitor: null, msg: 'x' },
+				{ heartbeat: baseHeartbeat, msg: 'x' },
 			]) {
 				const response = await app
 					.post('/api/v1/alerts/custom/uptimekuma')

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1308,7 +1308,7 @@ describe('Alerts API', () => {
 				.set('Authorization', `Bearer ${jwtToken}`)
 				.send(payload);
 
-			expect(response.status).toBe(200);
+			expect(response.status).toBe(400);
 		});
 
 		// Real Uptime Kuma heartbeats carry status as a NUMBER (0/1/2). A schema written
@@ -1335,6 +1335,21 @@ describe('Alerts API', () => {
 				.send({ heartbeat: { ...baseHeartbeat, time: 'not-a-date' }, monitor: baseMonitor, msg: 'x' });
 			expect(response.status).toBe(400);
 			expect(response.body.error).toBe('Validation error');
+		});
+
+		test('a partial payload (heartbeat without monitor) is a 400, not a phantom test alert', async () => {
+			const before = (
+				db.prepare("SELECT COUNT(*) AS c FROM alerts WHERE alert_name = 'Test Alert'").get() as { c: number }
+			).c;
+			const response = await app
+				.post('/api/v1/alerts/custom/uptimekuma')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ heartbeat: baseHeartbeat, msg: 'no monitor' });
+			expect(response.status).toBe(400);
+			const after = (
+				db.prepare("SELECT COUNT(*) AS c FROM alerts WHERE alert_name = 'Test Alert'").get() as { c: number }
+			).c;
+			expect(after).toBe(before);
 		});
 
 		test('should create a test alert for an empty request body', async () => {

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1352,6 +1352,25 @@ describe('Alerts API', () => {
 			expect(after).toBe(before);
 		});
 
+		test('a present-but-null heartbeat or monitor is a 400, not a phantom test alert', async () => {
+			const count = () =>
+				(db.prepare("SELECT COUNT(*) AS c FROM alerts WHERE alert_name = 'Test Alert'").get() as { c: number })
+					.c;
+			const before = count();
+			for (const payload of [
+				{ heartbeat: null, monitor: baseMonitor, msg: 'x' },
+				{ heartbeat: baseHeartbeat, monitor: null, msg: 'x' },
+				{ heartbeat: null, monitor: null, msg: 'x' },
+			]) {
+				const response = await app
+					.post('/api/v1/alerts/custom/uptimekuma')
+					.set('Authorization', `Bearer ${jwtToken}`)
+					.send(payload);
+				expect(response.status, JSON.stringify(payload)).toBe(400);
+			}
+			expect(count()).toBe(before);
+		});
+
 		test('should create a test alert for an empty request body', async () => {
 			const response = await app
 				.post('/api/v1/alerts/custom/uptimekuma')


### PR DESCRIPTION
## Issue Reference
Follow-up to #867 — closes the one CodeRabbit finding that was still open when it merged.

## What Was Changed
The Uptime Kuma test-alert branch checked `!heartbeat || !monitor`, so a payload with one field but not the other bypassed `UptimeKumaWebhookPayloadSchema.parse`, persisted a phantom "Test Alert" row and returned 200. Only the genuine Kuma Test notification (neither field) should bypass validation; partial payloads now fall through to the strict parse and 400.

The pre-existing test `should return 400 for invalid payload (missing heartbeat)` was literally asserting `200` — it was pinning the bug. It now expects 400, plus a new test asserting a partial payload creates no Test Alert row.

## Why Was It Changed
A misconfigured or buggy sender would silently accumulate "Test Alert" rows instead of getting a validation error telling them what's wrong. Verified live before the fix: heartbeat-only payload → 200 + phantom row.

Server 360/360, lint at `--max-warnings=0` clean, prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Uptime Kuma alert validation for incomplete payloads.
  * Requests missing required alert details now return a validation error instead of being accepted or creating a misleading test alert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->