### PR TITLE
[FIX]: Pluralize user deletion and cleanup messages

### DIFF
--- a/apps/client/src/components/Settings/RetentionSettings.tsx
+++ b/apps/client/src/components/Settings/RetentionSettings.tsx
@@ -187,7 +187,7 @@ export const RetentionSettings = () => {
 					title: 'Cleanup complete',
 					description:
 						total > 0
-							? `Deleted ${total} row(s).${result.vacuumed ? ' Disk space reclaimed.' : ''}`
+							? `Deleted ${total} row${total !== 1 ? 's' : ''}.${result.vacuumed ? ' Disk space reclaimed.' : ''}`
 							: 'Nothing to delete.',
 				});
 			},

--- a/apps/client/src/pages/Settings.tsx
+++ b/apps/client/src/pages/Settings.tsx
@@ -661,14 +661,14 @@ const Settings: React.FC = () => {
 					<AlertDialogHeader>
 						<AlertDialogTitle>Delete Multiple Users</AlertDialogTitle>
 						<AlertDialogDescription>
-							Are you sure you want to delete {selectedUsers.length} user(s)? This action cannot be
-							undone.
+							Are you sure you want to delete {selectedUsers.length} user
+							{selectedUsers.length !== 1 ? 's' : ''}? This action cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
 						<AlertDialogCancel>Cancel</AlertDialogCancel>
 						<AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleBulkDelete}>
-							Delete {selectedUsers.length} User(s)
+							Delete {selectedUsers.length} user{selectedUsers.length !== 1 ? 's' : ''}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>


### PR DESCRIPTION
The user-deletion dialog and retention cleanup toast currently show `user(s)` / `row(s)`. Use singular for one and plural otherwise, and use lowercase `user` consistently in the dialog description and confirmation button. The existing zero-row message and disk-space-reclaimed suffix are preserved.

Fixes #910.

Validation: rendered the actual changed JSX fragments for 0, 1 and 2 selected users, and evaluated the actual retention message for 0, 1 and 2 rows with/without vacuum (12 checks). Prettier and diff checks pass. Changed-file ESLint has no errors; its 19 warnings are identical to unchanged upstream, verified by comparing rule/severity/message results. No new test files for this copy-only change; full client suite and browser interaction were not rerun.

Developed and validated with OpenAI Codex assistance.
