### PR TITLE
feat: show the running version in the UI, baked in at release time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
         run: |
           docker buildx build \
             --platform ${{ matrix.platform }} \
+            --build-arg APP_VERSION=${{ needs.version.outputs.version }} \
+            --build-arg APP_COMMIT=${{ github.sha }} \
+            --build-arg APP_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
             -t opsimate/backend:${{ needs.version.outputs.version }}-${{ matrix.arch }} \
             -f Dockerfile.server \
             --push .
@@ -149,6 +152,9 @@ jobs:
         run: |
           docker buildx build \
             --platform ${{ matrix.platform }} \
+            --build-arg APP_VERSION=${{ needs.version.outputs.version }} \
+            --build-arg APP_COMMIT=${{ github.sha }} \
+            --build-arg APP_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
             -t opsimate/frontend:${{ needs.version.outputs.version }}-${{ matrix.arch }} \
             -f Dockerfile.client \
             --push .

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -21,6 +21,16 @@ COPY apps/client apps/client
 COPY packages/shared packages/shared
 COPY packages/custom-actions packages/custom-actions
 
+# The release workflow passes the tag-derived version; local builds fall back to
+# "dev" so the UI never claims a release number it isn't. Vite inlines VITE_* at
+# build time, which is why these are set in the BUILDER stage.
+ARG APP_VERSION=dev
+ARG APP_COMMIT=
+ARG APP_BUILD_DATE=
+ENV VITE_APP_VERSION=$APP_VERSION \
+    VITE_APP_COMMIT=$APP_COMMIT \
+    VITE_APP_BUILD_DATE=$APP_BUILD_DATE
+
 # Build shared package first, then client
 RUN pnpm --filter @OpsiMate/shared build && \
     pnpm --filter @OpsiMate/custom-actions build && \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -29,6 +29,13 @@ RUN pnpm --filter @OpsiMate/shared build && \
 
 # Production runtime
 FROM node:26-alpine AS server-runtime
+# Baked by the release workflow; read by GET /health. "dev" for local builds.
+ARG APP_VERSION=dev
+ARG APP_COMMIT=
+ARG APP_BUILD_DATE=
+ENV APP_VERSION=$APP_VERSION \
+    APP_COMMIT=$APP_COMMIT \
+    APP_BUILD_DATE=$APP_BUILD_DATE
 WORKDIR /app
 
 # Copy built server and minimal workspace files

--- a/apps/client/src/components/LeftSidebar.tsx
+++ b/apps/client/src/components/LeftSidebar.tsx
@@ -7,6 +7,7 @@ import { AppIcon } from './icons/AppIcon';
 import { ALERTS_PATHS } from './LeftSidebar.constants';
 import { PreserveQueryLink } from './PreserveQueryLink';
 import { ProfileButton } from './ProfileButton';
+import { VersionBadge } from './VersionBadge';
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@radix-ui/react-tooltip';
 
