### PR TITLE
[FIX]: Share clipboard handling while preserving dialog and table feedback

### DIFF
--- a/apps/client/src/components/Alerts/AlertsTable/AlertRow/CopyCellButton.tsx
+++ b/apps/client/src/components/Alerts/AlertsTable/AlertRow/CopyCellButton.tsx
@@ -1,30 +1,6 @@
 import { Check, Copy } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { cn } from '@/lib/utils';
-
-// The Clipboard API needs a secure context, and self-hosted OpsiMate commonly runs on
-// plain http — fall back to the legacy execCommand path there.
-const copyText = async (text: string): Promise<boolean> => {
-	if (navigator.clipboard?.writeText) {
-		try {
-			await navigator.clipboard.writeText(text);
-			return true;
-		} catch {
-			// Permission denied or transient failure — try the fallback below.
-		}
-	}
-	const textarea = document.createElement('textarea');
-	textarea.value = text;
-	textarea.style.position = 'fixed';
-	textarea.style.opacity = '0';
-	document.body.appendChild(textarea);
-	textarea.select();
-	try {
-		return document.execCommand('copy');
-	} finally {
-		textarea.remove();
-	}
-};
 
 export interface CopyCellButtonProps {
 	// The FULL underlying value — not the (possibly truncated/reformatted) display text.
@@ -36,16 +12,11 @@ export interface CopyCellButtonProps {
 // `relative group/cell` for the reveal and positioning to work. Click/mousedown stop
 // propagation so copying never opens the details panel or starts a drag selection.
 export const CopyCellButton = ({ value, className }: CopyCellButtonProps) => {
-	const [copied, setCopied] = useState(false);
-	const resetTimer = useRef<number>();
-	useEffect(() => () => window.clearTimeout(resetTimer.current), []);
+	const { copied, copy } = useCopyToClipboard({ resetMs: 1500, restartTimer: true, legacyFallback: true });
 
 	const handleCopy = async (e: React.MouseEvent) => {
 		e.stopPropagation();
-		if (!(await copyText(value))) return;
-		setCopied(true);
-		window.clearTimeout(resetTimer.current);
-		resetTimer.current = window.setTimeout(() => setCopied(false), 1500);
+		await copy(value);
 	};
 
 	return (

--- a/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
+++ b/apps/client/src/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useToast } from '@/components/ui/use-toast';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { API_HOST } from '@/lib/api';
 import { Check, CheckCircle2, Copy, ExternalLink, Send, Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -18,7 +18,7 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
 	const [copiedPayload, setCopiedPayload] = useState(false);
 	const [copiedResolve, setCopiedResolve] = useState(false);
 	const [copiedDelete, setCopiedDelete] = useState(false);
-	const { toast } = useToast();
+	const { copy } = useCopyToClipboard();
 
 	const webhookUrl = `${API_HOST}/api/v1/alerts/custom?api_token={your_api_token}`;
 	const resolveUrl = `${API_HOST}/api/v1/alerts/{alertId}?api_token={your_api_token}`;
@@ -39,35 +39,19 @@ export const CustomAlertsSetupModal = ({ open, onOpenChange }: CustomAlertsSetup
   ]
 }`;
 
-	const handleCopy = async (text: string, type: 'url' | 'payload' | 'resolve' | 'delete') => {
-		try {
-			await navigator.clipboard.writeText(text);
-			if (type === 'url') {
-				setCopiedUrl(true);
-				setTimeout(() => setCopiedUrl(false), 2000);
-			} else if (type === 'payload') {
-				setCopiedPayload(true);
-				setTimeout(() => setCopiedPayload(false), 2000);
-			} else if (type === 'resolve') {
-				setCopiedResolve(true);
-				setTimeout(() => setCopiedResolve(false), 2000);
-			} else {
-				setCopiedDelete(true);
-				setTimeout(() => setCopiedDelete(false), 2000);
-			}
-			toast({
-				title: 'Copied!',
-				description: type === 'payload' ? 'Example payload copied to clipboard' : 'URL copied to clipboard',
-				duration: 2000,
-			});
-		} catch (error) {
-			toast({
-				title: 'Failed to copy',
-				description: 'Please copy manually',
-				variant: 'destructive',
-				duration: 3000,
-			});
-		}
+	const handleCopy = (text: string, type: 'url' | 'payload' | 'resolve' | 'delete') => {
+		const setCopiedState = {
+			url: setCopiedUrl,
+			payload: setCopiedPayload,
+			resolve: setCopiedResolve,
+			delete: setCopiedDelete,
+		}[type];
+		return copy(text, {
+			successDescription: type === 'payload' ? 'Example payload copied to clipboard' : 'URL copied to clipboard',
+			failureDescription: 'Please copy manually',
+			onCopied: () => setCopiedState(true),
+			onReset: () => setCopiedState(false),
+		});
 	};
 
 	return (

--- a/apps/client/src/components/Integrations/DatadogSetupModal/DatadogSetupModal.tsx
+++ b/apps/client/src/components/Integrations/DatadogSetupModal/DatadogSetupModal.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { useToast } from '@/components/ui/use-toast';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { API_BASE_URL } from '@/lib/api';
 import { Check, Copy, ExternalLink, Info } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -18,7 +18,7 @@ const DATADOG_WEBHOOK_DOCS_URL = 'https://docs.datadoghq.com/integrations/webhoo
 export const DatadogSetupModal = ({ open, onOpenChange }: DatadogSetupModalProps) => {
 	const [copiedWebhook, setCopiedWebhook] = useState(false);
 	const [copiedPayload, setCopiedPayload] = useState(false);
-	const { toast } = useToast();
+	const { copy } = useCopyToClipboard();
 
 	const webhookUrl = useMemo(() => {
 		// Prefer the shared API_BASE_URL, which already encodes the correct host + base path.
@@ -47,33 +47,17 @@ export const DatadogSetupModal = ({ open, onOpenChange }: DatadogSetupModalProps
   }
 }`;
 
-	const handleCopy = async (value: string, type: 'webhook' | 'payload') => {
-		try {
-			await navigator.clipboard.writeText(value);
-			if (type === 'webhook') {
-				setCopiedWebhook(true);
-			} else {
-				setCopiedPayload(true);
-			}
-			toast({
-				title: 'Copied!',
-				description:
-					type === 'webhook' ? 'Webhook URL copied to clipboard' : 'Payload template copied to clipboard',
-				duration: 2000,
-			});
-			setTimeout(() => {
+	const handleCopy = (value: string, type: 'webhook' | 'payload') =>
+		copy(value, {
+			successDescription:
+				type === 'webhook' ? 'Webhook URL copied to clipboard' : 'Payload template copied to clipboard',
+			failureDescription: 'Please copy the value manually',
+			onCopied: () => (type === 'webhook' ? setCopiedWebhook(true) : setCopiedPayload(true)),
+			onReset: () => {
 				setCopiedWebhook(false);
 				setCopiedPayload(false);
-			}, 2000);
-		} catch (error) {
-			toast({
-				title: 'Failed to copy',
-				description: 'Please copy the value manually',
-				variant: 'destructive',
-				duration: 3000,
-			});
-		}
-	};
+			},
+		});
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/client/src/components/Integrations/GCPSetupModal/GCPSetupModal.tsx
+++ b/apps/client/src/components/Integrations/GCPSetupModal/GCPSetupModal.tsx
@@ -1,10 +1,9 @@
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { useToast } from '@/components/ui/use-toast';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { API_HOST } from '@/lib/api';
 import { Check, Copy, ExternalLink } from 'lucide-react';
-import { useState } from 'react';
 import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface GCPSetupModalProps {
@@ -13,32 +12,17 @@ export interface GCPSetupModalProps {
 }
 
 export const GCPSetupModal = ({ open, onOpenChange }: GCPSetupModalProps) => {
-	const [copied, setCopied] = useState(false);
-	const { toast } = useToast();
+	const { copied: copied, copy } = useCopyToClipboard();
 
 	// Correct webhook URL with API token parameter
 	// User needs to replace {your_api_token} with their actual API_TOKEN environment variable value
 	const webhookUrl = `${API_HOST}/api/v1/alerts/custom/gcp?api_token={your_api_token}`;
 
-	const handleCopyWebhook = async () => {
-		try {
-			await navigator.clipboard.writeText(webhookUrl);
-			setCopied(true);
-			toast({
-				title: 'Copied!',
-				description: 'Webhook URL copied to clipboard',
-				duration: 2000,
-			});
-			setTimeout(() => setCopied(false), 2000);
-		} catch (error) {
-			toast({
-				title: 'Failed to copy',
-				description: 'Please copy the URL manually',
-				variant: 'destructive',
-				duration: 3000,
-			});
-		}
-	};
+	const handleCopyWebhook = () =>
+		copy(webhookUrl, {
+			successDescription: 'Webhook URL copied to clipboard',
+			failureDescription: 'Please copy the URL manually',
+		});
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
+++ b/apps/client/src/components/Integrations/GrafanaSetupModal/GrafanaSetupModal.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { useToast } from '@/components/ui/use-toast';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { API_BASE_URL } from '@/lib/api';
 import { Check, Copy, ExternalLink, Info } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface GrafanaSetupModalProps {
@@ -16,8 +16,7 @@ const GRAFANA_CONTACT_POINTS_DOCS_URL =
 	'https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/';
 
 export const GrafanaSetupModal = ({ open, onOpenChange }: GrafanaSetupModalProps) => {
-	const [copiedWebhook, setCopiedWebhook] = useState(false);
-	const { toast } = useToast();
+	const { copied: copiedWebhook, copy } = useCopyToClipboard();
 
 	const webhookUrl = useMemo(() => {
 		// Prefer the shared API_BASE_URL, which already encodes the correct host + base path.
@@ -26,21 +25,11 @@ export const GrafanaSetupModal = ({ open, onOpenChange }: GrafanaSetupModalProps
 		return `${trimmedBase || ''}/alerts/custom/grafana?api_token={your_api_token}`;
 	}, []);
 
-	const handleCopy = async (value: string) => {
-		try {
-			await navigator.clipboard.writeText(value);
-			setCopiedWebhook(true);
-			toast({ title: 'Copied!', description: 'Webhook URL copied to clipboard', duration: 2000 });
-			setTimeout(() => setCopiedWebhook(false), 2000);
-		} catch (error) {
-			toast({
-				title: 'Failed to copy',
-				description: 'Please copy the value manually',
-				variant: 'destructive',
-				duration: 3000,
-			});
-		}
-	};
+	const handleCopy = (value: string) =>
+		copy(value, {
+			successDescription: 'Webhook URL copied to clipboard',
+			failureDescription: 'Please copy the value manually',
+		});
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/client/src/components/Integrations/UptimeKumaSetupModal/UptimeKumaSetupModal.tsx
+++ b/apps/client/src/components/Integrations/UptimeKumaSetupModal/UptimeKumaSetupModal.tsx
@@ -1,10 +1,9 @@
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { useToast } from '@/components/ui/use-toast';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { API_HOST } from '@/lib/api';
 import { Check, Copy, ExternalLink } from 'lucide-react';
-import { useState } from 'react';
 import { SeveritySetupNote } from '../SeveritySetupNote';
 
 export interface UptimeKumaSetupModalProps {
@@ -13,32 +12,17 @@ export interface UptimeKumaSetupModalProps {
 }
 
 export const UptimeKumaSetupModal = ({ open, onOpenChange }: UptimeKumaSetupModalProps) => {
-	const [copied, setCopied] = useState(false);
-	const { toast } = useToast();
+	const { copied: copied, copy } = useCopyToClipboard();
 
 	// Correct webhook URL with API token parameter
 	// User needs to replace {your_api_token} with their actual API_TOKEN environment variable value
 	const webhookUrl = `${API_HOST}/api/v1/alerts/custom/UptimeKuma?api_token={your_api_token}`;
 
-	const handleCopyWebhook = async () => {
-		try {
-			await navigator.clipboard.writeText(webhookUrl);
-			setCopied(true);
-			toast({
-				title: 'Copied!',
-				description: 'Webhook URL copied to clipboard',
-				duration: 2000,
-			});
-			setTimeout(() => setCopied(false), 2000);
-		} catch (error) {
-			toast({
-				title: 'Failed to copy',
-				description: 'Please copy the URL manually',
-				variant: 'destructive',
-				duration: 3000,
-			});
-		}
-	};
+	const handleCopyWebhook = () =>
+		copy(webhookUrl, {
+			successDescription: 'Webhook URL copied to clipboard',
+			failureDescription: 'Please copy the URL manually',
+		});
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
+++ b/apps/client/src/components/Integrations/ZabbixSetupModal/ZabbixSetupModal.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useToast } from '@/components/ui/use-toast';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { API_HOST } from '@/lib/api';
 import { Check, Copy, ExternalLink } from 'lucide-react';
 import { useState } from 'react';
@@ -17,7 +17,7 @@ export const ZabbixSetupModal = ({ open, onOpenChange }: ZabbixSetupModalProps) 
 	const [copied, setCopied] = useState(false);
 	const [copiedScript, setCopiedScript] = useState(false);
 	const [copiedCurl, setCopiedCurl] = useState(false);
-	const { toast } = useToast();
+	const { copy } = useCopyToClipboard();
 
 	const webhookUrl = `${API_HOST}/api/v1/alerts/custom/zabbix?api_token={your_api_token}`;
 
@@ -148,25 +148,13 @@ fi`;
     throw 'OpsiMate webhook error: ' + error;
 }`;
 
-	const handleCopy = async (text: string, setCopiedState: (v: boolean) => void, description: string) => {
-		try {
-			await navigator.clipboard.writeText(text);
-			setCopiedState(true);
-			toast({
-				title: 'Copied!',
-				description,
-				duration: 2000,
-			});
-			setTimeout(() => setCopiedState(false), 2000);
-		} catch {
-			toast({
-				title: 'Failed to copy',
-				description: 'Please copy manually',
-				variant: 'destructive',
-				duration: 3000,
-			});
-		}
-	};
+	const handleCopy = (text: string, setCopiedState: (v: boolean) => void, description: string) =>
+		copy(text, {
+			successDescription: description,
+			failureDescription: 'Please copy manually',
+			onCopied: () => setCopiedState(true),
+			onReset: () => setCopiedState(false),
+		});
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/client/src/hooks/useCopyToClipboard.ts
+++ b/apps/client/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { useToast } from '@/components/ui/use-toast';
+
+export const COPIED_RESET_MS = 2000;
+
+interface CopyOptions {
+	successDescription?: string;
+	failureDescription?: string;
+	// Multi-button dialogs keep their existing per-button or grouped indicators.
+	onCopied?: () => void;
+	onReset?: () => void;
+}
+
+interface ClipboardOptions {
+	resetMs?: number;
+	// Table feedback restarts; dialogs retain their existing scheduled resets.
+	restartTimer?: boolean;
+	legacyFallback?: boolean;
+}
+
+// The Clipboard API needs a secure context, and self-hosted OpsiMate commonly runs on
+// plain http — fall back to the legacy execCommand path there.
+const copyText = async (text: string, legacyFallback: boolean): Promise<boolean> => {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {
+			if (!legacyFallback) return false;
+		}
+	}
+	if (!legacyFallback) return false;
+	const textarea = document.createElement('textarea');
+	textarea.value = text;
+	textarea.style.position = 'fixed';
+	textarea.style.opacity = '0';
+	document.body.appendChild(textarea);
+	textarea.select();
+	try {
+		return document.execCommand('copy');
+	} finally {
+		textarea.remove();
+	}
+};
+
+export const useCopyToClipboard = ({
+	resetMs = COPIED_RESET_MS,
+	restartTimer = false,
+	legacyFallback = false,
+}: ClipboardOptions = {}) => {
+	const [copied, setCopied] = useState(false);
+	const timers = useRef(new Set<number>());
+	const mounted = useRef(true);
+	const { toast } = useToast();
+	useEffect(() => {
+		mounted.current = true;
+		const pending = timers.current;
+		return () => {
+			mounted.current = false;
+			pending.forEach((timer) => window.clearTimeout(timer));
+			pending.clear();
+		};
+	}, []);
+	const copy = async (text: string, options: CopyOptions = {}): Promise<boolean> => {
+		const success = await copyText(text, legacyFallback).catch(() => false);
+		if (!mounted.current) return false;
+		if (!success) {
+			if (options.failureDescription)
+				toast({
+					title: 'Failed to copy',
+					description: options.failureDescription,
+					variant: 'destructive',
+					duration: 3000,
+				});
+			return false;
+		}
+		setCopied(true);
+		options.onCopied?.();
+		if (options.successDescription)
+			toast({ title: 'Copied!', description: options.successDescription, duration: COPIED_RESET_MS });
+		if (restartTimer) {
+			timers.current.forEach((timer) => window.clearTimeout(timer));
+			timers.current.clear();
+		}
+		const timer = window.setTimeout(() => {
+			timers.current.delete(timer);
+			setCopied(false);
+			options.onReset?.();
+		}, resetMs);
+		timers.current.add(timer);
+		return true;
+	};
+	return { copied, copy };
+};

--- a/apps/client/src/test/CopyCellButton.test.tsx
+++ b/apps/client/src/test/CopyCellButton.test.tsx
@@ -1,0 +1,98 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { CopyCellButton } from '@/components/Alerts/AlertsTable/AlertRow/CopyCellButton';
+
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+const execDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand');
+const writeText = vi.fn();
+const execCommand = vi.fn();
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	writeText.mockReset().mockResolvedValue(undefined);
+	execCommand.mockReset().mockReturnValue(true);
+	Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+	Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand });
+});
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	if (clipboardDescriptor) Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
+	else Reflect.deleteProperty(navigator, 'clipboard');
+	if (execDescriptor) Object.defineProperty(document, 'execCommand', execDescriptor);
+	else Reflect.deleteProperty(document, 'execCommand');
+});
+
+async function copy() {
+	await act(async () => {
+		fireEvent.click(screen.getByRole('button', { name: 'Copy value' }));
+	});
+}
+
+describe('table clipboard feedback', () => {
+	test('copies the complete value without opening the parent and resets after 1500 ms', async () => {
+		const onClick = vi.fn();
+		const onMouseDown = vi.fn();
+		render(
+			<div onClick={onClick} onMouseDown={onMouseDown}>
+				<CopyCellButton value="full, untruncated value" />
+			</div>
+		);
+		fireEvent.mouseDown(screen.getByRole('button'));
+		await copy();
+		expect(writeText).toHaveBeenCalledWith('full, untruncated value');
+		expect(onClick).not.toHaveBeenCalled();
+		expect(onMouseDown).not.toHaveBeenCalled();
+		expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+		act(() => vi.advanceTimersByTime(1499));
+		expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+		act(() => vi.advanceTimersByTime(1));
+		expect(screen.getByRole('button', { name: 'Copy value' })).toBeInTheDocument();
+	});
+	test('restarts the feedback duration after a second copy', async () => {
+		render(<CopyCellButton value="value" />);
+		await copy();
+		act(() => vi.advanceTimersByTime(1000));
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Copied' }));
+		});
+		act(() => vi.advanceTimersByTime(500));
+		expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+		act(() => vi.advanceTimersByTime(1000));
+		expect(screen.getByRole('button', { name: 'Copy value' })).toBeInTheDocument();
+	});
+	test('clears its pending feedback timer on unmount', async () => {
+		const { unmount } = render(<CopyCellButton value="value" />);
+		const initial = vi.getTimerCount();
+		await copy();
+		expect(vi.getTimerCount()).toBe(initial + 1);
+		unmount();
+		expect(vi.getTimerCount()).toBe(initial);
+	});
+});
+
+describe('table clipboard fallback', () => {
+	test.each(['unavailable', 'rejected'])('uses the legacy path when Clipboard API is %s', async (mode) => {
+		if (mode === 'unavailable')
+			Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+		else writeText.mockRejectedValue(new Error('Permission denied'));
+		execCommand.mockImplementation((command) => {
+			expect(command).toBe('copy');
+			expect(document.querySelector('textarea')?.value).toBe('fallback value');
+			return true;
+		});
+		render(<CopyCellButton value="fallback value" />);
+		await copy();
+		expect(execCommand).toHaveBeenCalledOnce();
+		expect(document.querySelector('textarea')).toBeNull();
+		expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+	});
+	test('does not show success when the fallback returns false', async () => {
+		writeText.mockRejectedValue(new Error('Permission denied'));
+		execCommand.mockReturnValue(false);
+		render(<CopyCellButton value="value" />);
+		await copy();
+		expect(document.querySelector('textarea')).toBeNull();
+		expect(screen.getByRole('button', { name: 'Copy value' })).toBeInTheDocument();
+	});
+});

