### PR TITLE
[FIX]: Safely parse Datadog webhook timestamps

### DIFF
--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -632,6 +632,8 @@ export class AlertController {
 	// ISO timestamps too. Preserve Number()'s accepted numeric forms (including decimals),
 	// then delegate ISO and invalid values to Grafana's established fallback parser.
 	private static toDatadogIsoOrNow(value?: string): string {
+		if (value?.trim() === '') return AlertController.toIsoOrNow(undefined);
+
 		const epochMs = Number(value);
 		if (value !== undefined && Number.isFinite(epochMs)) {
 			const parsed = new Date(epochMs);

--- a/apps/server/src/api/v1/alerts/controller.ts
+++ b/apps/server/src/api/v1/alerts/controller.ts
@@ -561,8 +561,8 @@ export class AlertController {
 				// (P1 → critical, …) unless an explicit severity tag is present.
 				severity: tags['severity'] ?? payload.priority,
 				tags,
-				startsAt: new Date(Number(startsAtSource)).toISOString(),
-				updatedAt: new Date(Number(updatedAtSource)).toISOString(),
+				startsAt: AlertController.toDatadogIsoOrNow(startsAtSource),
+				updatedAt: AlertController.toDatadogIsoOrNow(updatedAtSource),
 				alertUrl: payload.link ?? '',
 				alertName: payload.title || 'UNKNOWN',
 				summary: payload.message,
@@ -626,6 +626,18 @@ export class AlertController {
 		if (!value) return new Date().toISOString();
 		const parsed = new Date(value);
 		return isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+	}
+
+	// Datadog normally sends epoch milliseconds as strings, but custom templates can emit
+	// ISO timestamps too. Preserve Number()'s accepted numeric forms (including decimals),
+	// then delegate ISO and invalid values to Grafana's established fallback parser.
+	private static toDatadogIsoOrNow(value?: string): string {
+		const epochMs = Number(value);
+		if (value !== undefined && Number.isFinite(epochMs)) {
+			const parsed = new Date(epochMs);
+			if (!isNaN(parsed.getTime())) return parsed.toISOString();
+		}
+		return AlertController.toIsoOrNow(value);
 	}
 
 	// Receives alerts pushed by a Grafana "Webhook" contact point. Replaces the old polling job:

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1009,6 +1009,8 @@ describe('Alerts API', () => {
 		test('should create a new Datadog alert successfully with valid payload', async () => {
 			const alertId = 'alert-id';
 			const alertInstanceId = 'alert-id-instance';
+			const date = '1765302826000';
+			const lastUpdated = '1765302886000';
 
 			const payload = {
 				alert_id: alertId,
@@ -1021,8 +1023,8 @@ describe('Alerts API', () => {
 				link: 'https://app.datadoghq.com/monitors/123',
 				tags: 'service:web,env:prod',
 				alert_scope: 'service:web',
-				date: '1765302826000',
-				last_updated: '1765302826000',
+				date,
+				last_updated: lastUpdated,
 				org: {
 					id: '123456',
 					name: 'Opsimate',
@@ -1038,15 +1040,113 @@ describe('Alerts API', () => {
 			expect(response.body.success).toBe(true);
 			expect(response.body.data.alertId).toBe(alertInstanceId);
 
-			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id);
+			const row = db.prepare('SELECT * FROM alerts WHERE id = ?').get(payload.id) as {
+				alert_name: string;
+				status: string;
+				tags: string | null;
+				starts_at: string;
+				updated_at: string;
+			};
 			expect(row).toBeDefined();
 			expect(row.alert_name).toBe(payload.title);
 			expect(row.status).toBe('firing');
+			expect(row.starts_at).toBe(new Date(Number(date)).toISOString());
+			expect(row.updated_at).toBe(new Date(Number(lastUpdated)).toISOString());
 
 			// Validate tags mapping – primary tag should be derived from alert_scope / tags.
 			// The ingestion funnel also mirrors the resolved severity into the tags.
-			const parsedTags = row.tags ? JSON.parse(row.tags as string) : {};
+			const parsedTags = row.tags ? (JSON.parse(row.tags) as Record<string, string>) : {};
 			expect(parsedTags).toEqual({ service: 'web', env: 'prod', severity: 'warning' });
+		});
+
+		test('accepts ISO date and last_updated timestamps', async () => {
+			const date = '2026-09-12T00:00:00.000Z';
+			const lastUpdated = '2026-09-12T00:05:00.000Z';
+			const response = await app
+				.post('/api/v1/alerts/custom/datadog')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id: 'datadog-iso-timestamps', title: 'ISO timestamps', date, last_updated: lastUpdated });
+
+			expect(response.status).toBe(200);
+			const row = db
+				.prepare('SELECT starts_at, updated_at FROM alerts WHERE id = ?')
+				.get('datadog-iso-timestamps') as {
+				starts_at: string;
+				updated_at: string;
+			};
+			expect(row).toEqual({ starts_at: date, updated_at: lastUpdated });
+		});
+
+		test('preserves decimal epoch timestamps with Date time-clipping', async () => {
+			const date = '1765302826000.9';
+			const lastUpdated = '1765302886000.1';
+			const response = await app
+				.post('/api/v1/alerts/custom/datadog')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					id: 'datadog-decimal-timestamps',
+					title: 'Decimal timestamps',
+					date,
+					last_updated: lastUpdated,
+				});
+
+			expect(response.status).toBe(200);
+			const row = db
+				.prepare('SELECT starts_at, updated_at FROM alerts WHERE id = ?')
+				.get('datadog-decimal-timestamps') as {
+				starts_at: string;
+				updated_at: string;
+			};
+			expect(row).toEqual({
+				starts_at: new Date(Number(date)).toISOString(),
+				updated_at: new Date(Number(lastUpdated)).toISOString(),
+			});
+		});
+
+		test.each([
+			{ name: 'ISO', date: '2026-09-12T00:00:00.000Z', expected: '2026-09-12T00:00:00.000Z' },
+			{ name: 'numeric-string epoch', date: '1765302826000', expected: new Date(1765302826000).toISOString() },
+		])('uses date for both timestamps when last_updated is missing ($name)', async ({ name, date, expected }) => {
+			const id = `datadog-no-last-updated-${name}`;
+			const response = await app
+				.post('/api/v1/alerts/custom/datadog')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id, title: 'No last updated', date });
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT starts_at, updated_at FROM alerts WHERE id = ?').get(id) as {
+				starts_at: string;
+				updated_at: string;
+			};
+			expect(row).toEqual({ starts_at: expected, updated_at: expected });
+		});
+
+		test('falls back to current time for invalid timestamps instead of returning 500', async () => {
+			const before = Date.now();
+			const response = await app
+				.post('/api/v1/alerts/custom/datadog')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					id: 'datadog-invalid-timestamps',
+					title: 'Invalid timestamps',
+					date: 'not-a-date',
+					last_updated: 'also-not-a-date',
+				});
+			const after = Date.now();
+
+			expect(response.status).toBe(200);
+			const row = db
+				.prepare('SELECT starts_at, updated_at FROM alerts WHERE id = ?')
+				.get('datadog-invalid-timestamps') as {
+				starts_at: string;
+				updated_at: string;
+			};
+			for (const timestamp of [row.starts_at, row.updated_at]) {
+				const parsed = Date.parse(timestamp);
+				expect(Number.isNaN(parsed)).toBe(false);
+				expect(parsed).toBeGreaterThanOrEqual(before);
+				expect(parsed).toBeLessThanOrEqual(after);
+			}
 		});
 
 		test('should resolve an existing Datadog alert when alert_transition is recovered', async () => {

--- a/apps/server/tests/alerts.test.ts
+++ b/apps/server/tests/alerts.test.ts
@@ -1149,6 +1149,56 @@ describe('Alerts API', () => {
 			}
 		});
 
+		test('falls back to current time for empty and whitespace-only timestamps', async () => {
+			const before = Date.now();
+			const response = await app
+				.post('/api/v1/alerts/custom/datadog')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({
+					id: 'datadog-blank-timestamps',
+					title: 'Blank timestamps',
+					date: '',
+					last_updated: ' \t ',
+				});
+			const after = Date.now();
+
+			expect(response.status).toBe(200);
+			const row = db
+				.prepare('SELECT starts_at, updated_at FROM alerts WHERE id = ?')
+				.get('datadog-blank-timestamps') as {
+				starts_at: string;
+				updated_at: string;
+			};
+			for (const timestamp of [row.starts_at, row.updated_at]) {
+				const parsed = Date.parse(timestamp);
+				expect(Number.isNaN(parsed)).toBe(false);
+				expect(parsed).toBeGreaterThanOrEqual(before);
+				expect(parsed).toBeLessThanOrEqual(after);
+			}
+		});
+
+		test.each([
+			{ name: 'zero', value: '0' },
+			{ name: 'padded zero', value: ' 0 ' },
+			{ name: 'decimal zero', value: '0.0' },
+		])('preserves $name timestamps as Unix epoch zero', async ({ value }) => {
+			const id = `datadog-${value.trim().replace('.', '-')}-timestamp`;
+			const response = await app
+				.post('/api/v1/alerts/custom/datadog')
+				.set('Authorization', `Bearer ${jwtToken}`)
+				.send({ id, title: 'Zero timestamp', date: value, last_updated: value });
+
+			expect(response.status).toBe(200);
+			const row = db.prepare('SELECT starts_at, updated_at FROM alerts WHERE id = ?').get(id) as {
+				starts_at: string;
+				updated_at: string;
+			};
+			expect(row).toEqual({
+				starts_at: '1970-01-01T00:00:00.000Z',
+				updated_at: '1970-01-01T00:00:00.000Z',
+			});
+		});
+
 		test('should resolve an existing Datadog alert when alert_transition is recovered', async () => {
 			const now = '1765302826000';
 			const alertId = 'datadog-alert-resolve';


### PR DESCRIPTION
## Issue Reference

Closes #766

---

## What Was Changed

* Added Datadog-specific timestamp normalization that accepts ISO dates while preserving existing numeric-string epoch conversions, including decimals.
* Applied normalization to both `startsAt` and `updatedAt`.
* Added endpoint regression coverage for ISO, numeric, decimal, missing `last_updated`, and invalid timestamps.

---

## Why Was It Changed

ISO timestamps previously passed payload validation but caused `Number(value)` to produce `NaN`, making `toISOString()` throw and returning HTTP 500.

The fix reuses the existing safe date parser for non-numeric values without changing Grafana behavior or Datadog’s timestamp-field precedence. Invalid timestamps now safely fall back to the current time.

---

## Screenshots

Not applicable — backend-only change with no visual UI changes.

---

## Additional Context (Optional)

Validation on the rebased branch:

* Full server suite: 370 tests passed across 25 files
* Full alerts test file: 101 tests passed
* Server build passed
* Focused Prettier check passed
* Git whitespace checks passed

Controller ESLint passed. The alerts test file retains its existing 183 errors and one warning; no additional diagnostics were introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Datadog alert ingestion now handles epoch timestamps, including decimal values, as well as ISO-formatted timestamps.
  - Missing update timestamps fall back to the alert’s creation timestamp.
  - Invalid, blank, or whitespace-only timestamps no longer cause ingestion failures and instead use the current time.
  - Zero-valued timestamps are preserved correctly as the Unix epoch.
  - These improvements provide more reliable alert timestamps across supported input formats and prevent malformed timestamp data from interrupting ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->