@@ -219,7 +220,7 @@ export const LeftSidebar = ({ collapsed }: LeftSidebarProps) => {
 								</Tooltip>
 							</div>
 
-							<p className={cn('text-xs text-foreground', collapsed && 'sr-only')}>© 2024 OpsiMate</p>
+							<VersionBadge collapsed={collapsed} />
 						</div>
 					</TooltipProvider>
 				</div>

--- a/apps/client/src/components/VersionBadge.tsx
+++ b/apps/client/src/components/VersionBadge.tsx
@@ -1,0 +1,70 @@
+import { useAppVersion } from '@/hooks/queries/version';
+import { formatVersion, releaseNotesUrl } from '@/lib/version';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@radix-ui/react-tooltip';
+
+interface VersionBadgeProps {
+	// Sidebar-collapsed mode: keep the text for screen readers, hide it visually.
+	collapsed?: boolean;
+	className?: string;
+}
+
+// Tooltip lines: build details, plus the two things worth calling out.
+const buildDetails = (info: ReturnType<typeof useAppVersion>): string[] => {
+	const lines: string[] = [];
+	if (info.commit) lines.push(`commit ${info.commit.slice(0, 7)}`);
+	if (info.buildDate) lines.push(`built ${new Date(info.buildDate).toLocaleDateString()}`);
+	if (info.mismatch) lines.push(`client ${formatVersion(info.clientVersion)}`);
+	if (info.updateAvailable) lines.push(`v${info.updateAvailable.version} available`);
+	return lines;
+};
+
+// "v0.0.110" in the sidebar footer, linking to that release's notes. Hover shows the
+// build details; a dot appears when GitHub has a newer release. The first thing a
+// support thread asks is "what version are you on?" — this makes the answer visible
+// without opening Settings or a terminal.
+export const VersionBadge = ({ collapsed, className }: VersionBadgeProps) => {
+	const info = useAppVersion();
+	const { version, commit, updateAvailable } = info;
+	const label = formatVersion(version, commit);
+	const details = buildDetails(info);
+	const ariaLabel = updateAvailable
+		? `OpsiMate ${label}, update available: v${updateAvailable.version}`
+		: `OpsiMate ${label}`;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<a
+					href={updateAvailable?.url ?? releaseNotesUrl(version)}
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label={ariaLabel}
+					className={cn(
+						'inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors',
+						collapsed && 'sr-only',
+						className
+					)}
+				>
+					<span className="font-mono">{label}</span>
+					{updateAvailable && (
+						<span
+							aria-hidden="true"
+							className="h-1.5 w-1.5 rounded-full bg-emerald-500"
+							title={`v${updateAvailable.version} available`}
+						/>
+					)}
+				</a>
+			</TooltipTrigger>
+			{details.length > 0 && (
+				<TooltipContent
+					side="top"
+					align="center"
+					className="rounded-md bg-popover text-popover-foreground px-2 py-1 text-xs border"
+				>
+					{details.join(' · ')}
+				</TooltipContent>
+			)}
+		</Tooltip>
+	);
+};

--- a/apps/client/src/hooks/queries/version/index.ts
+++ b/apps/client/src/hooks/queries/version/index.ts
@@ -1,0 +1,1 @@
+export * from './useAppVersion';

--- a/apps/client/src/hooks/queries/version/useAppVersion.ts
+++ b/apps/client/src/hooks/queries/version/useAppVersion.ts
@@ -1,0 +1,65 @@
+import { API_HOST } from '@/lib/api';
+import { isPlaygroundMode } from '@/lib/playground';
+import { CLIENT_VERSION, compareVersions, isReleaseVersion } from '@/lib/version';
+import { AppVersionInfo } from '@OpsiMate/shared';
+import { useQuery } from '@tanstack/react-query';
+
+// The running SERVER's build (GET /version, unauthenticated). Cached for the session:
+// it cannot change without a restart, and the sidebar mounts on every page.
+export const useServerVersion = () =>
+	useQuery({
+		queryKey: ['appVersion', 'server'],
+		queryFn: async (): Promise<AppVersionInfo> => {
+			const res = await fetch(`${API_HOST}/version`);
+			if (!res.ok) throw new Error(`version: HTTP ${res.status}`);
+			const body = (await res.json()) as { data: AppVersionInfo };
+			return body.data;
+		},
+		staleTime: Infinity,
+		retry: 1,
+		enabled: !isPlaygroundMode(),
+	});
+
+interface LatestRelease {
+	version: string;
+	url: string;
+}
+
+// The newest published release on GitHub — the "update available" signal. One
+// unauthenticated GitHub API call, cached for a day, and only asked when this build
+// is a real release (a dev build is never "behind"). Failures are silent: the badge
+// simply doesn't show the dot.
+export const useLatestRelease = (currentVersion: string) =>
+	useQuery({
+		queryKey: ['appVersion', 'latestRelease'],
+		queryFn: async (): Promise<LatestRelease | null> => {
+			const res = await fetch('https://api.github.com/repos/OpsiMate/OpsiMate/releases/latest', {
+				headers: { Accept: 'application/vnd.github+json' },
+			});
+			if (!res.ok) return null;
+			const body = (await res.json()) as { tag_name?: string; html_url?: string };
+			const version = body.tag_name?.replace(/^v/, '') ?? '';
+			return isReleaseVersion(version) && body.html_url ? { version, url: body.html_url } : null;
+		},
+		staleTime: 24 * 60 * 60 * 1000,
+		retry: false,
+		enabled: isReleaseVersion(currentVersion) && !isPlaygroundMode(),
+	});
+
+// Everything the version badge needs, resolved. The server's version is the source
+// of truth for "what am I running" (it's what a support thread needs); the client's
+// own build is surfaced when the two disagree, which is itself worth knowing.
+export const useAppVersion = () => {
+	const server = useServerVersion();
+	const version = server.data?.version ?? CLIENT_VERSION;
+	const latest = useLatestRelease(version);
+	const cmp = latest.data ? compareVersions(version, latest.data.version) : null;
+	return {
+		version,
+		commit: server.data?.commit ?? null,
+		buildDate: server.data?.buildDate ?? null,
+		clientVersion: CLIENT_VERSION,
+		mismatch: server.data ? server.data.version !== CLIENT_VERSION : false,
+		updateAvailable: cmp === -1 ? latest.data : null,
+	};
+};

