### PR TITLE
[FIX]: Standardize client on shared Role enum

### DIFF
--- a/apps/client/src/components/AddUserModal.tsx
+++ b/apps/client/src/components/AddUserModal.tsx
@@ -5,7 +5,8 @@ import { Label } from './ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog';
 import { apiRequest } from '../lib/api';
-import { User, Role } from '../types';
+import { Role } from '@OpsiMate/shared';
+import { User } from '../types';
 import { ErrorAlert } from './ErrorAlert';
 import { useFormErrors } from '../hooks/useFormErrors';
 

--- a/apps/client/src/lib/permissions.ts
+++ b/apps/client/src/lib/permissions.ts
@@ -1,13 +1,6 @@
+import { Role } from '@OpsiMate/shared';
 import { getUserRole } from './auth';
 import { isPlaygroundMode } from './playground';
-
-// Local role definitions for client-side use
-enum Role {
-	Admin = 'admin',
-	Editor = 'editor',
-	Viewer = 'viewer',
-	Operation = 'operation',
-}
 
 export type Permission = 'create' | 'edit' | 'delete' | 'view' | 'operate';
 

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -1,10 +1,6 @@
-// Client-side type definitions
-export enum Role {
-	Admin = 'admin',
-	Editor = 'editor',
-	Viewer = 'viewer',
-	Operation = 'operation',
-}
+import { Role } from '@OpsiMate/shared';
+
+export { Role } from '@OpsiMate/shared';
 
 export interface User {
 	id: number;

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -1,4 +1,6 @@
-export { Role } from '@OpsiMate/shared';
+import { Role } from '@OpsiMate/shared';
+
+export { Role };
 
 export interface User {
 	id: number;

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -1,5 +1,3 @@
-import { Role } from '@OpsiMate/shared';
-
 export { Role } from '@OpsiMate/shared';
 
 export interface User {


### PR DESCRIPTION
## Issue Reference

Closes #917

---

## What Was Changed

- Removed the duplicated `Role` enum from `apps/client/src/types/index.ts`.
- Re-exported the canonical `Role` enum from `@OpsiMate/shared` to preserve existing client imports.
- Removed the local `Role` enum from `apps/client/src/lib/permissions.ts`.
- Updated `permissions.ts` to use the shared `Role` enum.
- Updated `AddUserModal.tsx` to import `Role` directly from `@OpsiMate/shared`.

---

## Why Was It Changed

The `Role` enum was defined in multiple locations with the same values.

Keeping separate enum declarations creates a risk of the definitions diverging over time and can also cause TypeScript incompatibilities between values originating from different enum declarations.

This change makes `packages/shared/src/types.ts` the single source of truth for `Role` while keeping the existing client barrel export compatible.

---

## Screenshots

Not applicable. This change does not modify the UI.

---

## Additional Context

This is intentionally a small refactor.

No role values, permission rules, API behavior, or user-facing functionality were changed.

The branch only updates the client-side references needed to use the shared `Role` enum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized role definitions across the client to improve consistency in user and permission handling.
  - Updated role assignments and permission checks to use the same shared definitions.
  - Removed the separate client-side role definition while preserving existing roles and permission behavior.
  - No changes to the available user experience or role-based capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->