--- a/apps/client/src/test/DatadogClipboard.test.tsx
+++ b/apps/client/src/test/DatadogClipboard.test.tsx
@@ -1,0 +1,63 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { DatadogSetupModal } from '@/components/Integrations/DatadogSetupModal/DatadogSetupModal';
+
+const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast }) }));
+const descriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+const writeText = vi.fn();
+beforeEach(() => {
+	vi.useFakeTimers();
+	toast.mockReset();
+	writeText.mockReset().mockResolvedValue(undefined);
+	Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+});
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	if (descriptor) Object.defineProperty(navigator, 'clipboard', descriptor);
+	else Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe('Datadog clipboard behaviour', () => {
+	test('preserves each toast and resets both indicators at the first copy deadline', async () => {
+		render(<DatadogSetupModal open onOpenChange={vi.fn()} />);
+		const [webhook, payload] = screen.getAllByRole('button', { name: 'Copy' });
+		await act(async () => {
+			fireEvent.click(webhook);
+		});
+		expect(writeText.mock.calls[0][0]).toContain('/alerts/custom/datadog?api_token={your_api_token}');
+		expect(toast).toHaveBeenLastCalledWith({
+			title: 'Copied!',
+			description: 'Webhook URL copied to clipboard',
+			duration: 2000,
+		});
+		act(() => vi.advanceTimersByTime(1000));
+		await act(async () => {
+			fireEvent.click(payload);
+		});
+		expect(writeText.mock.calls[1][0]).toContain('"alert_id": "$ALERT_ID"');
+		expect(toast).toHaveBeenLastCalledWith({
+			title: 'Copied!',
+			description: 'Payload template copied to clipboard',
+			duration: 2000,
+		});
+		expect(screen.getAllByRole('button', { name: 'Copied' })).toHaveLength(2);
+		act(() => vi.advanceTimersByTime(1000));
+		expect(screen.getAllByRole('button', { name: 'Copy' })).toHaveLength(2);
+	});
+	test('keeps the manual-copy error message after rejection', async () => {
+		writeText.mockRejectedValue(new Error('Denied'));
+		render(<DatadogSetupModal open onOpenChange={vi.fn()} />);
+		await act(async () => {
+			fireEvent.click(screen.getAllByRole('button', { name: 'Copy' })[0]);
+		});
+		expect(toast).toHaveBeenCalledWith({
+			title: 'Failed to copy',
+			description: 'Please copy the value manually',
+			variant: 'destructive',
+			duration: 3000,
+		});
+		expect(screen.queryByRole('button', { name: 'Copied' })).not.toBeInTheDocument();
+	});
+});