--- a/apps/client/src/lib/version.ts
+++ b/apps/client/src/lib/version.ts
@@ -1,0 +1,32 @@
+// What THIS client build is. Vite inlines VITE_APP_* at build time; the release
+// workflow sets them from the git tag (see Dockerfile.client), and a local `pnpm dev`
+// or an unlabelled build reports "dev" — the honest answer, never a release number
+// the build isn't.
+export const CLIENT_VERSION: string = import.meta.env.VITE_APP_VERSION?.trim() || 'dev';
+export const CLIENT_COMMIT: string | null = import.meta.env.VITE_APP_COMMIT?.trim() || null;
+export const CLIENT_BUILD_DATE: string | null = import.meta.env.VITE_APP_BUILD_DATE?.trim() || null;
+
+export const isReleaseVersion = (version: string): boolean => /^\d+\.\d+\.\d+$/.test(version);
+
+// "v0.0.110" for releases, "dev" / "dev · a1b2c3d" otherwise.
+export const formatVersion = (version: string, commit: string | null = null): string => {
+	if (isReleaseVersion(version)) return `v${version}`;
+	return commit ? `${version} · ${commit.slice(0, 7)}` : version;
+};
+
+export const releaseNotesUrl = (version: string): string =>
+	isReleaseVersion(version)
+		? `https://github.com/OpsiMate/OpsiMate/releases/tag/v${version}`
+		: 'https://github.com/OpsiMate/OpsiMate/releases';
+
+// Numeric semver compare on the "a.b.c" form only; anything else is "unknown"
+// (null) rather than a guess — a dev build is never "behind" a release.
+export const compareVersions = (a: string, b: string): number | null => {
+	if (!isReleaseVersion(a) || !isReleaseVersion(b)) return null;
+	const pa = a.split('.').map(Number);
+	const pb = b.split('.').map(Number);
+	for (let i = 0; i < 3; i++) {
+		if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+	}
+	return 0;
+};

