### PR TITLE
[FIX]: Name the alerts refresh interval and remove unused catch binding

### DIFF
--- a/apps/client/src/components/Alerts/hooks/useAlertsRefresh.ts
+++ b/apps/client/src/components/Alerts/hooks/useAlertsRefresh.ts
@@ -2,6 +2,9 @@ import { useToast } from '@/hooks/use-toast';
 import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 
+// Poll for alert updates every five seconds while automatic refresh is enabled.
+const ALERTS_REFRESH_INTERVAL_MS = 5 * 1000;
+
 export interface UseAlertsRefreshOptions {
 	shouldPause?: boolean;
 }
@@ -22,7 +25,7 @@ export const useAlertsRefresh = (
 		const interval = setInterval(() => {
 			refetch();
 			setLastRefresh(new Date());
-		}, 5000);
+		}, ALERTS_REFRESH_INTERVAL_MS);
 
 		return () => clearInterval(interval);
 	}, [refetch, shouldPause]);
@@ -36,7 +39,7 @@ export const useAlertsRefresh = (
 				title: 'Alerts refreshed',
 				description: 'The alerts list has been updated.',
 			});
-		} catch (error) {
+		} catch {
 			toast({
 				title: 'Error refreshing alerts',
 				description: 'Failed to refresh alerts',


### PR DESCRIPTION
The alerts refresh hook embeds its five-second polling interval as a bare `5000` and declares an unused error variable in the manual-refresh catch block. Name the interval `ALERTS_REFRESH_INTERVAL_MS = 5 * 1000` with a comment, and use an optional catch binding.

Fixes #919. The pause logic, timer cleanup, manual-refresh state and toast messages are unchanged.

Validation: changed-file ESLint passes with zero warnings; Prettier and diff checks pass. Reviewed the diff to verify the interval still evaluates to 5000 ms. No new tests or full-suite rerun for this constant extraction and unused-binding cleanup.

Developed and validated with OpenAI Codex assistance.