--- a/apps/client/src/test/IntegrationClipboard.test.tsx
+++ b/apps/client/src/test/IntegrationClipboard.test.tsx
@@ -1,0 +1,101 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { GCPSetupModal } from '@/components/Integrations/GCPSetupModal/GCPSetupModal';
+import { UptimeKumaSetupModal } from '@/components/Integrations/UptimeKumaSetupModal/UptimeKumaSetupModal';
+import { GrafanaSetupModal } from '@/components/Integrations/GrafanaSetupModal/GrafanaSetupModal';
+import { CustomAlertsSetupModal } from '@/components/Integrations/CustomAlertsSetupModal/CustomAlertsSetupModal';
+import { ZabbixSetupModal } from '@/components/Integrations/ZabbixSetupModal/ZabbixSetupModal';
+
+const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast }) }));
+const descriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+const writeText = vi.fn();
+beforeEach(() => {
+	vi.useFakeTimers();
+	toast.mockReset();
+	writeText.mockReset().mockResolvedValue(undefined);
+	Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+});
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	if (descriptor) Object.defineProperty(navigator, 'clipboard', descriptor);
+	else Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+const dialogs = [
+	{
+		name: 'GCP',
+		Component: GCPSetupModal,
+		content: '/alerts/custom/gcp?api_token={your_api_token}',
+		success: 'Webhook URL copied to clipboard',
+		failure: 'Please copy the URL manually',
+	},
+	{
+		name: 'Uptime Kuma',
+		Component: UptimeKumaSetupModal,
+		content: '/alerts/custom/UptimeKuma?api_token={your_api_token}',
+		success: 'Webhook URL copied to clipboard',
+		failure: 'Please copy the URL manually',
+	},
+	{
+		name: 'Grafana',
+		Component: GrafanaSetupModal,
+		content: '/alerts/custom/grafana?api_token={your_api_token}',
+		success: 'Webhook URL copied to clipboard',
+		failure: 'Please copy the value manually',
+	},
+	{
+		name: 'Custom alerts',
+		Component: CustomAlertsSetupModal,
+		content: '/alerts/custom?api_token={your_api_token}',
+		success: 'URL copied to clipboard',
+		failure: 'Please copy manually',
+	},
+	{
+		name: 'Zabbix',
+		Component: ZabbixSetupModal,
+		content: '#!/bin/bash',
+		success: 'Script copied',
+		failure: 'Please copy manually',
+	},
+];
+
+describe('integration dialog copy success', () => {
+	test.each(dialogs)(
+		'$name preserves the copied content, toast and reset',
+		async ({ Component, content, success }) => {
+			render(<Component open onOpenChange={vi.fn()} />);
+			const button = screen.getAllByRole('button', { name: 'Copy' })[0];
+			await act(async () => {
+				fireEvent.click(button);
+			});
+			expect(writeText).toHaveBeenCalledOnce();
+			expect(writeText.mock.calls[0][0]).toContain(content);
+			expect(toast).toHaveBeenCalledWith({ title: 'Copied!', description: success, duration: 2000 });
+			expect(button).toHaveTextContent('Copied');
+			act(() => vi.advanceTimersByTime(1999));
+			expect(button).toHaveTextContent('Copied');
+			act(() => vi.advanceTimersByTime(1));
+			expect(button).toHaveTextContent(/^Copy$/);
+		}
+	);
+});
+
+describe('integration dialog copy failures', () => {
+	test.each(dialogs)('$name preserves its manual-copy guidance', async ({ Component, failure }) => {
+		writeText.mockRejectedValue(new Error('Clipboard access denied'));
+		render(<Component open onOpenChange={vi.fn()} />);
+		const button = screen.getAllByRole('button', { name: 'Copy' })[0];
+		await act(async () => {
+			fireEvent.click(button);
+		});
+		expect(toast).toHaveBeenCalledWith({
+			title: 'Failed to copy',
+			description: failure,
+			variant: 'destructive',
+			duration: 3000,
+		});
+		expect(button).toHaveTextContent(/^Copy$/);
+	});
+});