--- a/apps/client/src/test/version.test.ts
+++ b/apps/client/src/test/version.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { compareVersions, formatVersion, isReleaseVersion, releaseNotesUrl } from '@/lib/version';
+
+// The version badge's pure helpers. The invariant that matters: a non-release build
+// is displayed as what it is ("dev"), never dressed up as a release number, and is
+// never reported as "behind" the latest release.
+
+describe('isReleaseVersion', () => {
+	test('accepts strict a.b.c only', () => {
+		expect(isReleaseVersion('0.0.110')).toBe(true);
+		expect(isReleaseVersion('1.2.3')).toBe(true);
+		for (const bad of ['dev', 'v0.0.110', '0.0', '0.0.110-rc1', '', 'latest']) {
+			expect(isReleaseVersion(bad), bad).toBe(false);
+		}
+	});
+});
+
+describe('formatVersion', () => {
+	test('releases get a v prefix; the commit is not appended', () => {
+		expect(formatVersion('0.0.110', 'abcdef1234')).toBe('v0.0.110');
+	});
+	test('dev builds show the short commit when known', () => {
+		expect(formatVersion('dev', 'abcdef1234')).toBe('dev · abcdef1');
+		expect(formatVersion('dev', null)).toBe('dev');
+	});
+});
+
+describe('releaseNotesUrl', () => {
+	test('a release links to its own tag; anything else to the releases list', () => {
+		expect(releaseNotesUrl('0.0.110')).toBe('https://github.com/OpsiMate/OpsiMate/releases/tag/v0.0.110');
+		expect(releaseNotesUrl('dev')).toBe('https://github.com/OpsiMate/OpsiMate/releases');
+	});
+});
+
+describe('compareVersions', () => {
+	test('numeric, not lexical: 0.0.9 < 0.0.10 < 0.1.0', () => {
+		expect(compareVersions('0.0.9', '0.0.10')).toBe(-1);
+		expect(compareVersions('0.0.10', '0.1.0')).toBe(-1);
+		expect(compareVersions('0.1.0', '0.0.999')).toBe(1);
+		expect(compareVersions('0.0.110', '0.0.110')).toBe(0);
+	});
+	test('a dev build is never behind — comparison is unknown, not -1', () => {
+		expect(compareVersions('dev', '0.0.110')).toBeNull();
+		expect(compareVersions('0.0.110', 'dev')).toBeNull();
+	});
+});

--- a/apps/server/src/api/health.ts
+++ b/apps/server/src/api/health.ts
@@ -1,3 +1,4 @@
+import { AppVersionInfo } from '@OpsiMate/shared';
 import { Request, Response, Router } from 'express';
 import { isEmailEnabled } from '../config/config';
 
