### PR TITLE
[FIX]: Cover role permissions and playground restrictions

### DIFF
--- a/apps/client/src/test/permissions.test.ts
+++ b/apps/client/src/test/permissions.test.ts
@@ -1,0 +1,85 @@
+import { Role } from '@OpsiMate/shared';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getUserRole } from '@/lib/auth';
+import { isPlaygroundMode } from '@/lib/playground';
+import {
+	canCreate,
+	canDelete,
+	canEdit,
+	canManageIntegrations,
+	canManageServices,
+	canManageTags,
+	canManageUsers,
+	canOperate,
+	canView,
+	hasPermission,
+	isReadOnlyMode,
+	type Permission,
+} from '@/lib/permissions';
+
+vi.mock('@/lib/auth', () => ({ getUserRole: vi.fn() }));
+vi.mock('@/lib/playground', () => ({ isPlaygroundMode: vi.fn() }));
+
+const checks: Record<Permission, () => boolean> = {
+	create: canCreate,
+	edit: canEdit,
+	delete: canDelete,
+	view: canView,
+	operate: canOperate,
+};
+const permissions = Object.keys(checks) as Permission[];
+const roles: { role: Role | null; allowed: Permission[]; users: boolean; services: boolean }[] = [
+	{ role: Role.Admin, allowed: ['create', 'edit', 'delete', 'view', 'operate'], users: true, services: true },
+	{ role: Role.Editor, allowed: ['create', 'edit', 'view', 'operate'], users: false, services: true },
+	{ role: Role.Viewer, allowed: ['view'], users: false, services: false },
+	{ role: Role.Operation, allowed: ['view', 'operate'], users: false, services: false },
+	{ role: null, allowed: [], users: false, services: false },
+];
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+describe.each(roles)('permissions for $role', ({ role, allowed, users, services }) => {
+	beforeEach(() => {
+		vi.mocked(getUserRole).mockReturnValue(role);
+		vi.mocked(isPlaygroundMode).mockReturnValue(false);
+	});
+
+	test.each(permissions)('%s permission and its convenience helper', (permission) => {
+		const expected = allowed.includes(permission);
+		expect(hasPermission(permission)).toBe(expected);
+		expect(checks[permission]()).toBe(expected);
+	});
+
+	test('feature management permissions', () => {
+		expect(canManageUsers()).toBe(users);
+		expect(canManageIntegrations()).toBe(users);
+		expect(canManageServices()).toBe(services);
+		expect(canManageTags()).toBe(services);
+	});
+
+	describe('in read-only playground mode', () => {
+		beforeEach(() => {
+			vi.mocked(isPlaygroundMode).mockReturnValue(true);
+		});
+
+		test.each(permissions)('%s permission and its convenience helper', (permission) => {
+			const expected = permission === 'view' && allowed.includes('view');
+			expect(hasPermission(permission)).toBe(expected);
+			expect(checks[permission]()).toBe(expected);
+		});
+
+		test('blocks every feature management action, including for admins', () => {
+			expect(canManageUsers()).toBe(false);
+			expect(canManageIntegrations()).toBe(false);
+			expect(canManageServices()).toBe(false);
+			expect(canManageTags()).toBe(false);
+		});
+	});
+});
+
+test.each([false, true])('read-only mode follows playground mode (%s)', (playground) => {
+	vi.mocked(isPlaygroundMode).mockReturnValue(playground);
+	expect(isReadOnlyMode()).toBe(playground);
+});


### PR DESCRIPTION
Add a table-driven permission suite covering all four shared roles plus a missing role, every permission and convenience helper, feature-management checks, and the read-only playground override.

Addresses #927. The issue describes playground mode as granting admin permissions, but current `getCurrentUser()` only grants the admin identity: `hasPermission()` explicitly rejects non-view actions when `isReadOnlyMode()` is true, and both user/integration management helpers do the same. These tests preserve that deliberate write restriction. No permission policy changes are included.

Normal-mode expectations:

| Role | Create | Edit | Delete | View | Operate | Manage users/integrations | Manage services/tags |
|---|---|---|---|---|---|---|---|
| Admin | yes | yes | yes | yes | yes | yes | yes |
| Editor | yes | yes | no | yes | yes | no | yes |
| Viewer | no | no | no | yes | no | no | no |
| Operation | no | no | no | yes | yes | no | no |
| Missing | no | no | no | no | no | no | no |

Playground mode blocks all write/management actions for every mocked role, including admin. The test imports `Role` from `@OpsiMate/shared`, so it is compatible with the enum consolidation in #933.

Validation:
- 62 focused tests passed, mocking `getUserRole` and `isPlaygroundMode` as requested.
- Mutation check: temporarily granting viewers every permission caused five tests to fail. Restored production source afterward; the PR contains only the new test file.

AI assistance: OpenAI Codex helped implement and validate this suite.

Additional validation: full client suite passed (378 tests in 39 files); changed-file ESLint passed with `--max-warnings=0`; Prettier and `git diff --check` passed. Ran installed Vitest/ESLint binaries directly: the default pnpm 11 command attempted installation and stopped at ignored-build policy checks, so no dependency builds were approved. Its generated workspace-file edit was reverted; no dependency/config changes remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for permission checks across supported roles and actions.
  * Added tests for feature-management permissions, including users, integrations, services, and tags.
  * Verified read-only mode allows viewing while blocking management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->