### PR TITLE
[FIX]: Add accessible names to icon-only buttons

### DIFF
--- a/apps/client/src/components/Alerts/AlertDetails/AlertDetailsHeader/AlertDetailsHeader.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/AlertDetailsHeader/AlertDetailsHeader.tsx
@@ -16,7 +16,13 @@ export const AlertDetailsHeader = ({ onClose, className, actions }: AlertDetails
 			<h2 className="text-lg font-semibold text-foreground">Alert Details</h2>
 			<div className="flex items-center gap-0.5">
 				{actions}
-				<Button variant="ghost" size="icon" onClick={onClose} className="h-8 w-8 text-foreground">
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onClose}
+					aria-label="Close details"
+					className="h-8 w-8 text-foreground"
+				>
 					<X className="h-4 w-4" />
 				</Button>
 			</div>

--- a/apps/client/src/components/Alerts/AlertDetails/CommentsWall/CommentItem/CommentItem.tsx
+++ b/apps/client/src/components/Alerts/AlertDetails/CommentsWall/CommentItem/CommentItem.tsx
@@ -73,6 +73,7 @@ export const CommentItem = ({
 								size="icon"
 								className="h-6 w-6 text-muted-foreground hover:text-foreground"
 								onClick={() => setIsEditing(true)}
+								aria-label="Edit comment"
 								disabled={isUpdating}
 							>
 								<Pencil className="h-3 w-3" />
@@ -82,6 +83,7 @@ export const CommentItem = ({
 								size="icon"
 								className="h-6 w-6 text-muted-foreground hover:text-destructive"
 								onClick={() => onDelete(comment.id)}
+								aria-label="Delete comment"
 								disabled={isDeleting}
 							>
 								<Trash2 className="h-3 w-3" />

--- a/apps/client/src/components/Dashboards/DashboardRow/DashboardRow.tsx
+++ b/apps/client/src/components/Dashboards/DashboardRow/DashboardRow.tsx
@@ -117,6 +117,7 @@ export const DashboardRow = ({
 					variant="ghost"
 					size="icon"
 					className="h-8 w-8"
+					aria-label={dashboard.isFavorite ? 'Remove dashboard from favorites' : 'Add dashboard to favorites'}
 					onClick={(e) => {
 						e.stopPropagation();
 						onToggleFavorite();
@@ -287,6 +288,7 @@ export const DashboardRow = ({
 							variant="ghost"
 							size="icon"
 							className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity text-destructive hover:text-destructive hover:bg-destructive/10"
+							aria-label="Delete dashboard"
 							onClick={(e) => e.stopPropagation()}
 						>
 							<Trash2 className="h-4 w-4" />

--- a/apps/client/src/test/iconButtonAccessibility.test.tsx
+++ b/apps/client/src/test/iconButtonAccessibility.test.tsx
@@ -1,0 +1,74 @@
+import { AlertComment } from '@OpsiMate/shared';
+import { describe, expect, test, vi } from 'vitest';
+import { CommentItem } from '@/components/Alerts/AlertDetails/CommentsWall/CommentItem';
+import { AlertDetailsHeader } from '@/components/Alerts/AlertDetails/AlertDetailsHeader';
+import { DashboardRow } from '@/components/Dashboards/DashboardRow';
+import { DashboardWithFavorite } from '@/components/Dashboards/Dashboards.types';
+import { render, screen } from './test-utils';
+
+const comment: AlertComment = {
+	id: 'comment-1',
+	alertId: 'alert-1',
+	userId: 'user-1',
+	comment: 'Investigating the alert.',
+	createdAt: new Date(0).toISOString(),
+	updatedAt: new Date(0).toISOString(),
+};
+
+const dashboard = (isFavorite: boolean): DashboardWithFavorite => ({
+	id: 'dashboard-1',
+	type: 'alerts',
+	name: 'Production alerts',
+	filters: {},
+	visibleColumns: [],
+	query: '',
+	groupBy: [],
+	isFavorite,
+	tags: [],
+});
+
+describe('icon-only button accessible names', () => {
+	test('names the edit and delete actions on an own comment', () => {
+		render(
+			<CommentItem
+				comment={comment}
+				currentUserId="user-1"
+				userMap={new Map([['user-1', { fullName: 'Test User', email: 'test@example.com' }]])}
+				onEdit={vi.fn()}
+				onDelete={vi.fn()}
+				isDeleting={false}
+				isUpdating={false}
+			/>
+		);
+
+		expect(screen.getByRole('button', { name: 'Edit comment' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Delete comment' })).toBeInTheDocument();
+	});
+
+	test('names the alert details close action', () => {
+		render(<AlertDetailsHeader onClose={vi.fn()} />);
+
+		expect(screen.getByRole('button', { name: 'Close details' })).toBeInTheDocument();
+	});
+
+	test.each<[boolean, string]>([
+		[false, 'Add dashboard to favorites'],
+		[true, 'Remove dashboard from favorites'],
+	])('names the dashboard favorite action when isFavorite=%s', (isFavorite, label) => {
+		render(
+			<table>
+				<tbody>
+					<DashboardRow
+						dashboard={dashboard(isFavorite)}
+						onClick={vi.fn()}
+						onDelete={vi.fn()}
+						onToggleFavorite={vi.fn()}
+					/>
+				</tbody>
+			</table>
+		);
+
+		expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Delete dashboard' })).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Issue Reference

Closes #909

## What Was Changed

- Added accessible names to the comment edit and delete buttons.
- Added an accessible name to the alert details close button.
- Added state-aware accessible names to the dashboard favorite button.
- Added an accessible name to the dashboard delete trigger.
- Added focused regression coverage for all of these icon-only controls.

## Why Was It Changed

Without an accessible name, screen readers expose these icon-only controls as an indistinguishable "button". The labels now describe the action a user will take, including whether the dashboard favorite action adds or removes the dashboard from Favorites.

The issue called out one unlabelled dashboard action. The same `DashboardRow` also contains an unlabelled delete trigger, so it is included because it has the same accessibility defect and lives in the same component.

## How It Was Tested

- Baseline regression: 4/4 focused tests failed when the labels were removed.
- Fixed regression: 4/4 focused tests passed.
- Client unit suite: 261/261 tests passed across 34 files.
- Client type gate: no new TypeScript errors.
- Prettier and ESLint passed for the changed files (ESLint reported only existing warnings in the touched components).
- Shared packages and the client production build completed successfully.

## Additional Context

The implementation and verification were reviewed locally with AI assistance; the final diff and test results were checked before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added accessible labels to icon-only controls for closing alert details, editing and deleting comments, and favoriting or deleting dashboards.
* **Tests**
  * Added coverage to verify that these controls are exposed with meaningful accessible names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->