@@ -5,6 +6,20 @@ const router = Router();
 
 function healthCheck(req: Request, res: Response) {
 	res.send('ok');
+}
+
+// Baked into the image by the release workflow (see Dockerfile.server); absent in
+// local dev, where the answer "dev" is the honest one. Unauthenticated on purpose:
+// it leaks nothing an image tag doesn't, and support threads start with "what
+// version are you on?" before anyone has logged in.
+export const getAppVersionInfo = (env: NodeJS.ProcessEnv = process.env): AppVersionInfo => ({
+	version: env.APP_VERSION?.trim() || 'dev',
+	commit: env.APP_COMMIT?.trim() || null,
+	buildDate: env.APP_BUILD_DATE?.trim() || null,
+});
+
+function versionHandler(_req: Request, res: Response) {
+	return res.status(200).json({ success: true, data: getAppVersionInfo() });
 }
 
 function emailStatusHandler(req: Request, res: Response) {
@@ -18,6 +33,8 @@ function emailStatusHandler(req: Request, res: Response) {
 }
 
 router.get('/health', healthCheck);
+
+router.get('/version', versionHandler);
 
 router.get('/email-status', emailStatusHandler);
 

--- a/apps/server/tests/version.test.ts
+++ b/apps/server/tests/version.test.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { SuperTest, Test } from 'supertest';
+import { getAppVersionInfo } from '../src/api/health';
+import { setupDB, setupExpressApp } from './setup';
+
+describe('GET /version', () => {
+	let app: SuperTest<Test>;
+	beforeAll(async () => {
+		app = await setupExpressApp(await setupDB());
+	});
+
+	test('is unauthenticated and reports "dev" when nothing is baked in', async () => {
+		const res = await app.get('/version');
+		expect(res.status).toBe(200);
+		expect(res.body.success).toBe(true);
+		expect(res.body.data.version).toBe('dev');
+	});
+
+	test('/health keeps its plain "ok" contract (container probes depend on it)', async () => {
+		const res = await app.get('/health');
+		expect(res.status).toBe(200);
+		expect(res.text).toBe('ok');
+	});
+});
+
+describe('getAppVersionInfo', () => {
+	test('reads the baked build identity from the environment', () => {
+		expect(
+			getAppVersionInfo({ APP_VERSION: '0.0.110', APP_COMMIT: 'abc123', APP_BUILD_DATE: '2026-09-06T09:18:52Z' })
+		).toEqual({ version: '0.0.110', commit: 'abc123', buildDate: '2026-09-06T09:18:52Z' });
+	});
+	test('blank values fall back to dev / null, never empty strings', () => {
+		expect(getAppVersionInfo({ APP_VERSION: '  ', APP_COMMIT: '', APP_BUILD_DATE: undefined })).toEqual({
+			version: 'dev',
+			commit: null,
+			buildDate: null,
+		});
+	});
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -433,6 +433,14 @@ export interface AlertComment {
 	updatedAt: string;
 }
 
+// Build identity of the running server, from GET /version. The release workflow bakes
+// these into the image; a local/dev build reports version "dev" with no commit.
+export interface AppVersionInfo {
+	version: string;
+	commit: string | null;
+	buildDate: string | null;
+}
+
 // Who produced a root-cause analysis: an external system pushing through the API
 // ("bring your own"), or the built-in AI agent (phase 2).
 export type RootCauseSource = 'api' | 'ai';


### PR DESCRIPTION
## Issue Reference
"I don't know what version I'm running" — there was no way to tell from the UI.

## What Was Changed

**Why nothing knew its version (the finding):** the three `package.json` files say `1.0.0` / `0.0.0` / `1.0.0` against a latest release of `v0.0.110`, and the `sync-version` workflow has **failed at checkout on every release since v0.0.107** (`ADMIN_PAT` missing/expired — worth fixing or deleting separately). The release workflow already computes the true version from git tags; it just never reached the code.

**Pipeline** — `release.yml` passes `APP_VERSION` / `APP_COMMIT` / `APP_BUILD_DATE` as build-args to both images. `Dockerfile.client` turns them into `VITE_APP_*` in the builder stage (Vite inlines at build time — verified `0.0.110` lands in the bundle); `Dockerfile.server` sets them as runtime `ENV`. Local/unlabelled builds default to **`dev`**, so the UI never claims a release number the build isn't.

**Server** — `GET /version` (unauthenticated, at the root next to `/health`) → `{ version, commit, buildDate }`. `/health` keeps its plain-text `ok` — container probes depend on it — pinned by a test.

**Client** — `VersionBadge` replaces the sidebar footer's stale **"© 2024 OpsiMate"**: `v0.0.110` in monospace, linking to that tag's release notes. Hover: commit · build date · client build if it differs from the server. A green dot appears when GitHub's latest release is newer (one unauthenticated call, cached a day, never for dev builds, silent on failure). Server version is the source of truth; disabled in playground.

## Why Was It Changed
"What version are you on?" is the first question in every support thread, and the answer required a terminal. Now it's in the footer of every page, and the update dot is the nudge that gets installs off broken releases (0.0.108 comes to mind).

Verified live on the dev instance (`/version` → `dev`, badge renders) and via a release-style build with the env set. Server 365/365, client 267/267 (10 new tests), lint at `--max-warnings=0`, prettier clean on all three packages.

**Note:** the first release after this merge is the first that will show a real number — the currently-published images have nothing baked in.

## Screenshots
Footer with the badge (dev build): the `© 2024` line is now the version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible application version information to the sidebar.
  * Version details now include commit and build date information.
  * Added links to release notes and an indicator when a newer release is available.
  * Added an endpoint for retrieving server version and build metadata.

* **Bug Fixes**
  * Version displays now distinguish development builds from released versions.

* **Tests**
  * Added coverage for version formatting, comparisons, release links, and version endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->