### PR TITLE
[FIX]: Consolidate tag contrast helper and replace deprecated substr

### DIFF
--- a/apps/client/src/components/Dashboards/Dashboards.utils.ts
+++ b/apps/client/src/components/Dashboards/Dashboards.utils.ts
@@ -71,11 +71,4 @@ export const formatDate = (dateString?: string): string => {
 	}
 };
 
-export const getContrastColor = (hexColor: string): string => {
-	const hex = hexColor.replace('#', '');
-	const r = parseInt(hex.substr(0, 2), 16);
-	const g = parseInt(hex.substr(2, 2), 16);
-	const b = parseInt(hex.substr(4, 2), 16);
-	const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-	return luminance > 0.5 ? '#000000' : '#ffffff';
-};
+export { getContrastColor } from '@/lib/colors';

--- a/apps/client/src/components/ui/tag-badge.tsx
+++ b/apps/client/src/components/ui/tag-badge.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { getContrastColor } from '@/lib/colors';
 import { Tag } from '@OpsiMate/shared';
 
 interface TagBadgeProps {
@@ -34,20 +35,3 @@ export const TagBadge = ({ tag, onRemove, className }: TagBadgeProps) => {
 		</Badge>
 	);
 };
-
-// Helper function to determine text color based on background color
-function getContrastColor(hexColor: string): string {
-	// Remove the # if present
-	const hex = hexColor.replace('#', '');
-
-	// Convert to RGB
-	const r = parseInt(hex.substr(0, 2), 16);
-	const g = parseInt(hex.substr(2, 2), 16);
-	const b = parseInt(hex.substr(4, 2), 16);
-
-	// Calculate luminance
-	const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-
-	// Return black or white based on luminance
-	return luminance > 0.5 ? '#000000' : '#ffffff';
-}

--- a/apps/client/src/lib/colors.ts
+++ b/apps/client/src/lib/colors.ts
@@ -1,0 +1,9 @@
+/** Choose black or white text using the existing tag brightness threshold. */
+export const getContrastColor = (hexColor: string): string => {
+	const hex = hexColor.replace('#', '');
+	const r = parseInt(hex.slice(0, 2), 16);
+	const g = parseInt(hex.slice(2, 4), 16);
+	const b = parseInt(hex.slice(4, 6), 16);
+	const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+	return luminance > 0.5 ? '#000000' : '#ffffff';
+};

--- a/apps/client/src/test/colors.test.ts
+++ b/apps/client/src/test/colors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { getContrastColor } from '@/lib/colors';
+import { getContrastColor as dashboardContrastColor } from '@/components/Dashboards/Dashboards.utils';
+
+describe('tag contrast colour', () => {
+	test.each([
+		['#ffffff', '#000000'],
+		['#000000', '#ffffff'],
+		['#ff0000', '#ffffff'],
+		['#00ff00', '#000000'],
+		['#0000ff', '#ffffff'],
+		['#7f7f7f', '#ffffff'],
+		['#808080', '#000000'],
+		['FFFFFF', '#000000'],
+		['000000', '#ffffff'],
+	])('uses %s background with %s text', (background, text) => {
+		expect(getContrastColor(background)).toBe(text);
+	});
+	test('keeps the dashboard export pointing to the shared implementation', () => {
+		expect(dashboardContrastColor).toBe(getContrastColor);
+	});
+});


### PR DESCRIPTION
TagBadge and the dashboard utilities contained the same colour-contrast helper, including the client's remaining deprecated `substr` calls. Move the calculation into `lib/colors.ts`, import it in TagBadge, and re-export it from the existing dashboard utility path to preserve that API. Use `slice` for the RGB pairs; the brightness formula and colour choices stay unchanged.

Fixes #912.

Validation: 10 focused tests cover white/black, each primary colour, greys immediately around the brightness threshold, hashless hex values and the existing dashboard export. All 422 client tests across 42 files pass. Compared the old and new helper over 4,096 RGB samples: identical results. Changed-file ESLint passes with zero warnings; Prettier and diff checks pass. No `substr` calls remain in client source.

Developed and validated with OpenAI Codex assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text color selection for dashboard and tag badge backgrounds, enhancing readability across a wider range of colors.

* **Tests**
  * Added coverage for contrast color handling across common and hexadecimal color values, including colors without a leading `#`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->