### PR TITLE
[FIX]: Add tests for profile utilities

### DIFF
--- a/apps/client/src/test/profile.utils.test.ts
+++ b/apps/client/src/test/profile.utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { formatDate, getInitials } from '@/components/Profile/utils/profile.utils';
+
+describe('getInitials', () => {
+	it.each([
+		['', '?'],
+		['   ', '?'],
+		['Santiago', 'S'],
+		['alice bob', 'AB'],
+		['Alice Bob Carol', 'AB'],
+	])('formats %j as %j', (name, expected) => {
+		expect(getInitials(name)).toBe(expected);
+	});
+});
+
+describe('formatDate', () => {
+	it('formats a date with the expected month, day, and year', () => {
+		const date = new Date(2026, 7, 11, 12, 0, 0);
+
+		expect(formatDate(date.toISOString())).toBe('August 11, 2026');
+	});
+});


### PR DESCRIPTION
## Issue Reference

Closes #922

## What Was Changed

Added `apps/client/src/test/profile.utils.test.ts` with coverage for the profile utility helpers:

- blank and whitespace-only names
- single-word, two-word, and multi-word initials
- uppercase initials from lowercase input
- fixed-date formatting for `formatDate`

## Why Was It Changed

These pure helpers had no direct regression coverage. The tests document their existing behavior and protect profile rendering from silent changes.

## Screenshots

Not applicable; this is a test-only change.

## Additional Context (Optional)

Validation completed:

- Client test: 1 file, 6 tests passed
- Full workspace test: 35 files, 267 tests passed
- Workspace check: 4 tasks successful, 0 errors
- Client typecheck: no new type errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for profile utilities that generate user initials and format dates.
  - Included cases for empty, whitespace-only, single-name, and multi-word inputs.
  - Verified date formatting for ISO date values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->