### PR TITLE
[FIX]: Add TagKey column helper tests

### DIFF
--- a/apps/client/src/test/TagKey.test.ts
+++ b/apps/client/src/test/TagKey.test.ts
@@ -3,7 +3,10 @@ import { extractTagKeyFromColumnId, getTagKeyColumnId, isTagKeyColumn } from '@/
 
 describe('TagKey column ID helpers', () => {
 	it.each(['environment', 'team', 'service:name'])('round trips the tag key %j', (tagKey) => {
-		expect(extractTagKeyFromColumnId(getTagKeyColumnId(tagKey))).toBe(tagKey);
+		const columnId = getTagKeyColumnId(tagKey);
+		expect(columnId).toBe(`tagKey:${tagKey}`);
+		expect(extractTagKeyFromColumnId(columnId)).toBe(tagKey);
+		expect(isTagKeyColumn(columnId)).toBe(true);
 	});
 
 	it.each(['alertName', 'severity'])('does not treat %j as a tag column', (columnId) => {

--- a/apps/client/src/test/TagKey.test.ts
+++ b/apps/client/src/test/TagKey.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { extractTagKeyFromColumnId, getTagKeyColumnId, isTagKeyColumn } from '@/types/TagKey';
+
+describe('TagKey column ID helpers', () => {
+	it.each(['environment', 'team', 'service:name'])('round trips the tag key %j', (tagKey) => {
+		expect(extractTagKeyFromColumnId(getTagKeyColumnId(tagKey))).toBe(tagKey);
+	});
+
+	it.each(['alertName', 'severity'])('does not treat %j as a tag column', (columnId) => {
+		expect(isTagKeyColumn(columnId)).toBe(false);
+	});
+
+	it('returns null for a non-tag column ID', () => {
+		expect(extractTagKeyFromColumnId('alertName')).toBeNull();
+	});
+
+	it('round trips an empty tag key', () => {
+		expect(extractTagKeyFromColumnId(getTagKeyColumnId(''))).toBe('');
+	});
+});


### PR DESCRIPTION
## Issue Reference

Closes #921

---

## What Was Changed

Added direct Vitest coverage for the TagKey column ID helpers, including ordinary IDs, colon-containing keys, and the empty-key boundary.

---

## Why Was It Changed

These helpers identify tag columns throughout the alerts table. The tests protect their round-trip behavior and the `null` result used for unrelated column IDs.

---

## Screenshots

<img width="1400" height="760" alt="TagKey helper test results" src="https://github.com/user-attachments/assets/c10e1275-3b3a-4f16-9e59-0840a2caf969" />

---

## Additional Context (Optional)

- Client test suite: 36 files passed, 301 tests passed.
- Focused TagKey suite: 7 tests passed.
- Prettier and ESLint passed on the new test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for tag key column ID conversion and extraction.
  - Verified support for standard, namespaced, and empty tag keys.
  - Added checks that non-tag column IDs are correctly rejected and return no tag key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->