### PR TITLE
[FIX]: Reject failed typecheck commands without diagnostics

### DIFF
--- a/apps/client/scripts/check-types.mjs
+++ b/apps/client/scripts/check-types.mjs
@@ -20,9 +20,9 @@ const baselineFile = join(clientDir, 'type-errors-baseline.txt');
 // would never match across environments.
 const repoRoot = resolve(clientDir, '..', '..');
 
-// tsc exits 1 (or 2) when it reports diagnostics — expected. Any OTHER failure means
-// tsc never actually ran (binary missing, bad config path), which must fail the gate
-// loudly instead of looking like "no errors".
+// tsc exits 1 (or 2) when it reports diagnostics — expected. Package-manager and
+// shell failures can use the same exit codes, so require actual diagnostics too.
+// Otherwise a failed invocation would look like "no errors", even in --update mode.
 const runTsc = () => {
 	try {
 		execSync('pnpm exec tsc -p tsconfig.app.json --noEmit', {
@@ -33,7 +33,7 @@ const runTsc = () => {
 		return '';
 	} catch (error) {
 		const output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
-		if (error.status !== 1 && error.status !== 2) {
+		if ((error.status !== 1 && error.status !== 2) || normalize(output).length === 0) {
 			console.error(`Could not run tsc — the client typecheck gate did not execute:\n${output}`);
 			process.exit(2);
 		}

--- a/apps/client/scripts/check-types.test.js
+++ b/apps/client/scripts/check-types.test.js
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	execSync: vi.fn(),
+	existsSync: vi.fn(),
+	readFileSync: vi.fn(),
+	writeFileSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+	default: { execSync: mocks.execSync },
+	execSync: mocks.execSync,
+}));
+vi.mock('node:fs', () => ({
+	default: mocks,
+	existsSync: mocks.existsSync,
+	readFileSync: mocks.readFileSync,
+	writeFileSync: mocks.writeFileSync,
+}));
+
+const baseline = 'src/example.ts: error TS2322: Type mismatch.\n';
+const diagnostic = 'src/example.ts(12,3): error TS2322: Type mismatch.\n';
+const originalArgv = process.argv;
+const exit = new Error('process exited');
+
+const runGate = async (update = false) => {
+	process.argv = update ? [...originalArgv, '--update'] : originalArgv;
+	try {
+		await import('./check-types.mjs');
+	} catch (error) {
+		if (error !== exit) throw error;
+	}
+};
+
+const failCommand = (status, output) => {
+	mocks.execSync.mockImplementation(() => {
+		throw Object.assign(new Error('Command failed'), { status, stdout: '', stderr: output });
+	});
+};
+
+beforeEach(() => {
+	vi.resetModules();
+	vi.resetAllMocks();
+	mocks.existsSync.mockReturnValue(true);
+	mocks.readFileSync.mockReturnValue(baseline);
+	vi.spyOn(process, 'exit').mockImplementation(() => {
+		throw exit;
+	});
+	vi.spyOn(console, 'log').mockImplementation(() => {});
+	vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	process.argv = originalArgv;
+	vi.restoreAllMocks();
+});
+
+describe('client typecheck command failures', () => {
+	it.each([1, 2])('rejects exit %s without TypeScript diagnostics', async (status) => {
+		failCommand(status, 'ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "tsc" not found\n');
+		await runGate();
+		expect(process.exit).toHaveBeenCalledWith(2);
+		expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Could not run tsc'));
+		expect(mocks.writeFileSync).not.toHaveBeenCalled();
+	});
+
+	it('rejects a silent nonzero exit', async () => {
+		failCommand(1, '');
+		await runGate();
+		expect(process.exit).toHaveBeenCalledWith(2);
+	});
+
+	it('does not erase the baseline when --update cannot run tsc', async () => {
+		failCommand(1, 'Package manager failed before launching tsc\n');
+		await runGate(true);
+		expect(process.exit).toHaveBeenCalledWith(2);
+		expect(mocks.writeFileSync).not.toHaveBeenCalled();
+	});
+
+	it.each([1, 2])('accepts baselined diagnostics with exit %s', async (status) => {
+		failCommand(status, diagnostic);
+		await runGate();
+		expect(process.exit).not.toHaveBeenCalled();
+		expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No new client type errors'));
+	});
+
+	it('rejects new global TypeScript diagnostics', async () => {
+		failCommand(1, "error TS5058: The specified path does not exist: 'tsconfig.app.json'.\n");
+		await runGate();
+		expect(process.exit).toHaveBeenCalledWith(1);
+	});
+
+	it('accepts a successful compiler run without diagnostics', async () => {
+		mocks.execSync.mockReturnValue('');
+		await runGate();
+		expect(process.exit).not.toHaveBeenCalled();
+	});
+
+	it('allows --update to clear a baseline after a successful compiler run', async () => {
+		mocks.execSync.mockReturnValue('');
+		await runGate(true);
+		expect(mocks.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('type-errors-baseline.txt'), '');
+		expect(process.exit).toHaveBeenCalledWith(0);
+	});
+});


### PR DESCRIPTION
## Issue Reference

Found while validating the client locally; no existing issue found for failed compiler commands passing this gate.

## What Was Changed

Require at least one recognized TypeScript diagnostic before accepting a failed `tsc` command with exit code 1 or 2. Command failures without diagnostics now exit 2 before comparing or rewriting the baseline.

## Why Was It Changed

Package-manager failures can return the same exit codes as TypeScript. For example, `pnpm exec tsc` failing with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` was normalized to an empty diagnostic list and reported as a passing type check. Running `typecheck:update` in that situation could erase the committed baseline. Successful compiler runs with no diagnostics and genuine baselined TypeScript errors keep their existing behavior.

## Screenshots

Not applicable: this changes the command-line type-check gate, with no UI changes.

## Additional Context (Optional)

- Added nine Vitest tests loading the actual gate script with mocked command output, filesystem access, and process exits. Four regression cases failed before the fix and all nine pass afterward.
- Coverage includes command errors with exit 1/2, silent failures, preserving the baseline on a failed update, accepting known diagnostics, rejecting a new global diagnostic, successful runs, and intentionally clearing the baseline after success.
- Full client suite: **303 tests across 36 files pass**. Changed files pass ESLint, Prettier, JavaScript syntax checks, and `git diff --check`.
- The tests simulate compiler outcomes; they do not install or invoke another TypeScript compiler. No application code, dependencies, or baseline entries changed.
- AI assistance: developed and validated with OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type-check validation so command and shell failures are no longer treated as successful runs without diagnostics.
  - Applied the same validation when updating the diagnostic baseline.

- **Tests**
  - Added coverage for successful checks, command failures, missing output, existing diagnostics, newly detected diagnostics, and baseline updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->