### PR TITLE
[FIX]: Centralize the auth token storage key without changing sessions

### DIFF
--- a/apps/client/src/components/AuthGuard.tsx
+++ b/apps/client/src/components/AuthGuard.tsx
@@ -1,3 +1,4 @@
+import { AUTH_TOKEN_STORAGE_KEY } from '@/lib/auth';
 import { useUsersExist } from '@/hooks/queries';
 import { isPlaygroundMode } from '@/lib/playground';
 import { useEffect } from 'react';
@@ -19,7 +20,7 @@ export const AuthGuard = ({ children }: AuthGuardProps) => {
 		}
 
 		// Check if user is already authenticated
-		const jwt = localStorage.getItem('jwt');
+		const jwt = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
 		const isOnRegisterPage = location.pathname === '/register';
 		const isOnLoginPage = location.pathname === '/login';
 		const isOnForgotPasswordPage = location.pathname === '/forgot-password';
@@ -91,7 +92,7 @@ export const AuthGuard = ({ children }: AuthGuardProps) => {
 	}
 
 	// If there's an error and no JWT, show error state
-	if (error && !localStorage.getItem('jwt')) {
+	if (error && !localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)) {
 		return (
 			<div className="flex items-center justify-center min-h-screen">
 				<div className="text-lg text-red-500">Error loading application</div>

--- a/apps/client/src/components/Profile/Profile.tsx
+++ b/apps/client/src/components/Profile/Profile.tsx
@@ -1,3 +1,4 @@
+import { AUTH_TOKEN_STORAGE_KEY } from '@/lib/auth';
 import { useCallback } from 'react';
 import { DashboardLayout } from '@/components/DashboardLayout';
 import { ProfileContent, ProfileLoadingState, ProfileErrorState } from '@/components/Profile/components';
@@ -10,7 +11,7 @@ const Profile: React.FC = () => {
 		useProfileEdit({ profile, setProfile });
 
 	const handleLogout = useCallback(() => {
-		localStorage.removeItem('jwt');
+		localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
 		window.location.href = '/login';
 	}, []);
 

--- a/apps/client/src/components/Profile/hooks/useProfileEdit.ts
+++ b/apps/client/src/components/Profile/hooks/useProfileEdit.ts
@@ -1,3 +1,4 @@
+import { AUTH_TOKEN_STORAGE_KEY } from '@/lib/auth';
 import { useFormErrors } from '@/hooks/useFormErrors';
 import { apiRequest } from '@/lib/api';
 import { Logger, User } from '@OpsiMate/shared';
@@ -109,7 +110,7 @@ export const useProfileEdit = ({ profile, setProfile }: UseProfileEditProps): Us
 			if (response.success) {
 				// Update JWT token if password was changed
 				if (response.data && typeof response.data === 'object' && 'token' in response.data) {
-					localStorage.setItem('jwt', response.data.token as string);
+					localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, response.data.token as string);
 				}
 
 				// update local profile state to reflect changes in UI

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { AUTH_TOKEN_STORAGE_KEY } from './auth';
 import { CustomAction } from '@OpsiMate/custom-actions';
 import {
 	AiConfig,
@@ -63,7 +64,7 @@ async function apiRequest<T>(
 ): Promise<ApiResponse<T>> {
 	const url = `${API_BASE_URL}${endpoint}`;
 
-	const token = localStorage.getItem('jwt');
+	const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
 	const options: RequestInit = {
 		method,
 		headers: {
@@ -96,7 +97,7 @@ async function apiRequest<T>(
 			// Try to parse the error as JSON to handle validation errors properly
 
 			if (response.status === 401 && !isPlaygroundMode()) {
-				localStorage.removeItem('jwt');
+				localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
 
 				const authPages = new Set(['/login', '/register', '/forgot-password', '/reset-password']);
 				if (!authPages.has(window.location.pathname)) {

--- a/apps/client/src/lib/auth.ts
+++ b/apps/client/src/lib/auth.ts
@@ -2,6 +2,8 @@ import { Logger, Role } from '@OpsiMate/shared';
 import { jwtDecode } from 'jwt-decode';
 import { getPlaygroundUser, isPlaygroundMode } from './playground';
 
+export const AUTH_TOKEN_STORAGE_KEY = 'jwt';
+
 const logger = new Logger('auth');
 
 export interface JWTPayload {
@@ -24,7 +26,7 @@ export function getCurrentUser(): JWTPayload | null {
 		};
 	}
 
-	const token = localStorage.getItem('jwt');
+	const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
 	if (!token) return null;
 
 	try {

--- a/apps/client/src/pages/Login.tsx
+++ b/apps/client/src/pages/Login.tsx
@@ -1,3 +1,4 @@
+import { AUTH_TOKEN_STORAGE_KEY } from '../lib/auth';
 import { Logger } from '@OpsiMate/shared';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -20,7 +21,7 @@ const Login: React.FC = () => {
 	});
 
 	useEffect(() => {
-		if (localStorage.getItem('jwt') && window.location.pathname === '/login') {
+		if (localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) && window.location.pathname === '/login') {
 			window.location.href = '/';
 		}
 
@@ -63,7 +64,7 @@ const Login: React.FC = () => {
 			if (res.success) {
 				const token = (res.data && res.data.token) || res.token;
 				if (token) {
-					localStorage.setItem('jwt', token);
+					localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
 					window.location.href = '/';
 				} else {
 					logger.error('Login successful but no token received');

--- a/apps/client/src/pages/Register.tsx
+++ b/apps/client/src/pages/Register.tsx
@@ -1,3 +1,4 @@
+import { AUTH_TOKEN_STORAGE_KEY } from '../lib/auth';
 import { Logger } from '@OpsiMate/shared';
 import React, { useState } from 'react';
 import { ErrorAlert } from '../components/ErrorAlert';
@@ -39,7 +40,7 @@ const Register: React.FC = () => {
 			if (res.success) {
 				const token = (res.data && res.data.token) || res.token;
 				if (token) {
-					localStorage.setItem('jwt', token);
+					localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
 					window.location.href = '/';
 				} else {
 					// This shouldn't happen in normal flow, but handle it gracefully


### PR DESCRIPTION
Fixes #913.

Export `AUTH_TOKEN_STORAGE_KEY = 'jwt'` from `lib/auth.ts` and use it at all ten token-storage operations across seven current files: API authorization/401 cleanup, current-user lookup, auth guard, login, registration, logout, and profile-token refresh. Existing sessions retain the same storage key.

Validation: all 412 client tests across 41 files pass. Prettier and `git diff --check` pass. Changed-file ESLint reports zero errors and the same 15 warnings as unchanged main. TypeScript reports the same 33 diagnostics as unchanged main in this local checkout; no new diagnostics after normalizing line offsets. Reversing just the constant/import substitutions reproduces the original source of all seven files. No new tests for this mechanical refactor.

Prepared with OpenAI Codex assistance and validated on Node 24 / Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authentication token storage across login, registration, profile updates, logout, session checks, and API requests.
  * Improved consistency when retrieving, saving, and removing authentication tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->