### PR TITLE
[FIX]: Attribute secrets endpoint logs to the correct controller

### DIFF
--- a/apps/server/src/api/v1/secrets/controller.ts
+++ b/apps/server/src/api/v1/secrets/controller.ts
@@ -7,7 +7,7 @@ import { encryptPassword } from '../../../utils/encryption';
 import { isZodError } from '../../../utils/isZodError';
 import { validateKubeConfig, validatePublicSSHKey } from '../../../utils/validators/validators';
 
-const logger = new Logger('v1/integrations/controller');
+const logger = new Logger('api/v1/secrets/controller');
 
 export class SecretsController {
 	constructor(private secretsBL: SecretsMetadataBL) {}


### PR DESCRIPTION
Errors from the secrets endpoints are currently tagged `v1/integrations/controller`, directing log searches to the wrong module. Change the logger context to `api/v1/secrets/controller`, matching the module-path convention used by the audit controller.

Fixes #907.

Validation: verified the logger string is the only source change; TypeScript syntax/transpilation, Prettier and diff checks pass. Server ESLint could not run because this local server workspace lacks `@eslint/js`. No endpoint behaviour changes; full server tests were not run for this logging-label-only fix.

Developed and validated with OpenAI Codex assistance.