--- a/apps/client/src/test/useCopyToClipboard.test.ts
+++ b/apps/client/src/test/useCopyToClipboard.test.ts
@@ -1,0 +1,113 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { COPIED_RESET_MS, useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+
+const { toast } = vi.hoisted(() => ({ toast: vi.fn() }));
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast }) }));
+const descriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+const writeText = vi.fn();
+beforeEach(() => {
+	vi.useFakeTimers();
+	toast.mockReset();
+	writeText.mockReset().mockResolvedValue(undefined);
+	Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+});
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	if (descriptor) Object.defineProperty(navigator, 'clipboard', descriptor);
+	else Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe('clipboard dialog feedback', () => {
+	test('shows caller-specific success text and resets after two seconds', async () => {
+		const { result } = renderHook(() => useCopyToClipboard());
+		expect(result.current.copied).toBe(false);
+		await act(async () => {
+			expect(
+				await result.current.copy('payload', { successDescription: 'Example payload copied to clipboard' })
+			).toBe(true);
+		});
+		expect(writeText).toHaveBeenCalledWith('payload');
+		expect(result.current.copied).toBe(true);
+		expect(toast).toHaveBeenCalledWith({
+			title: 'Copied!',
+			description: 'Example payload copied to clipboard',
+			duration: 2000,
+		});
+		act(() => vi.advanceTimersByTime(COPIED_RESET_MS - 1));
+		expect(result.current.copied).toBe(true);
+		act(() => vi.advanceTimersByTime(1));
+		expect(result.current.copied).toBe(false);
+	});
+	test.each(['rejected', 'missing'])('reports %s clipboard without success or timers', async (mode) => {
+		if (mode === 'missing') Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+		else writeText.mockRejectedValue(new Error('Denied'));
+		const onCopied = vi.fn();
+		const { result } = renderHook(() => useCopyToClipboard());
+		await act(async () => {
+			expect(
+				await result.current.copy('value', { failureDescription: 'Please copy the URL manually', onCopied })
+			).toBe(false);
+		});
+		expect(result.current.copied).toBe(false);
+		expect(onCopied).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(0);
+		expect(toast).toHaveBeenCalledWith({
+			title: 'Failed to copy',
+			description: 'Please copy the URL manually',
+			variant: 'destructive',
+			duration: 3000,
+		});
+	});
+});
+
+describe('clipboard lifecycle and reset callbacks', () => {
+	test('keeps independent scheduled resets for dialog copies', async () => {
+		const first = vi.fn(),
+			second = vi.fn();
+		const { result } = renderHook(() => useCopyToClipboard());
+		await act(async () => {
+			await result.current.copy('first', { onReset: first });
+		});
+		act(() => vi.advanceTimersByTime(1000));
+		await act(async () => {
+			await result.current.copy('second', { onReset: second });
+		});
+		act(() => vi.advanceTimersByTime(1000));
+		expect(first).toHaveBeenCalledOnce();
+		expect(second).not.toHaveBeenCalled();
+		act(() => vi.advanceTimersByTime(1000));
+		expect(second).toHaveBeenCalledOnce();
+	});
+	test('cleans up every dialog reset on unmount', async () => {
+		const onReset = vi.fn();
+		const { result, unmount } = renderHook(() => useCopyToClipboard());
+		await act(async () => {
+			await result.current.copy('one', { onReset });
+			await result.current.copy('two', { onReset });
+		});
+		expect(vi.getTimerCount()).toBe(2);
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+		act(() => vi.advanceTimersByTime(2000));
+		expect(onReset).not.toHaveBeenCalled();
+	});
+	test('ignores a clipboard promise that finishes after unmount', async () => {
+		let finish!: () => void;
+		writeText.mockReturnValue(
+			new Promise<void>((resolve) => {
+				finish = resolve;
+			})
+		);
+		const onCopied = vi.fn();
+		const { result, unmount } = renderHook(() => useCopyToClipboard());
+		const pending = result.current.copy('value', { successDescription: 'Copied text', onCopied });
+		unmount();
+		finish();
+		expect(await pending).toBe(false);
+		expect(onCopied).not.toHaveBeenCalled();
+		expect(toast).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});


### PR DESCRIPTION
Seven components independently implement copying and temporary success feedback. Introduce `useCopyToClipboard` with a named `COPIED_RESET_MS` default and move all seven call sites onto it. The hook owns clipboard access, optional fallback, toast feedback and timer cleanup. Multi-button dialogs supply callbacks to retain their existing indicator grouping.

Fixes #918.

The current implementations differ from the issue's description, so this preserves their observable distinctions:
- Integration dialogs retain their exact success/error toast messages, 2-second success/reset duration and 3-second error duration.
- Datadog's copy deadline still resets both indicators together; CustomAlerts and Zabbix retain their independent indicator callbacks.
- CopyCellButton retains its 1.5-second feedback, restart-on-repeat behaviour, no toast, click/mousedown propagation guards and legacy execCommand fallback for unavailable/rejected Clipboard API.

Timers are now cleaned up for dialogs too, and async copies finishing after unmount do not trigger feedback. A throwing legacy fallback is treated as failure instead of an unhandled rejection.

Validation:
- 24 tests cover the real table button, all six integration dialogs and shared hook: copied values, success/error text, reset boundaries/grouping, fallback failure/cleanup, repeated copies, unmount and pending promises. All 18 component regression tests also pass against the original upstream components.
- Full client suite: 436 tests across 45 files pass.
- TypeScript baseline comparison: no new diagnostics; the old CopyCellButton useRef-without-an-argument error is removed (25 baseline diagnostics to 24). The overall project type check remains affected by unrelated baseline errors.
- ESLint: no errors; touched-file warnings decrease from 14 to 9 existing size-limit warnings. New hook/tests have zero warnings. Prettier and diff checks pass.
- Browser clipboard permissions and real integration services were not exercised; clipboard operations are mocked in jsdom.

Developed and validated with OpenAI Codex assistance.
